### PR TITLE
develop/interop messaging admonition updates

### DIFF
--- a/develop/index.md
+++ b/develop/index.md
@@ -34,12 +34,11 @@ graph TD
     A --> D[Application Development]
 ```
 
-!!! tip
-    All three pathways can leverage Cross-Consensus Messaging (XCM) to create innovative cross-chain workflows and applications. Get started with these resources:
+All three pathways can leverage Cross-Consensus Messaging (XCM) to create innovative cross-chain workflows and applications. To get started with XCM, see these resources:
 
-    - [**Introduction to XCM**](/develop/interoperability/intro-to-xcm/){target=\_blank} - introduces key concepts, core function definitions, and code examples
-    - [**XCM Tools**](/develop/toolkit/interoperability/xcm-tools/){target=\_blank} - provides an overview of popular XCM tools
-    - [**Tutorials for Managing XCM Channels**](/tutorials/interoperability/xcm-channels/){target=\_blank} - guides for using [Polkadot.js Apps](https://polkadot.js.org/apps/#/explorer){target=\_blank} UI to establish cross-chain messaging channels 
+- [**Introduction to XCM**](/develop/interoperability/intro-to-xcm/){target=\_blank} - introduces key concepts, core function definitions, and code examples
+- [**XCM Tools**](/develop/toolkit/interoperability/xcm-tools/){target=\_blank} - provides an overview of popular XCM tools
+- [**Tutorials for Managing XCM Channels**](/tutorials/interoperability/xcm-channels/){target=\_blank} - guides for using [Polkadot.js Apps](https://polkadot.js.org/apps/#/explorer){target=\_blank} UI to establish cross-chain messaging channels 
 
 ### Parachain Developers
 
@@ -75,8 +74,7 @@ Build, deploy, and maintain custom parachains with the Polkadot SDK.
 
 Leverage smart contracts and execute custom logic over existing chains to streamline your development process.
 
-!!! tip
-    The Polkadot smart contract ecosystem is in active development. Please expect frequent changes. You can follow progress, or join the discussion, by visiting this [Contracts on AssetHub Roadmap](https://forum.polkadot.network/t/contracts-on-assethub-roadmap/9513/57){target=\_blank} Polkadot Network Forum post.
+The Polkadot smart contract ecosystem is in active development. Please expect frequent changes. To follow progress, or join the discussion, see [Contracts on AssetHub Roadmap](https://forum.polkadot.network/t/contracts-on-assethub-roadmap/9513/57){target=\_blank} on the Polkadot Network Forum.
 
 <div class="grid cards links" markdown>
 

--- a/develop/interoperability/send-messages.md
+++ b/develop/interoperability/send-messages.md
@@ -13,12 +13,9 @@ This page provides a detailed overview of the XCM pallet's key features, its pri
 
 ## XCM Frame Pallet Overview
 
-The [`pallet-xcm`](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm/pallet/index.html){target=\_blank} provides a set of pre-defined, commonly used [XCVM programs](https://github.com/polkadot-fellows/xcm-format?tab=readme-ov-file#12-the-xcvm){target=\_blank} in the form of a [set of extrinsics](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm/pallet/dispatchables/index.html){target=\blank}.
+The [`pallet-xcm`](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm/pallet/index.html){target=\_blank} provides a set of pre-defined, commonly used [XCVM programs](https://github.com/polkadot-fellows/xcm-format?tab=readme-ov-file#12-the-xcvm){target=\_blank} in the form of a [set of extrinsics](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm/pallet/dispatchables/index.html){target=\blank}. This pallet provides some [default implementations](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm/pallet/struct.Pallet.html#implementations){target=\_blank} for traits required by [`XcmConfig`](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm_benchmarks/trait.Config.html#associatedtype.XcmConfig){target=\_blank}. The [XCM executor](https://paritytech.github.io/polkadot-sdk/master/staging_xcm_executor/struct.XcmExecutor.html){target=\_blank} is also included as an associated type within the pallet's configuration. 
 
-This pallet provides some [default implementations](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm/pallet/struct.Pallet.html#implementations){target=\_blank} for traits required by [`XcmConfig`](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm_benchmarks/trait.Config.html#associatedtype.XcmConfig){target=\_blank}. The [XCM executor](https://paritytech.github.io/polkadot-sdk/master/staging_xcm_executor/struct.XcmExecutor.html){target=\_blank} is also included as an associated type within the pallet's configuration.
-
-!!!note
-    For further details on the XCM configuration, refer to the [XCM Configuration](/develop/interoperability/xcm-config/){target=\_blank} page.
+For further details about the XCM configuration, see the [XCM Configuration](/develop/interoperability/xcm-config/){target=\_blank} page.
 
 Where the [XCM format](https://github.com/polkadot-fellows/xcm-format){target=\_blank} defines a set of instructions used to construct XCVM programs, `pallet-xcm` defines a set of extrinsics that can be utilized to build XCVM programs, either to target the local or external chains. The `pallet-xcm` functionality is divided into three categories:
 
@@ -61,8 +58,7 @@ pub fn execute<T: Config>(
 )
 ```
 
