### PR TITLE
add scripts for styling-related purposes

### DIFF
--- a/js/header-scroll.js
+++ b/js/header-scroll.js
@@ -1,0 +1,13 @@
+let lastScrollY = window.scrollY;
+
+window.addEventListener('scroll', () => {
+  const header = document.querySelector('.md-header__inner');
+  if (window.scrollY > lastScrollY) {
+    // User is scrolling down - hide the header
+    header.classList.add('hidden');
+  } else {
+    // User is scrolling up - show the header
+    header.classList.remove('hidden');
+  }
+  lastScrollY = window.scrollY;
+});

--- a/js/search-bar-results.js
+++ b/js/search-bar-results.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', function () {
+  // Only show the search results if the user has started to type
+  // Select the search input and output elements
+  const searchInput = document.querySelector('.md-search__input');
+  const searchOutput = document.querySelector('.md-search__output');
+
+  // Listen for input events on the search field
+  searchInput.addEventListener('input', function () {
+    // Add the "visible" class if there is text in the input field
+    if (searchInput.value.trim() !== '') {
+      searchOutput.classList.add('visible');
+    } else {
+      // Remove the "visible" class if input is empty
+      searchOutput.classList.remove('visible');
+    }
+  });
+
+  // Do not show the search results if it contains the text: "Type to start searching"
+  const searchResultMeta = document.querySelector('.md-search-result__meta');
+
+  if (searchResultMeta) {
+    // Define a function to check and update the text
+    const checkAndUpdateText = () => {
+      if (searchResultMeta.textContent.trim() === "Type to start searching") {
+        searchResultMeta.textContent = "";
+      }
+    };
+
+    // Create a MutationObserver to observe changes in the element
+    const observer = new MutationObserver(checkAndUpdateText);
+
+    // Start observing the element for changes in child elements or text
+    observer.observe(searchResultMeta, { childList: true, subtree: true, characterData: true });
+
+    // Run the initial check in case the text was already present
+    checkAndUpdateText();
+  }
+});
+


### PR DESCRIPTION
This PR enables some specific functionality as outlined below:

- It enables the header to scroll up out of sight while scrolling down a page
- It cleans up the search functionality so that only show the search results if the user has started to type and that the default "Type to start searching" text gets removed entirely from the search results dropdown, as this has been moved to the input placeholder

This goes with mkdocs PR: https://github.com/papermoonio/polkadot-mkdocs/pull/30