### PR TITLE
[Fix] Adding .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode


### PR DESCRIPTION
This PR adds `.vscode` folder to `.gitignore` to avoid accidentally committing any local config that any contributor might have in their local dev environment

