### PR TITLE
Polkadot Protocol > Basics > Data Encoding

### DIFF
--- a/polkadot-protocol/basics/data-encoding.md
+++ b/polkadot-protocol/basics/data-encoding.md
@@ -1,6 +1,6 @@
 ---
 title: Data Encoding
-description: TODO
+description: SCALE codec enables fast, efficient data encoding in Substrate, ideal for resource-constrained environments like Wasm, supporting custom types and compact encoding.
 ---
 
 # Data Encoding

--- a/polkadot-protocol/basics/data-encoding.md
+++ b/polkadot-protocol/basics/data-encoding.md
@@ -2,3 +2,104 @@
 title: Data Encoding
 description: TODO
 ---
+
+# Data Encoding
+
+Polkadot SDK uses a lightweight and efficient encoding/decoding mechanism to optimize data transmission across the network. This mechanism, known as the **SCALE** codec, is used for serializing and deserializing data.
+
+The **SCALE** codec plays a vital role in enabling communication between the runtime and the outer node.
+
+The **SCALE** codec is designed for high-performance, copy-free data encoding and decoding in resource-constrained environments like the Polkadot SDK [WebAssembly runtime](add link to Runtime development page){target=\_blank}.
+
+It is not self-describing, meaning the decoding context must have full knowledge of the encoded data types. 
+
+Parity's front-end libraries utilize the [`parity-scale-codec`](https://github.com/paritytech/parity-scale-codec){target=\_blank} crate (a Rust implementation of the SCALE codec) to handle encoding and decoding for interactions between RPCs and the runtime.
+
+The codec is ideal for Polkadot SDK chains and blockchain systems because:
+
+- It is lightweight compared to generic serialization frameworks like [`serde`](https://serde.rs/){target=\_blank}, which add unnecessary bulk to binaries.
+- It doesn’t rely on Rust’s `libstd`, making it compatible with `no_std` environments like Wasm runtime.
+- It integrates seamlessly with Rust, allowing easy derivation of encoding and decoding logic for new types using `#[derive(Encode, Decode)]`.
+
+Defining a custom encoding scheme in Polkadot SDK chain, rather than using an existing Rust codec library, is crucial for enabling cross-platform and multi-language support. 
+
+By creating the SCALE codec, Substrate ensures that the encoding can be re-implemented in other languages and platforms to support interoperability between Substrate-based blockchains.
+
+## Parity SCALE Codec
+
+Rust implementation of the SCALE data format for types used in the Polkadot SDK framework.
+
+The codec is implemented using the following traits:
+
+- Encode
+- Decode
+- CompactAs
+- HasCompact
+- EncodeLike
+
+### Encode
+
+The `Encode` trait handles data encoding into SCALE format and includes the following key functions:
+
+- s`ize_hint(&self) -> usize`: Estimates the number of bytes required for encoding to prevent multiple memory allocations. This should be inexpensive and avoid complex operations. Optional if the size isn’t known.
+- `encode_to<T: Output>(&self, dest: &mut T)`: Encodes the data, appending it to a destination buffer.
+- `encode(&self) -> Vec<u8>`: Encodes the data and returns it as a byte vector.
+- `using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R`: Encodes the data and passes it to a closure, returning the result.
+
+!!!note
+    For best performance, value types should override `using_encoded`, and allocating types should override `encode_to`. It's recommended to implement `size_hint` for all types where possible.
+
+### Decode
+
+The `Decode` trait handles decoding SCALE-encoded data back into the appropriate types:
+
+- `fn decode<I: Input>(value: &mut I) -> Result<Self, Error>`: Decodes data from the SCALE format, returning an error if decoding fails.
+
+### CompactAs
+
+The `CompactAs` trait wraps custom types for compact encoding:
+
+- `encode_as(&self) -> &Self::As`: Encodes the type as a compact type.
+- `decode_from(_: Self::As) -> Result<Self, Error>`: Decodes from a compact encoded type.
+
+### HasCompact
+
+The `HasCompact` trait indicates a type supports compact encoding.
+
+### EncodeLike
+
+The `EncodeLike` trait is used to ensure multiple types that encode similarly are accepted by the same function. When using `derive`, it is automatically implemented.
+
+### Data Types
+
+The table below outlines how the Rust implementation of the Parity SCALE codec encodes different data types.
+
+| Type                          | Description                                                                                                                                                                 | Example SCALE Decoded Value                                                                                                            | SCALE Encoded Value                                         |
+|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| Boolean                       | Boolean values are encoded using the least significant bit of a single byte.                                                                                                | `false` / `true`                                                                                                                           | `0x00` / `0x01`                                                 |
+| Compact/general integers      | A "compact" or general integer encoding is sufficient for encoding large integers (up to 2^536) and is more efficient at encoding most values than the fixed-width version. | `unsigned integer 0` / `unsigned integer 1` / `unsigned integer 42` / `unsigned integer 69` / `unsigned integer 65535` / `BigInt(100000000000000)` | `0x00` / `0x04` / `0xa8` / `0x1501` / `0xfeff0300` / `0x0b00407a10f35a` |
+| Enumerations (tagged-unions)  | A fixed number of variants                                                                                                                                                  |
+| Fixed-width integers          | Basic integers are encoded using a fixed-width little-endian (LE) format.                                                                                                   | `signed 8-bit integer 69` / `unsigned 16-bit integer 42` / `unsigned 32-bit integer 16777215`                                                | `0x45` / `0x2a00` / `0xffffff00`                                  |
+| Options                       | One or zero values of a particular type.                                                                                                                                    | `Some` / `None`                                                                                                                            | `0x01` followed by the encoded value / `0x00`                   |
+| Results                       | Results are commonly used enumerations which indicate whether certain operations were successful or unsuccessful.                                                           | `Ok(42)` / `Err(false)`                                                                                                                    | `0x002a` / `0x0100`                                             |
+| Strings                       | Strings are Vectors of bytes (Vec<u8>) containing a valid UTF8 sequence.                                                                                                    |                                                                                                                                        |                                                             |
+| Structs                       | For structures, the values are named, but that is irrelevant for the encoding (names are ignored - only order matters).                                                     | `SortedVecAsc::from([3, 5, 2, 8])`                                                                                                       | `[3, 2, 5, 8]   `                                             |
+| Tuples                        | A fixed-size series of values, each with a possibly different but predetermined and fixed type. This is simply the concatenation of each encoded value.                     | Tuple of compact unsigned integer and boolean: `(3, false)                        `                                                      | `0x0c00`                                                      |
+| Vectors (lists, series, sets) | A collection of same-typed values is encoded, prefixed with a compact encoding of the number of items, followed by each item's encoding concatenated in turn.               | Vector of unsigned `16`-bit integers: `[4, 8, 15, 16, 23, 42]               `                                                              | `0x18040008000f00100017002a00`                                |
+
+## SCALE codec libraries
+
+Several **SCALE** codec implementations are available in various languages. Here's a list of them:
+
+- AssemblyScript: [`LimeChain/as-scale-codec`](https://github.com/LimeChain/as-scale-codec){target=\_blank}
+- C: [`MatthewDarnell/cScale`](https://github.com/MatthewDarnell/cScale){target=\_blank}
+- C++: [`soramitsu/scale-codec-cpp`](https://github.com/qdrvm/scale-codec-cpp){target=\_blank}
+- JavaScript: [`polkadot-js/api`](https://github.com/polkadot-js/api){target=\_blank}
+- Dart: [`leonardocustodio/polkadart`](https://github.com/leonardocustodio/polkadart){target=\_blank}
+- Haskell: [`airalab/hs-web3`](https://github.com/airalab/hs-web3/tree/master/packages/scale){target=\_blank}
+- Golang: [`itering/scale.go`](https://github.com/itering/scale.go){target=\_blank}
+- Java: [`emeraldpay/polkaj`](https://github.com/splix/polkaj){target=\_blank}
+- Python: [`polkascan/py-scale-codec`](https://github.com/polkascan/py-scale-codec){target=\_blank}
+- Ruby:[` wuminzhe/scale_rb`](https://github.com/wuminzhe/scale_rb){target=\_blank}
+- TypeScript: [`parity-scale-codec-ts`](https://github.com/tjjfvi/subshape){target=\_blank}, [`scale-ts`](https://github.com/unstoppablejs/unstoppablejs/tree/main/packages/scale-ts#scale-ts){target=\_blank}, [`soramitsu/scale-codec-js-library`](https://github.com/soramitsu/scale-codec-js-library){target=\_blank}, [`subsquid/scale-codec`](https://github.com/subsquid/squid-sdk/tree/master/substrate/scale-codec){target=\_blank}
+


### PR DESCRIPTION
Migrated from the pages: 
- https://github.com/paritytech/parity-scale-codec#parity-scale-codec
- https://docs.substrate.io/reference/scale-codec/  