### PR TITLE
[FIX] -  formatting on install polkadot sdk page

### DIFF
--- a/develop/parachains/get-started/install-polkadot-sdk.md
+++ b/develop/parachains/get-started/install-polkadot-sdk.md
@@ -223,8 +223,8 @@ However, suppose your local computer uses Microsoft Windows instead of a UNIX-ba
 Before installing on Microsoft Windows, verify the following basic requirements:
 
 - You have a computer running a supported Microsoft Windows operating system:
-  - **For Windows desktop** - you must be running Microsoft Windows 10, version 2004 or later, or Microsoft Windows 11 to install WSL
-  - **For Windows server** - you must be running Microsoft Windows Server 2019, or later, to install WSL on a server operating system
+    - **For Windows desktop** - you must be running Microsoft Windows 10, version 2004 or later, or Microsoft Windows 11 to install WSL
+    - **For Windows server** - you must be running Microsoft Windows Server 2019, or later, to install WSL on a server operating system
 - You have good internet connection and access to a shell terminal on your local computer
 
 ### Set Up Windows Subsystem for Linux


### PR DESCRIPTION
This PR aims to fix a minor formatting issue in the polkadot sdk installation page:

From:
![image](https://github.com/user-attachments/assets/551e3e1a-bc08-48f8-bfc0-06da45bf8d84)
To:
![image](https://github.com/user-attachments/assets/bd11d1d3-f094-4fca-8e0e-a496d0e37d0b)
