### PR TITLE
add script to fix created dates

### DIFF
--- a/js/fix-created-date.js
+++ b/js/fix-created-date.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const dateLabels = document.querySelectorAll(
+    '.git-revision-date-localized-plugin-date'
+  );
+
+  // Only make modifications on pages with dates
+  if (dateLabels.length > 0) {
+    const lastUpdate = dateLabels[0].innerHTML;
+    const created = dateLabels[1].innerHTML;
+
+    const lastUpdateDate = new Date(lastUpdate);
+    const createdDate = new Date(created);
+
+    // If the created date is after the last updated date,
+    // default to using the last updated date
+    if (lastUpdateDate < createdDate) {
+      dateLabels[1].innerHTML = lastUpdate;
+    }
+  }
+});


### PR DESCRIPTION
This just adds a script to default to the last updated date instead of the current date if for whatever reason the created date cannot be found

Goes with PR: https://github.com/papermoonio/polkadot-mkdocs/pull/56