### PR TITLE
update pre-commit hook to account for whitespaces in html

### DIFF
--- a/.husky/html-whitespace.js
+++ b/.husky/html-whitespace.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+
+// Directory containing HTML snippets (including subdirectories)
+const snippetsDir = './.snippets/code';
+
+// Function to modify leading whitespace inside <span> elements
+function replaceLeadingWhitespaceInSpan(content) {
+  return content.replace(/(<span[^>]*?>)(\s+)/g, (match, spanTag, leadingWhitespace) => {
+    // Replace leading spaces with &nbsp;
+    const replacedWhitespace = leadingWhitespace.replace(/ /g, '&nbsp;');
+    return spanTag + replacedWhitespace;
+  });
+}
+
+// Recursive function to process HTML files in directories and subdirectories
+function processHtmlFiles(dir) {
+  fs.readdir(dir, (err, files) => {
+    if (err) {
+      console.error(`Unable to read directory: ${err}`);
+      return;
+    }
+
+    // Loop through files in the directory
+    files.forEach(file => {
+      const filePath = path.join(dir, file);
+
+      // Check if the file is a directory
+      fs.stat(filePath, (err, stats) => {
+        if (err) {
+          console.error(`Error getting stats for file ${filePath}: ${err}`);
+          return;
+        }
+
+        if (stats.isDirectory()) {
+          // If it's a directory, recursively process the directory
+          processHtmlFiles(filePath);
+        } else if (path.extname(file) === '.html') {
+          // If it's an HTML file, read and process it
+          fs.readFile(filePath, 'utf-8', (err, content) => {
+            if (err) {
+              console.error(`Unable to read file ${file}: ${err}`);
+              return;
+            }
+
+            // Modify leading whitespace in <span> elements
+            const modifiedContent = replaceLeadingWhitespaceInSpan(content);
+
+            // Write the modified content back to the file
+            fs.writeFile(filePath, modifiedContent, 'utf-8', err => {
+              if (err) {
+                console.error(`Unable to write file ${file}: ${err}`);
+              } else {
+                console.log(`Processed: ${filePath}`);
+              }
+            });
+          });
+        }
+      });
+    });
+  });
+}
+
+// Run the script on the snippets directory
+processHtmlFiles(snippetsDir);

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,22 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+# Run the Node.js script that processes HTML files in the snippets directory
+echo "Running HTML whitespace check..."
+
+# Check for Node.js and abort commit if not available
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is required but not installed. Aborting commit."
+  exit 1
+fi
+
+# Call the Node.js script
+node ./.husky/html-whitespace.js
+
+# Automatically add any modified files back to the commit
+git add -u
+
+# Run code formatters
 echo "Running Prettier on .snippets/code/**/*.{js,json,html}"
 npx prettier --write .snippets/code/**/*.{js,json,html}
 

--- a/.snippets/code/polkadot-protocol/protocol-components/accounts/address-formats/address-formats-1.html
+++ b/.snippets/code/polkadot-protocol/protocol-components/accounts/address-formats/address-formats-1.html
@@ -1,9 +1,9 @@
 <div id="termynal" data-termynal markdown>
   <span data-ty="input"><span class="file-path"></span>subkey inspect "caution juice atom organ advance problem want pledge someone senior holiday very"</span>
   <span data-ty>Secret phrase `caution juice atom organ advance problem want pledge someone senior holiday very` is account:</span>
-  <span data-ty> Secret seed: 0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849</span>
-  <span data-ty> Public key (hex): 0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746</span>
-  <span data-ty> Public key (SS58): 5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR</span>
-  <span data-ty> Account ID: 0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746</span>
-  <span data-ty> SS58 Address: 5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR</span>
+  <span data-ty>&nbsp;Secret seed: 0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849</span>
+  <span data-ty>&nbsp;Public key (hex): 0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746</span>
+  <span data-ty>&nbsp;Public key (SS58): 5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR</span>
+  <span data-ty>&nbsp;Account ID: 0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746</span>
+  <span data-ty>&nbsp;SS58 Address: 5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR</span>
 </div>

