### PR TITLE
Fix `create_github_issue` function call in check-repositories workflow

### DIFF
--- a/.github/scripts/create_issues.py
+++ b/.github/scripts/create_issues.py
@@ -90,7 +90,7 @@ Latest version: {repo['latest_version']}
 
 Please review the change log and update the documentation accordingly."""
 
-    create_github_issue(owner, repo_name, title, body)
+        create_github_issue(owner, repo_name, title, body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes an indentation bug in the script that creates GitHub issues for outdated repositories. 

Previously, the `create_github_issue` function call was outside the for loop, causing only one issue to be created for the last repository. 

The function call has been correctly indented to ensure an issue is created for each outdated repository in the input JSON file.