### PR TITLE
Create mermaid diagram for Substrate Node

### DIFF
--- a/develop/parachains/intro-polkadot-sdk.md
+++ b/develop/parachains/intro-polkadot-sdk.md
@@ -51,18 +51,16 @@ Every blockchain platform relies on a decentralized network of computers—calle
     - Also known as State Transition Function (STF)
 
 ``` mermaid
-
 graph TB
     subgraph sg1[Substrate Node]
-        B[Wasm Runtime -</br>application logic]
+        B[Wasm Runtime - STF]
         I[RuntimeCall Executor]
         subgraph sg2[Client]
             direction TB
-            C[Network and blockchain</br>infrastructure activity]
+            C[Network and blockchain</br>infrastructure services]
         end
         I -.-> B
     end
-
 ```
 
 ### FRAME

--- a/develop/parachains/intro-polkadot-sdk.md
+++ b/develop/parachains/intro-polkadot-sdk.md
@@ -50,6 +50,21 @@ Every blockchain platform relies on a decentralized network of computers—calle
     - Stored as a part of the chain state
     - Also known as State Transition Function (STF)
 
+``` mermaid
+
+graph TB
+    subgraph sg1[Substrate Node]
+        B[Wasm Runtime -</br>application logic]
+        I[RuntimeCall Executor]
+        subgraph sg2[Client]
+            direction TB
+            C[Network and blockchain</br>infrastructure activity]
+        end
+        I -.-> B
+    end
+
+```
+
 ### FRAME
 
 FRAME provides the core modular and extensible components that make the Substrate SDK flexible and adaptable to different use cases. FRAME includes Rust-based libraries that simplify the development of application-specific logic. Most of the functionality that FRAME provides takes the form of plug-in modules called [pallets](/polkadot-protocol/glossary#pallet){target=\_blank} that you can add and configure to suit your requirements.

--- a/develop/parachains/intro-polkadot-sdk.md
+++ b/develop/parachains/intro-polkadot-sdk.md
@@ -50,17 +50,27 @@ Every blockchain platform relies on a decentralized network of computers—calle
     - Stored as a part of the chain state
     - Also known as State Transition Function (STF)
 
-``` mermaid
+```mermaid
+%%{init: {'flowchart': {'padding': 25, 'nodeSpacing': 10, 'rankSpacing': 50}}}%%
 graph TB
+    %% Define comprehensive styles
+    classDef titleStyle font-size:30px,font-weight:bold,stroke-width:2px,padding:20px
+    
     subgraph sg1[Substrate Node]
+        %% Add invisible spacer with increased height
+        spacer[ ]
+        style spacer height:2px,opacity:0
+        
         B[Wasm Runtime - STF]
         I[RuntimeCall Executor]
         subgraph sg2[Client]
             direction TB
-            C[Network and blockchain</br>infrastructure services]
+            C[Network and Blockchain<br/>Infrastructure Services]
         end
         I -.-> B
     end
+    %% Apply comprehensive styles
+    class sg1 titleStyle
 ```
 
 ### FRAME


### PR DESCRIPTION
This PR creates a mermaid diagram for Substrate Node architecture. It demonstrates the separation between the runtime and the client. 

@nhussein11 I got this laid out ok but I'm not having luck applying styles. I was hoping to make the "Substrate Node" text a size bigger and maybe bold? idk. Just doesn't stand out much. Do you want to take a shot at applying styles?