--- a/.snippets/code/polkadot-protocol/protocol-components/accounts/address-formats/address-formats-2.html
+++ b/.snippets/code/polkadot-protocol/protocol-components/accounts/address-formats/address-formats-2.html
@@ -1,9 +1,9 @@
 <div id="termynal" data-termynal markdown>
   <span data-ty="input"><span class="file-path"></span>subkey inspect "12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU"</span>
   <span data-ty>Public Key URI `12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU` is account:</span>
-  <span data-ty> Network ID/Version: polkadot</span>
-  <span data-ty> Public key (hex): 0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a</span>
-  <span data-ty> Account ID: 0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a</span>
-  <span data-ty> Public key (SS58): 12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU</span>
-  <span data-ty> SS58 Address: 12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU</span>
+  <span data-ty>&nbsp;Network ID/Version: polkadot</span>
+  <span data-ty>&nbsp;Public key (hex): 0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a</span>
+  <span data-ty>&nbsp;Account ID: 0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a</span>
+  <span data-ty>&nbsp;Public key (SS58): 12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU</span>
+  <span data-ty>&nbsp;SS58 Address: 12bzRJfh7arnnfPPUZHeJUaE62QLEwhK48QnH9LXeK2m1iZU</span>
 </div>

--- a/.snippets/code/tutorials/polkadot-sdk/build-a-blockchain/add-trusted-nodes/chainspec-head.html
+++ b/.snippets/code/tutorials/polkadot-sdk/build-a-blockchain/add-trusted-nodes/chainspec-head.html
@@ -1,15 +1,14 @@
 <div id="termynal" data-termynal>
   <span data-ty="input"><span class="file-path"></span>head customSpec.json</span>
