### PR TITLE
removes "crosschain" as a dev pathway from develop/index.md

### DIFF
--- a/develop/development-pathways.md
+++ b/develop/development-pathways.md
@@ -15,8 +15,8 @@ The Polkadot ecosystem provides multiple development pathways:
 ```mermaid
 graph TD
     A[Development Pathways]
-    A --> B[Smart Contract Development]
-    A --> C[Parachain Development]
+    A --> B[Parachain Development]
+    A --> C[Smart Contract Development]
     A --> D[Client-Side Development]
 ```
 

--- a/develop/index.md
+++ b/develop/index.md
@@ -26,7 +26,7 @@ This section builds on concepts from the [Polkadot Protocol](/polkadot-protocol)
 
     - **Where to start** - [Polkadot Ecosystem Toolkit](/develop/toolkit/){target=\_blank}
 
-- **Cross-chain developers** - harness Polkadot's interoperability features to enable secure communication and asset transfers across blockchains. Leverage Cross-Consensus Messaging (XCM) to create innovative cross-chain workflows and applications
+- **Cross-Consensus Messaging (XCM)** - developers across all three pathways can leverage Cross-Consensus Messaging (XCM) to create innovative cross-chain workflows and applications
 
     - **Where to start** - [Introduction to XCM](/develop/interoperability/intro-to-xcm/){target=\_blank}
 


### PR DESCRIPTION
This PR does: pending decision on merging development-pathways into the develop/index page, I've updated the index page to be consistent with the three dev paths and the diagram on the development-pathways.

This PR is part of Issue #237 but more work is needed to resolve the issue