### PR TITLE
[Polkadot Wiki Migration] Stop Validating

### DIFF
--- a/infrastructure/validators/offboarding/.pages
+++ b/infrastructure/validators/offboarding/.pages
@@ -1,3 +1,4 @@
 title: Offboarding
 nav:
   - index.md
+  - stop-validating.md

--- a/infrastructure/validators/offboarding/stop-validating.md
+++ b/infrastructure/validators/offboarding/stop-validating.md
@@ -12,7 +12,7 @@ To ensure a smooth stop to validation, make sure you should do the following act
 - Purge validator session keys
 - Unbond your tokens
 
-These can all be done with [Polkadot.js](https://polkadot.js.org/apps){target=_blank} interface or with extrinsics.
+These can all be done with [Polkadot.js Apps](https://polkadot.js.org/apps){target=\_blank} UI or by using various [libraries](https://wiki.polkadot.network/docs/build-tools-index#libraries){target=\_blank} such as [Polkadot.js API](https://polkadot.js.org/docs/){target=\_blank}.
 
 <!-- TODO: add links later -->
 
@@ -44,5 +44,5 @@ were set).
 ## Unbond your Tokens
 
 Unbonding your tokens can be done through the `Network > Staking > Account actions` page in
-PolkadotJS Apps by clicking the corresponding stash account dropdown and selecting **Unbond Funds**.
+Polkadot.js Apps by clicking the corresponding stash account dropdown and selecting **Unbond Funds**.
 This can also be done through the `staking.unbond()` extrinsic with the staking proxy account.

--- a/infrastructure/validators/offboarding/stop-validating.md
+++ b/infrastructure/validators/offboarding/stop-validating.md
@@ -3,8 +3,7 @@ title: Stop Validating
 description: Instructions on how to stop validating.
 ---
 
-If you wish to remain a validator or nominator (e.g. you're only stopping for planned downtime or
-server maintenance), submitting the `chill` extrinsic in the `staking` pallet should suffice. It is
+If you wish to remain a validator or nominator (for example, you're only stopping for planned downtime or server maintenance), submitting the `chill` extrinsic in the `staking` pallet should suffice. It is
 only if you wish to unbond funds or reap an account that you should continue with the following.
 
 To ensure a smooth stop to validation, make sure you should do the following actions:
@@ -13,9 +12,7 @@ To ensure a smooth stop to validation, make sure you should do the following act
 - Purge validator session keys
 - Unbond your tokens
 
-These can all be done with [PolkadotJS Apps](https://polkadot.js.org/apps){target=_blank} interface or with
-extrinsics.
-
+These can all be done with [PolkadotJS Apps](https://polkadot.js.org/apps){target=_blank} interface or with extrinsics.
 
 <!-- TODO: add links later -->
 
@@ -23,7 +20,7 @@ extrinsics.
 
 To chill your validator or nominator, call the `staking.chill()` extrinsic. See the How to Chill page for more information. You can also claim your rewards at this time.
 
-## Purge validator session keys
+## Purge Validator Session Keys
 
 Purging the validator's session keys removes the key reference. This can be done through the
 `session.purgeKeys()` extrinsic. The key reference exists on the account that originally called the
@@ -37,15 +34,15 @@ were set).
     that **cannot** be removed, and as a result that account cannot be reaped.
 
 !!!warning
-    **If you skip this step, you will not be able to reap your stash account**, and you will also need
+    **If you skip this step, you won't be able to reap your stash account**, and you will also need
     to rebond, purge the session keys, unbond, and wait the unbonding period again before being able to
     transfer your tokens.
 
     See Unbonding and Rebonding for more details.
 
 
-## Unbond your tokens
+## Unbond your Tokens
 
 Unbonding your tokens can be done through the `Network > Staking > Account actions` page in
-PolkadotJS Apps by clicking the corresponding stash account dropdown and selecting "Unbond funds".
+PolkadotJS Apps by clicking the corresponding stash account dropdown and selecting **Unbond Funds**.
 This can also be done through the `staking.unbond()` extrinsic with the staking proxy account.

--- a/infrastructure/validators/offboarding/stop-validating.md
+++ b/infrastructure/validators/offboarding/stop-validating.md
@@ -12,7 +12,7 @@ To ensure a smooth stop to validation, make sure you should do the following act
 - Purge validator session keys
 - Unbond your tokens
 
-These can all be done with [Polkadot.js Apps](https://polkadot.js.org/apps){target=\_blank} UI or by using various [libraries](https://wiki.polkadot.network/docs/build-tools-index#libraries){target=\_blank} such as [Polkadot.js API](https://polkadot.js.org/docs/){target=\_blank}.
+These can all be done with [Polkadot.js Apps](https://polkadot.js.org/apps){target=\_blank} UI or by using various [libraries](https://wiki.polkadot.network/docs/build-tools-index#libraries){target=\_blank} such as [the Polkadot-API (PAPI)](https://papi.how/){target=\_blank}.
 
 <!-- TODO: add links later -->
 

--- a/infrastructure/validators/offboarding/stop-validating.md
+++ b/infrastructure/validators/offboarding/stop-validating.md
@@ -1,0 +1,51 @@
+---
+title: Stop Validating
+description: Instructions on how to stop validating.
+---
+
+If you wish to remain a validator or nominator (e.g. you're only stopping for planned downtime or
+server maintenance), submitting the `chill` extrinsic in the `staking` pallet should suffice. It is
+only if you wish to unbond funds or reap an account that you should continue with the following.
+
+To ensure a smooth stop to validation, make sure you should do the following actions:
+
+- Chill your validator
+- Purge validator session keys
+- Unbond your tokens
+
+These can all be done with [PolkadotJS Apps](https://polkadot.js.org/apps){target=_blank} interface or with
+extrinsics.
+
+
+<!-- TODO: add links later -->
+
+## Chill Validator
+
+To chill your validator or nominator, call the `staking.chill()` extrinsic. See the How to Chill page for more information. You can also claim your rewards at this time.
+
+## Purge validator session keys
+
+Purging the validator's session keys removes the key reference. This can be done through the
+`session.purgeKeys()` extrinsic. The key reference exists on the account that originally called the
+`session.set_keys()` extrinsic, which could be the stash or the staking proxy (at the time the keys
+were set).
+
+!!!warning "Purge keys using the same account that set the keys"
+    Make sure to call the session.purge_keys() extrinsic from the same account that set the keys in the
+    first place in order for the correct reference to be removed. Calling the `session.purge_keys()`
+    from the wrong account, although it may succeed, will result in a reference on the other account
+    that **cannot** be removed, and as a result that account cannot be reaped.
+
+!!!warning
+    **If you skip this step, you will not be able to reap your stash account**, and you will also need
+    to rebond, purge the session keys, unbond, and wait the unbonding period again before being able to
+    transfer your tokens.
+
+    See Unbonding and Rebonding for more details.
+
+
+## Unbond your tokens
+
+Unbonding your tokens can be done through the `Network > Staking > Account actions` page in
+PolkadotJS Apps by clicking the corresponding stash account dropdown and selecting "Unbond funds".
+This can also be done through the `staking.unbond()` extrinsic with the staking proxy account.

--- a/infrastructure/validators/offboarding/stop-validating.md
+++ b/infrastructure/validators/offboarding/stop-validating.md
@@ -1,6 +1,6 @@
 ---
 title: Stop Validating
-description: Instructions on how to stop validating.
+description: Instructions on how to stop validating, unbonding your tokens, purging validator keys, and chilling your Polkadot validator.
 ---
 
 If you wish to remain a validator or nominator (for example, you're only stopping for planned downtime or server maintenance), submitting the `chill` extrinsic in the `staking` pallet should suffice. It is
@@ -12,17 +12,17 @@ To ensure a smooth stop to validation, make sure you should do the following act
 - Purge validator session keys
 - Unbond your tokens
 
-These can all be done with [PolkadotJS Apps](https://polkadot.js.org/apps){target=_blank} interface or with extrinsics.
+These can all be done with [Polkadot.js](https://polkadot.js.org/apps){target=_blank} interface or with extrinsics.
 
 <!-- TODO: add links later -->
 
 ## Chill Validator
 
-To chill your validator or nominator, call the `staking.chill()` extrinsic. See the How to Chill page for more information. You can also claim your rewards at this time.
+To chill your validator or nominator, call the `staking.chill()` extrinsic. See the [How to Chill](todo:link) page for more information. You can also claim your rewards at this time.
 
 ## Purge Validator Session Keys
 
-Purging the validator's session keys removes the key reference. This can be done through the
+Purging validator session keys removes the key reference. This can be done through the
 `session.purgeKeys()` extrinsic. The key reference exists on the account that originally called the
 `session.set_keys()` extrinsic, which could be the stash or the staking proxy (at the time the keys
 were set).
@@ -31,14 +31,14 @@ were set).
     Make sure to call the session.purge_keys() extrinsic from the same account that set the keys in the
     first place in order for the correct reference to be removed. Calling the `session.purge_keys()`
     from the wrong account, although it may succeed, will result in a reference on the other account
-    that **cannot** be removed, and as a result that account cannot be reaped.
+    that _cannot_ be removed, and as a result that account cannot be reaped.
 
 !!!warning
     **If you skip this step, you won't be able to reap your stash account**, and you will also need
     to rebond, purge the session keys, unbond, and wait the unbonding period again before being able to
     transfer your tokens.
 
-    See Unbonding and Rebonding for more details.
+    See [Unbonding and Rebonding on the Polkadot Wiki](https://wiki.polkadot.network/docs/learn-guides-nominator#bond-your-tokens{target=_blank}) for more details.
 
 
 ## Unbond your Tokens


### PR DESCRIPTION
> This page was migrated from https://wiki.polkadot.network/docs/maintain-guides-how-to-stop-validating