### PR TITLE
add github workflows

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,0 +1,1 @@
+IMAGE="docker.io/paritytech/ci-unified:bullseye-1.81.0-2024-11-19-v202411281558"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,102 @@
+name: Checks
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.snippets/code/**'
+      - '.github/workflows/**'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.snippets/code/**'
+      - '.github/workflows/**'
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    uses: ./.github/workflows/reusable-preflight.yml
+
+  fmt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [preflight]
+    container:
+      image: ${{ needs.preflight.outputs.IMAGE }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cargo fmt
+        working-directory: .snippets/code
+        run: cargo +nightly fmt --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [preflight]
+    container:
+      image: ${{ needs.preflight.outputs.IMAGE }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clippy check
+        working-directory: .snippets/code
+        run: cargo clippy -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [preflight]
+    container:
+      image: ${{ needs.preflight.outputs.IMAGE }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        working-directory: .snippets/code
+        run: cargo test
+
+  check-fail-ci:
+    runs-on: ubuntu-latest
+    container:
+      image: "paritytech/tools:latest"
+      options: --user root
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check
+        working-directory: .snippets/code
+        run: |
+          set +e
+          rg --line-number --hidden --type rust --glob '!{.git,target}' "$ASSERT_REGEX" .; exit_status=$?
+          if [ $exit_status -eq 0 ]; then
+            echo "$ASSERT_REGEX was found, exiting with 1";
+            exit 1;
+          else
+            echo "No $ASSERT_REGEX was found, exiting with 0";
+            exit 0;
+          fi
+        env:
+          ASSERT_REGEX: "FAIL-CI"
+          GIT_DEPTH: 1
+
+  confirm-checks:
+    runs-on: ubuntu-latest
+    name: All checks passed
+    needs:
+      - fmt
+      - clippy
+      - test
+      - check-fail-ci
+    if: always() && !cancelled()
+    steps:
+      - run: |
+          tee resultfile <<< '${{ toJSON(needs) }}'
+          FAILURES=$(cat resultfile | grep '"result": "failure"' | wc -l)
+          if [ $FAILURES -gt 0 ]; then
+            echo "### At least one required job failed ❌" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          else
+            echo '### Good job! All the required jobs passed 🚀' >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,7 +44,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Clippy check
         working-directory: .snippets/code
-        run: cargo clippy -- -D warnings
+        run: |
+            cargo clippy --all-targets --locked --workspace --quiet
+            cargo clippy --all-targets --all-features --locked --workspace --quiet
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-preflight.yml
+++ b/.github/workflows/reusable-preflight.yml
@@ -1,0 +1,48 @@
+name: Preflight
+
+on:
+  workflow_call:
+    outputs:
+      changes_rust:
+        value: ${{ jobs.preflight.outputs.changes_rust }}
+      changes_currentWorkflow:
+        value: ${{ jobs.preflight.outputs.changes_currentWorkflow }}
+      IMAGE:
+        value: ${{ jobs.preflight.outputs.IMAGE }}
+        description: "CI image"
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      changes_rust: ${{ steps.set_changes.outputs.rust_any_changed || steps.set_changes.outputs.currentWorkflow_any_changed }}
+      changes_currentWorkflow: ${{ steps.set_changes.outputs.currentWorkflow_any_changed }}
+      IMAGE: ${{ steps.set_image.outputs.IMAGE }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Current file
+        id: current_file
+        shell: bash
+        run: |
+          echo "currentWorkflowFile=$(echo ${{ github.workflow_ref }} | sed -nE "s/.*(\.github\/workflows\/[a-zA-Z0-9_-]*\.y[a]?ml)@refs.*/\1/p")" >> $GITHUB_OUTPUT
+          echo "currentActionDir=$(echo ${{ github.action_path }} | sed -nE "s/.*(\.github\/actions\/[a-zA-Z0-9_-]*)/\1/p")" >> $GITHUB_OUTPUT
+
+      - name: Set changes
+        id: set_changes
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            rust:
+              - '.snippets/code/**/*'
+              - '!.github/**/*'
+              - '!docs/**/*'
+            currentWorkflow:
+              - '${{ steps.current_file.outputs.currentWorkflowFile }}'
+              - '.github/workflows/reusable-preflight.yml'
+
+      - name: Set image
+        id: set_image
+        shell: bash
+        run: cat .github/env >> $GITHUB_OUTPUT


### PR DESCRIPTION
* This PR adds Github workflows for some basic checks.
* This is required as we are trying to make all the rust code in this repository buildable and testable as part of [this issue](https://github.com/polkadot-developers/polkadot-docs/issues/236). These workflows would streamline the review process by performing some basic checks like `build`, `test` and `fmt`. These tests are largely inspired by what is already present in the `polkadot-sdk`.
* This uses the same docker image for the environment as the `polkadot-sdk` repository for consistency.
* Given that the code in this repository is exclusively for the tutorials on docs.polkadot.com, I have added the minimum tests required (IMO) to make reviews streamlined and easy. More tests can be added later on if required.
* **Testing**: Used `act` library with docker for local testing. Also the checks are running on this PR which should help.
* Part of #236 