### PR TITLE
Minor fixes

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,11 +8,3 @@ hide:
 - navigation
 template: home.html
 ---
-
-# Polkadot Developer Docs
-
-Explore everything you need to start building on top of Polkadot, a protocol that provides parachains with shared security and interoperability using XCM.
-
-## In This Section
-
-:::INSERT_IN_THIS_SECTION:::

--- a/js/header-scroll.js
+++ b/js/header-scroll.js
@@ -1,10 +1,11 @@
 // The purpose of this script is to move the header up out of view while
 // the user is scrolling down a page
-let lastScrollY = window.scrollY;
+let lastScrollY = Math.max(0, window.scrollY);
 const header = document.querySelector('.md-header__inner');
 
 window.addEventListener('scroll', () => {
-  // Toggle header visibility based on scroll direction
-  header.classList.toggle('hidden', window.scrollY > lastScrollY);
-  lastScrollY = window.scrollY;
+  const currentScrollY = Math.max(0, window.scrollY);
+  const isScrollingDown = currentScrollY > lastScrollY;
+  header.classList.toggle('hidden', isScrollingDown);
+  lastScrollY = currentScrollY;
 });


### PR DESCRIPTION
This PR fixes the following:

- Scrolling behavior on Safari. It was pretty jumpy, these changes smooth it out without impacting the scrolling behavior on other browsers
- Removes the index page content for the home page. The home page content is in the `home.html` template in the mkdocs repo, so this is unnecessary and gets overwritten (was added by accident). However, it was also causing issues with the left navigation on smaller screens, next to the home menu option it was showing a TOC icon