### PR TITLE
add an editor config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+[*.ts]
+indent_style=space
+indent_size=2
+max_line_length=80
+quote_type=single
+
+[*.js]
+indent_style=space
+indent_size=2
+max_line_length=80
+quote_type=single
+
+[*.json]
+indent_style=space
+indent_size=4
+max_line_length=80
+quote_type=double


### PR DESCRIPTION
This just adds an editor config file that can be used to overwrite default styling preferences implemented by other formatters.