-!!!note
-    For further details on the `execute` extrinsic, see the [`pallet-xcm` documentation](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm/pallet/struct.Pallet.html){target=\_blank}.
+For further details about the `execute` extrinsic, see the [`pallet-xcm` documentation](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm/pallet/struct.Pallet.html){target=\_blank}.
 
 !!!warning
     Partial execution of messages may occur depending on the constraints or barriers applied.
@@ -82,8 +78,7 @@ pub fn send<T: Config>(
 )
 ```
 
-!!!note
-    For further information about the `send` extrinsic, check the [`pallet-xcm` documentation](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm/pallet/struct.Pallet.html){target=\_blank}.
+For further information about the `send` extrinsic, see the [`pallet-xcm` documentation](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm/pallet/struct.Pallet.html){target=\_blank}.
 
 <!-- TODO: we should complement this page with some real examples of where the .send() call is used, or maybe how to use it through papi or something like that -->
 
@@ -97,5 +92,4 @@ For instance, the Kusama network employs the [`ChildParachainRouter`](https://pa
 --8<-- 'https://raw.githubusercontent.com/polkadot-fellows/runtimes/refs/heads/main/relay/kusama/src/xcm_config.rs:122:125'
 ```
 
-!!!note
-    For more details on XCM transport protocols, see the [XCM Channels](/develop/interoperability/xcm-channels/){target=\_blank} page.
+For more details about XCM transport protocols, see the [XCM Channels](/develop/interoperability/xcm-channels/){target=\_blank} page.

--- a/develop/interoperability/test-and-debug.md
+++ b/develop/interoperability/test-and-debug.md
@@ -54,10 +54,7 @@ The `xcm-simulator` provides the following macros for building a mocked simulati
     }
     ```
 
-    The [`para_ext(para_id: u32)`](https://github.com/paritytech/polkadot-sdk/blob/{{dependencies.polkadot_sdk.stable_version}}/polkadot/xcm/xcm-simulator/example/src/lib.rs#L97C1-L115C2){target=\_blank} function initializes a test environment for a parachain with a specified `para_id`, sets the initial configuration of the parachain, returning a [`TestExternalities`](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_frame/testing_prelude/type.TestExternalities.html){target=\_blank} instance for testing.
-
-    !!!note
-        Developers can take this idea and define as many parachains as they want, like `ParaA`, `ParaB`, `ParaC`, etc
+    The [`para_ext(para_id: u32)`](https://github.com/paritytech/polkadot-sdk/blob/{{dependencies.polkadot_sdk.stable_version}}/polkadot/xcm/xcm-simulator/example/src/lib.rs#L97C1-L115C2){target=\_blank} function initializes a test environment for a parachain with a specified `para_id`, sets the initial configuration of the parachain, returning a [`TestExternalities`](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_frame/testing_prelude/type.TestExternalities.html){target=\_blank} instance for testing. Developers can follow this example and define as many parachains as they want, like `ParaA`, `ParaB`, `ParaC`, etc.
 
 - [**`decl_test_network`**](https://github.com/paritytech/polkadot-sdk/blob/{{dependencies.polkadot_sdk.stable_version}}/polkadot/xcm/xcm-simulator/src/lib.rs#L292){target=\_blank} - defines a testing network consisting of a relay chain and multiple parachains. Takes a network struct as input and implements functionalities for testing, including [`ParachainXcmRouter`](https://paritytech.github.io/polkadot-sdk/master/xcm_simulator_example/struct.ParachainXcmRouter.html){target=\_blank} and [`RelayChainXcmRouter`](https://paritytech.github.io/polkadot-sdk/master/xcm_simulator_example/struct.RelayChainXcmRouter.html){target=\_blank}. The struct must specify the relay chain and an indexed list of parachains to be included in the network:
 


### PR DESCRIPTION
This PR does the following:

- Removes instances of using admonitions for cross-references 
- Screened the /develop/index and /develop/networks pages and all pages in the /develop/interoperability section for instances of improper messaging admonitions and made needed updates

to align with new style guide standards for admonitions. 