-
   <br />
   <span data-ty>{</span>
-  <span data-ty> "name": "Local Testnet",</span>
-  <span data-ty> "id": "local_testnet",</span>
-  <span data-ty> "chainType": "Local",</span>
-  <span data-ty> "bootNodes": [],</span>
-  <span data-ty> "telemetryEndpoints": null,</span>
-  <span data-ty> "protocolId": null,</span>
-  <span data-ty> "properties": null,</span>
-  <span data-ty> "codeSubstitutes": {},</span>
-  <span data-ty> "genesis": {</span>
+  <span data-ty>&nbsp;"name": "Local Testnet",</span>
+  <span data-ty>&nbsp;"id": "local_testnet",</span>
+  <span data-ty>&nbsp;"chainType": "Local",</span>
+  <span data-ty>&nbsp;"bootNodes": [],</span>
+  <span data-ty>&nbsp;"telemetryEndpoints": null,</span>
+  <span data-ty>&nbsp;"protocolId": null,</span>
+  <span data-ty>&nbsp;"properties": null,</span>
+  <span data-ty>&nbsp;"codeSubstitutes": {},</span>
+  <span data-ty>&nbsp;"genesis": {</span>
 </div>

--- a/.snippets/code/tutorials/polkadot-sdk/build-a-blockchain/add-trusted-nodes/chainspec-tail.html
+++ b/.snippets/code/tutorials/polkadot-sdk/build-a-blockchain/add-trusted-nodes/chainspec-tail.html
@@ -2,82 +2,82 @@
   <span data-ty="input"><span class="file-path">tail -n 78 customSpec.json</span></span>
 
   <br />
-  <span data-ty> "patch": {</span>
-  <span data-ty> "aura": {</span>
-  <span data-ty> "authorities": [</span>
-  <span data-ty> "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",</span>
-  <span data-ty> "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"</span>
-  <span data-ty> ]</span>
-  <span data-ty> },</span>
-  <span data-ty> "balances": {</span>
-  <span data-ty> "balances": [</span>
-  <span data-ty> [</span>
-  <span data-ty> "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5HpG9w8EBLe5XCrbczpwq5TSXvedjrBGCwqxK1iQ7qUsSWFc",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5Ck5SLSHYac6WFt5UZRSsdJjwmpSZq85fd5TRNAdZQVzEAPT",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5HKPmK9GYtE1PSLsS1qiYU9xQ9Si1NcEhdeCq9sw5bqu4ns8",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5FCfAonRZgTFrTd9HREEyeJjDpT397KMzizE6T3DvebLFE7n",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5CRmqmsiNFExV6VbdmPJViVxrWmkaXXvBrSX8oqBT8R9vmWk",</span>
-  <span data-ty> 1152921504606846976</span>
-  <span data-ty> ]</span>
-  <span data-ty> ]</span>
-  <span data-ty> },</span>
-  <span data-ty> "grandpa": {</span>
-  <span data-ty> "authorities": [</span>
-  <span data-ty> [</span>
-  <span data-ty> "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu",</span>
-  <span data-ty> 1</span>
-  <span data-ty> ],</span>
-  <span data-ty> [</span>
-  <span data-ty> "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E",</span>
-  <span data-ty> 1</span>
-  <span data-ty> ]</span>
-  <span data-ty> ]</span>
-  <span data-ty> },</span>
-  <span data-ty> "sudo": {</span>
-  <span data-ty> "key": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"</span>
-  <span data-ty> }</span>
-  <span data-ty> }</span>
-  <span data-ty> }</span>
-  <span data-ty> }</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"patch": {</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"aura": {</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"authorities": [</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"balances": {</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"balances": [</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5HpG9w8EBLe5XCrbczpwq5TSXvedjrBGCwqxK1iQ7qUsSWFc",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5Ck5SLSHYac6WFt5UZRSsdJjwmpSZq85fd5TRNAdZQVzEAPT",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5HKPmK9GYtE1PSLsS1qiYU9xQ9Si1NcEhdeCq9sw5bqu4ns8",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5FCfAonRZgTFrTd9HREEyeJjDpT397KMzizE6T3DvebLFE7n",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5CRmqmsiNFExV6VbdmPJViVxrWmkaXXvBrSX8oqBT8R9vmWk",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1152921504606846976</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"grandpa": {</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"authorities": [</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;],</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E",</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;},</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"sudo": {</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"key": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}</span>
+  <span data-ty>&nbsp;&nbsp;&nbsp;&nbsp;}</span>
+  <span data-ty>&nbsp;&nbsp;}</span>
   <span data-ty>}%</span>
 </div>

--- a/.snippets/code/tutorials/polkadot-sdk/build-a-blockchain/add-trusted-nodes/key-ed25519-1.html
+++ b/.snippets/code/tutorials/polkadot-sdk/build-a-blockchain/add-trusted-nodes/key-ed25519-1.html
@@ -1,14 +1,14 @@
-<div id='termynal' data-termynal>
-    <span data-ty="input"><span class="file-path"></span>./target/release/solochain-template-node key inspect \</span>
-    <span>--scheme Ed25519 \</span></br>
-    <span>--password-interactive \</span></br>
-    <span data-ty>Key password:</span>
-    <span data-ty>Secret phrase: digital width rely long insect blind usual name oyster easy steak spend</span>
-    <span data-ty>Network ID: substrate</span>
-    <span data-ty>Secret seed: 0xc52405d0b45dd856cbf1371f3b33fbde20cb76bf6ee440d12ea15f7ed17cca0a</span>
-    <span data-ty>Public key (hex): 0xc9c2cd111f98f2bf78bab6787449fc007dd7f2a5d02f099919f7fb50ade97dd6</span>
-    <span data-ty>Account ID: 0xc9c2cd111f98f2bf78bab6787449fc007dd7f2a5d02f099919f7fb50ade97dd6</span>
-    <span data-ty>Public key (SS58): 5GdFMFbXy24uz8mFZroFUgdBkY2pq6igBNGAq9tsBfEZRSzP</span>
-    <span data-ty>SS58 Address: 5GdFMFbXy24uz8mFZroFUgdBkY2pq6igBNGAq9tsBfEZRSzP</span>
-    <span data-ty="input"><span class="file-path"></span></span>
+<div id="termynal" data-termynal>
+  <span data-ty="input"><span class="file-path"></span>./target/release/solochain-template-node key inspect \</span>
+  <span>--scheme Ed25519 \</span>
+  <span>--password-interactive \</span>
+  <span data-ty>Key password:</span>
+  <span data-ty>Secret phrase: digital width rely long insect blind usual name oyster easy steak spend</span>
+  <span data-ty>Network ID: substrate</span>
+  <span data-ty>Secret seed: 0xc52405d0b45dd856cbf1371f3b33fbde20cb76bf6ee440d12ea15f7ed17cca0a</span>
+  <span data-ty>Public key (hex): 0xc9c2cd111f98f2bf78bab6787449fc007dd7f2a5d02f099919f7fb50ade97dd6</span>
+  <span data-ty>Account ID: 0xc9c2cd111f98f2bf78bab6787449fc007dd7f2a5d02f099919f7fb50ade97dd6</span>
+  <span data-ty>Public key (SS58): 5GdFMFbXy24uz8mFZroFUgdBkY2pq6igBNGAq9tsBfEZRSzP</span>
+  <span data-ty>SS58 Address: 5GdFMFbXy24uz8mFZroFUgdBkY2pq6igBNGAq9tsBfEZRSzP</span>
+  <span data-ty="input"><span class="file-path"></span></span>
 </div>

--- a/.snippets/code/tutorials/polkadot-sdk/build-a-blockchain/add-trusted-nodes/key-sr25519-1.html
+++ b/.snippets/code/tutorials/polkadot-sdk/build-a-blockchain/add-trusted-nodes/key-sr25519-1.html
@@ -1,14 +1,14 @@
-<div id='termynal' data-termynal>
-    <span data-ty="input"><span class="file-path"></span>./target/release/solochain-template-node key generate \</span>
-    <span>--scheme Sr25519 \</span></br>
-    <span>--password-interactive</span>
-    <span data-ty>Key password:</span>
-    <span data-ty>Secret phrase: digital width rely long insect blind usual name oyster easy steak spend</span>
-    <span data-ty>Network ID: substrate</span>
-    <span data-ty>Secret seed: 0xc52405d0b45dd856cbf1371f3b33fbde20cb76bf6ee440d12ea15f7ed17cca0a</span>
-    <span data-ty>Public key (hex): 0xea23fa399c6bd91af3d7ea2d0ad46c48aff818b285342d9aaf15b3172270e914</span>
-    <span data-ty>Account ID: 0xea23fa399c6bd91af3d7ea2d0ad46c48aff818b285342d9aaf15b3172270e914</span>
-    <span data-ty>Public key (SS58): 5HMhkSHpD4XcibjbU9ZiGemLpnsTUzLsG5JhQJQEcxp3KJaW</span>
-    <span data-ty>SS58 Address: 5HMhkSHpD4XcibjbU9ZiGemLpnsTUzLsG5JhQJQEcxp3KJaW</span>
-    <span data-ty="input"><span class="file-path"></span></span>
+<div id="termynal" data-termynal>
+  <span data-ty="input"><span class="file-path"></span>./target/release/solochain-template-node key generate \</span>
+  <span>--scheme Sr25519 \</span>
+  <span>--password-interactive</span>
+  <span data-ty>Key password:</span>
+  <span data-ty>Secret phrase: digital width rely long insect blind usual name oyster easy steak spend</span>
+  <span data-ty>Network ID: substrate</span>
+  <span data-ty>Secret seed: 0xc52405d0b45dd856cbf1371f3b33fbde20cb76bf6ee440d12ea15f7ed17cca0a</span>
+  <span data-ty>Public key (hex): 0xea23fa399c6bd91af3d7ea2d0ad46c48aff818b285342d9aaf15b3172270e914</span>
+  <span data-ty>Account ID: 0xea23fa399c6bd91af3d7ea2d0ad46c48aff818b285342d9aaf15b3172270e914</span>
+  <span data-ty>Public key (SS58): 5HMhkSHpD4XcibjbU9ZiGemLpnsTUzLsG5JhQJQEcxp3KJaW</span>
+  <span data-ty>SS58 Address: 5HMhkSHpD4XcibjbU9ZiGemLpnsTUzLsG5JhQJQEcxp3KJaW</span>
+  <span data-ty="input"><span class="file-path"></span></span>
 </div>

--- a/.snippets/code/tutorials/polkadot-sdk/build-a-blockchain/add-trusted-nodes/node-output.html
+++ b/.snippets/code/tutorials/polkadot-sdk/build-a-blockchain/add-trusted-nodes/node-output.html
@@ -1,26 +1,26 @@
-<div id='termynal' data-termynal>
-    <span data-ty="input"><span class="file-path"></span>./target/release/solochain-template-node \</span>
-    <span>--base-path /tmp/node01 \</span></br>
-    <span>--chain ./customSpecRaw.json \</span></br>
-    <span>--port 30333 \</span></br>
-    <span>--rpc-port 9945 \</span></br>
-    <span>--validator \</span></br>
-    <span>--name MyNode01 \</span></br>
-    <span>--password-interactive</span></br>
-    <span data-ty>2024-09-12 11:18:46 Substrate Node</span>
-    <span data-ty>2024-09-12 11:18:46 ✌️  version 0.1.0-8599efc46ae</span>
-    <span data-ty>2024-09-12 11:18:46 ❤️  by Parity Technologies <admin@parity.io>, 2017-2024</span>
-    <span data-ty>2024-09-12 11:18:46 📋 Chain specification: My Custom Testnet</span>
-    <span data-ty>2024-09-12 11:18:46 🏷  Node name: MyNode01</span>
-    <span data-ty>2024-09-12 11:18:46 👤 Role: AUTHORITY</span>
-    <span data-ty>2024-09-12 11:18:46 💾 Database: RocksDb at /tmp/node01/chains/local_testnet/db/full</span>
-    <span data-ty>2024-09-12 11:18:46 Using default protocol ID "sup" because none is configured in the chain specs</span>
-    <span data-ty>2024-09-12 11:18:46 🏷  Local node identity is: 12D3KooWSbaPxmb2tWLgkQVoJdxzpBPTd9dQPmKiJfsvtP753Rg1</span>
-    <span data-ty>2024-09-12 11:18:46 Running libp2p network backend</span>
-    <span data-ty>2024-09-12 11:18:46 💻 Operating system: macos</span>
-    <span data-ty>2024-09-12 11:18:46 💻 CPU architecture: aarch64</span>
-    <span data-ty>2024-09-12 11:18:46 📦 Highest known block at #0</span>
-    <span data-ty>2024-09-12 11:18:46 〽️ Prometheus exporter started at 127.0.0.1:9615</span>
-    <span data-ty>2024-09-12 11:18:46 Running JSON-RPC server: addr=127.0.0.1:9945, allowed origins=["http://localhost:*", "http://127.0.0.1:*", "https://localhost:*", "https://127.0.0.1:*", "https://polkadot.js.org"]</span>
-    <span data-ty>2024-09-12 11:18:51 💤 Idle (0 peers), best: #0 (0x850f…951f), finalized #0 (0x850f…951f), ⬇ 0 ⬆ 0</span>
+<div id="termynal" data-termynal>
+  <span data-ty="input"><span class="file-path"></span>./target/release/solochain-template-node \</span>
+  <span data-ty>--base-path /tmp/node01 \</span>
+  <span data-ty>--chain ./customSpecRaw.json \</span>
+  <span data-ty>--port 30333 \</span>
+  <span data-ty>--rpc-port 9945 \</span>
+  <span data-ty>--validator \</span>
+  <span data-ty>--name MyNode01 \</span>
+  <span data-ty>--password-interactive</span>
+  <span data-ty>2024-09-12 11:18:46 Substrate Node</span>
+  <span data-ty>2024-09-12 11:18:46 ✌️ version 0.1.0-8599efc46ae</span>
+  <span data-ty>2024-09-12 11:18:46 ❤️ by Parity Technologies &lt;admin@parity.io&gt;, 2017-2024</span>
+  <span data-ty>2024-09-12 11:18:46 📋 Chain specification: My Custom Testnet</span>
+  <span data-ty>2024-09-12 11:18:46 🏷 Node name: MyNode01</span>
+  <span data-ty>2024-09-12 11:18:46 👤 Role: AUTHORITY</span>
+  <span data-ty>2024-09-12 11:18:46 💾 Database: RocksDb at /tmp/node01/chains/local_testnet/db/full</span>
+  <span data-ty>2024-09-12 11:18:46 Using default protocol ID "sup" because none is configured in the chain specs</span>
+  <span data-ty>2024-09-12 11:18:46 🏷 Local node identity is: 12D3KooWSbaPxmb2tWLgkQVoJdxzpBPTd9dQPmKiJfsvtP753Rg1</span>
+  <span data-ty>2024-09-12 11:18:46 Running libp2p network backend</span>
+  <span data-ty>2024-09-12 11:18:46 💻 Operating system: macos</span>
+  <span data-ty>2024-09-12 11:18:46 💻 CPU architecture: aarch64</span>
+  <span data-ty>2024-09-12 11:18:46 📦 Highest known block at #0</span>
+  <span data-ty>2024-09-12 11:18:46 〽️ Prometheus exporter started at 127.0.0.1:9615</span>
+  <span data-ty>2024-09-12 11:18:46 Running JSON-RPC server: addr=127.0.0.1:9945, allowed origins=["http://localhost:*", "http://127.0.0.1:*", "https://localhost:*", "https://127.0.0.1:*", "https://polkadot.js.org"]</span>
+  <span data-ty>2024-09-12 11:18:51 💤 Idle (0 peers), best: #0 (0x850f…951f), finalized #0 (0x850f…951f), ⬇ 0 ⬆ 0</span>
 </div>

--- a/.snippets/code/tutorials/tooling/chopsticks/overview/terminal/fork-output.html
+++ b/.snippets/code/tutorials/tooling/chopsticks/overview/terminal/fork-output.html
@@ -5,25 +5,25 @@
   <span data-ty>--p astar</span>
   <br />
   <span data-ty>[13:46:07.901] INFO: Loading config file https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml</span>
-  <span data-ty> app: "chopsticks"</span>
+  <span data-ty>&nbsp;app: "chopsticks"</span>
   <span data-ty>[13:46:12.631] INFO: Moonbeam RPC listening on port 8000</span>
-  <span data-ty> app: "chopsticks"</span>
+  <span data-ty>&nbsp;app: "chopsticks"</span>
   <span data-ty>[13:46:12.632] INFO: Loading config file https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/astar.yml</span>
-  <span data-ty> app: "chopsticks"</span>
-  <span data-ty> chopsticks::executor TRACE: Calling Metadata_metadata</span>
-  <span data-ty> chopsticks::executor TRACE: Completed Metadata_metadata</span>
+  <span data-ty>&nbsp;app: "chopsticks"</span>
+  <span data-ty>&nbsp;chopsticks::executor TRACE: Calling Metadata_metadata</span>
+  <span data-ty>&nbsp;chopsticks::executor TRACE: Completed Metadata_metadata</span>
   <span data-ty>[13:46:23.669] INFO: Astar RPC listening on port 8001</span>
-  <span data-ty> app: "chopsticks"</span>
+  <span data-ty>&nbsp;app: "chopsticks"</span>
   <span data-ty>[13:46:25.144] INFO (xcm): Connected parachains [2004,2006]</span>
-  <span data-ty> app: "chopsticks"</span>
+  <span data-ty>&nbsp;app: "chopsticks"</span>
   <span data-ty>[13:46:25.144] INFO: Loading config file https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/polkadot.yml</span>
-  <span data-ty> app: "chopsticks"</span>
-  <span data-ty> chopsticks::executor TRACE: Calling Metadata_metadata</span>
-  <span data-ty> chopsticks::executor TRACE: Completed Metadata_metadata</span>
+  <span data-ty>&nbsp;app: "chopsticks"</span>
+  <span data-ty>&nbsp;chopsticks::executor TRACE: Calling Metadata_metadata</span>
+  <span data-ty>&nbsp;chopsticks::executor TRACE: Completed Metadata_metadata</span>
   <span data-ty>[13:46:53.320] INFO: Polkadot RPC listening on port 8002</span>
-  <span data-ty> app: "chopsticks"</span>
+  <span data-ty>&nbsp;app: "chopsticks"</span>
   <span data-ty>[13:46:54.038] INFO (xcm): Connected relaychain 'Polkadot' with parachain 'Moonbeam'</span>
-  <span data-ty> app: "chopsticks"</span>
+  <span data-ty>&nbsp;app: "chopsticks"</span>
   <span data-ty>[13:46:55.028] INFO (xcm): Connected relaychain 'Polkadot' with parachain 'Astar'</span>
-  <span data-ty> app: "chopsticks"</span>
+  <span data-ty>&nbsp;app: "chopsticks"</span>
 </div>


### PR DESCRIPTION
This updates the pre-commit hook to run a script that replaces leading whitespaces in `span`s with non-breaking space characters to preserve the structure the leading whitespaces provided