### PR TITLE
Minor fix: Moved to inline from being copyable

### DIFF
--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -113,12 +113,7 @@ After successfully compiling your runtime, you can spin up a local chain and pro
 
 ## Interact with the Node
 
-When running the template node, it's accessible by default at:
-
-```bash
-ws://localhost:9944
-```
-To interact with your node using the [Polkadot.js Apps](https://polkadot.js.org/apps/#/explorer){target=\_blank} interface, follow these steps:
+When running the template node, it's accessible by default at `ws://localhost:9944`. To interact with your node using the [Polkadot.js Apps](https://polkadot.js.org/apps/#/explorer){target=\_blank} interface, follow these steps:
 
 1. Open [Polkadot.js Apps](https://polkadot.js.org/apps/#/explorer){target=\_blank} in your web browser and click the network icon in the top left corner
     


### PR DESCRIPTION
Problem: Websocket address was presented like it should be copied (which implied it needs to be pasted, which leads down a rabbit hole...). Instead moved it to inline, so that the instruction is clearly to open Polkadot app