### PR TITLE
[FIX] - Typo on asset transfer overview

### DIFF
--- a/.snippets/code/tutorials/polkadot-sdk/parachains/connect-to-relay-chain/acquire-a-testnet-slot/deploy-on-paseo-3.html
+++ b/.snippets/code/tutorials/polkadot-sdk/parachains/connect-to-relay-chain/acquire-a-testnet-slot/deploy-on-paseo-3.html
@@ -1,8 +1,7 @@
 <div id="termynal" data-termynal>
-    <span data-ty="input"><span class="file-path"></span>polkadot-omni-node key generate-node-key --base-path /tmp/parachain/pubs-demo --chain raw-parachain-chainspec.json</span>
-    <br />
-    <span data-ty="progress">2024-09-11 09:48:15 Building chain spec</span>
-    <span data-ty="progress">Generating key in "/tmp/parachain/pubs-demo/chains/live/network/secret_ed25519"</span>
-    <span data-ty="progress">12D3KooWJH816dWizsft7MXVrv1nH3dHnGsHxD1qdyQm9mMAbo7Z</span>
-  </div>
-  
+  <span data-ty="input"><span class="file-path"></span>polkadot-omni-node key generate-node-key --base-path /tmp/parachain/pubs-demo --chain raw-parachain-chainspec.json</span>
+  <br />
+  <span data-ty="progress">2024-09-11 09:48:15 Building chain spec</span>
+  <span data-ty="progress">Generating key in "/tmp/parachain/pubs-demo/chains/live/network/secret_ed25519"</span>
+  <span data-ty="progress">12D3KooWJH816dWizsft7MXVrv1nH3dHnGsHxD1qdyQm9mMAbo7Z</span>
+</div>

--- a/develop/toolkit/interoperability/asset-transfer-api/overview.md
+++ b/develop/toolkit/interoperability/asset-transfer-api/overview.md
@@ -68,7 +68,7 @@ Leverage the `constructApiPromise` helper function provided by the library for t
 ```
 
 !!!note
-    The code example id enclosed in an async main function to provide the necessary asynchronous context. However, you can use the code directly if you're already working within an async environment. The key is to ensure you're in an async context when working with these asynchronous operations, regardless of your specific setup.
+    The code example is enclosed in an async main function to provide the necessary asynchronous context. However, you can use the code directly if you're already working within an async environment. The key is to ensure you're in an async context when working with these asynchronous operations, regardless of your specific setup.
 
 ## Asset Transfer API Reference
 


### PR DESCRIPTION
This PR corrects a small typo on the asset transfer API overview page

Note: Prettier executed on `.snippets/code/tutorials/polkadot-sdk/parachains/connect-to-relay-chain/acquire-a-testnet-slot/deploy-on-paseo-3.html` also resolves a slight indentation issue