### PR TITLE
Add CODEOWNERS to polkadot-docs repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Request reviews from the formatting team for all PRs
+* @polkadot-developers/docs-formatting-team
+
+# Request reviews from the content team for all PRs
+* @polkadot-developers/docs-content-team


### PR DESCRIPTION
Specified code owners for `polkadot-docs` repo.

Each time PR is created two teams will be automatically assigned to review PR: 
- docs-formatting-team
- docs-content-team