### PR TITLE
Add link to Polkadot SDK best practices

### DIFF
--- a/develop/index.md
+++ b/develop/index.md
@@ -69,6 +69,7 @@ Build, deploy, and maintain custom parachains with the Polkadot SDK.
     <hr>
     - [Polkadot SDK source code repository](https://github.com/paritytech/polkadot-sdk){target=\_blank}
     - [FRAME source code repository](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/frame){target=\_blank}
+    - [Polkadot SDK Best Practices](https://libro.blockdeep.dev/index.html){target=\_blank}
 
 </div>
 

--- a/develop/parachains/customize-parachain/index.md
+++ b/develop/parachains/customize-parachain/index.md
@@ -31,4 +31,10 @@ The [FRAME directory](https://github.com/paritytech/polkadot-sdk/tree/master/sub
       <p class="description">Check out the Rust documentation for FRAME, Substrate's preferred framework for building runtimes.</p>
     </a>
   </div>
+  <div class="card">
+    <a href="https://libro.blockdeep.dev/index.html" target="_blank">
+      <h2 class="title">Polkadot SDK Best Practices</h2>
+      <p class="description">Understand and address common issues that can arise in blockchain development when building with the Polkadot SDK.</p>
+    </a>
+  </div>
 </div>


### PR DESCRIPTION
This PR adds a link to Polkadot SDK best practices in the following sections:

Develop Index
Develop > Parachains > Customize your Parachain Index