### PR TITLE
Update script logic to show left navigation on root level index pages

### DIFF
--- a/js/root-level-sections.js
+++ b/js/root-level-sections.js
@@ -5,8 +5,14 @@ document.addEventListener('DOMContentLoaded', function () {
   // Get the current pathname
   const path = window.location.pathname;
 
-  // Check if the path contains exactly one item in its path
   const pathParts = path.split('/').filter((part) => part !== ''); // Split by '/' and remove empty parts
+
+  // Remove 'polkadot-mkdocs' if it's the first part of the path
+  if (pathParts[0] === 'polkadot-mkdocs') {
+    pathParts.shift(); // Remove the first element
+  }
+  
+  // Check if the path contains exactly one item in its path  
   if (pathParts.length === 1) {
     // Select the target element
     const sidebarInner = document.querySelector(


### PR DESCRIPTION
This PR just updates the script to work on gh pages so the left navigation is shown on the root level index pages (i.e., https://papermoonio.github.io/polkadot-mkdocs/develop/)