### PR TITLE
remove clippy check for all features

### DIFF
--- a/.CONTRIBUTING.md
+++ b/.CONTRIBUTING.md
@@ -6,19 +6,21 @@ This guide covers how to contribute to the documentation, including serving a lo
 
 ## Contents
 
-- [Viewing Site Locally](#view-site-locally)
-  - [Clone Repositories](#clone-repositories)
-  - [Install Dependencies and Serve Site](#install-dependencies)
-- [Adding New Pages](#adding-new-pages)
-  - [Creating a Subdirectory](#creating-a-subdirectory)
-    - [Example `.pages` File](#example-pages-file)
-    - [Example `index.md` File](#example-indexmd-file)
-  - [Adding Pages to Existing Subdirectory](#adding-pages-to-existing-subdirectory)
-- [Modifying Existing Pages](#modifying-existing-pages)
-- [Adding Code and Text Snippets](#adding-code-and-text-snippets)
-- [Adding Images](#adding-images)
-- [Optimizing for SEO](#search-enging-optimization-seo)
-- [Tools for Editing](#tools-for-editing)
+- [Contribute to the Polkadot Developer Docs](#contribute-to-the-polkadot-developer-docs)
+  - [Contents](#contents)
+  - [Viewing Site Locally](#viewing-site-locally)
+    - [Clone Repositories](#clone-repositories)
+    - [Install Dependencies and Serve Site](#install-dependencies-and-serve-site)
+  - [Adding New Pages](#adding-new-pages)
+    - [Creating a New Section](#creating-a-new-section)
+      - [Example `.pages` File](#example-pages-file)
+      - [Example `index.md` File](#example-indexmd-file)
+    - [Adding Pages to Existing Section](#adding-pages-to-existing-section)
+  - [Modifying Existing Pages](#modifying-existing-pages)
+  - [Adding Code and Text Snippets](#adding-code-and-text-snippets)
+  - [Adding Images](#adding-images)
+  - [Search Engine Optimization (SEO)](#search-engine-optimization-seo)
+  - [Tools for Editing](#tools-for-editing)
 
 ## Viewing Site Locally
 
@@ -66,7 +68,13 @@ To set up the structure, follow these steps:
 
     This command will install all dependencies listed in the `requirements.txt` file.
 
-2. In the `polkadot-mkdocs` folder (which should be the current one), you can build the site by running:
+2. Switch to the polkadot-docs directory and use [npm](https://docs.npmjs.com/about-npm) to install dependencies:
+
+    ```bash
+    cd polkadot-docs && npm install
+    ```
+
+3. Navigate back to the `polkadot-mkdocs` folder, then build the site:
 
     ```bash
     mkdocs serve

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,6 @@ jobs:
         working-directory: .snippets/code
         run: |
             cargo clippy --all-targets --locked --workspace --quiet
-            cargo clippy --all-targets --all-features --locked --workspace --quiet
 
   test:
     runs-on: ubuntu-latest

--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/add-pallets-to-runtime.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/add-pallets-to-runtime.md
@@ -72,6 +72,9 @@ This command ensures the runtime compiles without errors, validates the pallet c
 
 Launch your parachain locally and start producing blocks:
 
+!!!info 
+    Generated chain TestNet specifications include development accounts "Alice" and "Bob." These accounts are pre-funded with native parachain currency, allowing you to sign and send TestNet transactions. Take a look at the [Polkadot.js Accounts section](https://polkadot.js.org/apps/#/accounts){target=\_blank} to view the development accounts for your chain.
+
 1. Create a new chain specification file with the updated runtime:
 
     ```bash


### PR DESCRIPTION
Since now we are pulling in templates, they bring in features which are not fully implemented in the custom pallet leading to build errors. Removing `--all-features` from `clippy` to allow for successful CI checks.

Issue identified in #302 

Part of #236 

