### PR TITLE
add rust toolchain information

### DIFF
--- a/.snippets/code/README.md
+++ b/.snippets/code/README.md
@@ -1,0 +1,25 @@
+# Polkadot Developer Docs Code Snippets
+
+## Project Setup
+
+This project requires specific versions of Rust and Cargo.
+
+### Rust Toolchains
+
+The project uses the following Rust toolchains:
+
+-   **Stable:** `1.81.0` (for building)
+-   **Nightly:** `1.85.0-nightly` (for formatting and linting)
+
+To install the required toolchains, instrall `rustup` and run:
+
+```bash
+rustup toolchain install 1.81.0
+rustup toolchain install nightly-2024-12-15
+```
+
+## Disclaimer
+
+### License
+
+All code examples or related software provided in this repository are available under the [MIT-0 License](https://opensource.org/license/mit-0).

--- a/.snippets/code/README.md
+++ b/.snippets/code/README.md
@@ -11,7 +11,7 @@ The project uses the following Rust toolchains:
 -   **Stable:** `1.81.0` (for building)
 -   **Nightly:** `1.85.0-nightly` (for formatting and linting)
 
-To install the required toolchains, instrall `rustup` and run:
+To install the required toolchains, install `rustup` and run:
 
 ```bash
 rustup toolchain install 1.81.0

--- a/.snippets/code/rust-toolchain.toml
+++ b/.snippets/code/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+channel = "1.81.0"
+components = ["rustfmt", "clippy"]
+
+[toolchain.nightly]
+channel = "1.85.0-nightly"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Small PR to add rust toolchain information to ensure consistent builds. The rust versions are the same as the `polkadot-sdk` package.