### PR TITLE
develop/parachains messaging admo updates

### DIFF
--- a/develop/parachains/customize-parachain/add-existing-pallets.md
+++ b/develop/parachains/customize-parachain/add-existing-pallets.md
@@ -24,14 +24,14 @@ For Rust programs, this configuration is defined in the `Cargo.toml` file, which
 - The locations and versions of the pallets that are to be imported as dependencies for the runtime
 - The features in each pallet that should be enabled when compiling the native Rust binary. By enabling the standard (`std`) feature set from each pallet, you ensure that the runtime includes the functions, types, and primitives necessary for the native build, which are otherwise excluded when compiling the Wasm binary
 
-!!! note
-    For information about adding dependencies in `Cargo.toml` files, see the [Dependencies](https://doc.rust-lang.org/cargo/guide/dependencies.html){target=\_blank} page in the Cargo documentation. For information about enabling and managing features from dependent packages, see the [Features](https://doc.rust-lang.org/cargo/reference/features.html){target=\_blank} section in the Cargo documentation.
+
+For information about adding dependencies in `Cargo.toml` files, see the [Dependencies](https://doc.rust-lang.org/cargo/guide/dependencies.html){target=\_blank} page in the Cargo documentation. To learn more about enabling and managing features from dependent packages, see the [Features](https://doc.rust-lang.org/cargo/reference/features.html){target=\_blank} section in the Cargo documentation.
 
 ## Dependencies for a New Pallet
 
 To add the dependencies for a new pallet to the runtime, you must modify the `Cargo.toml` file by adding a new line into the `[workspace.dependencies]` section with the pallet you want to add. This pallet definition might look like:
 
-```toml
+```toml title="Cargo.toml"
 pallet-example = { version = "4.0.0-dev", default-features = false }
 ```
 
@@ -40,10 +40,10 @@ This line imports the `pallet-example` crate as a dependency and specifies the f
 - **`version`** - the specific version of the crate to import
 - **`default-features`** - determines the behavior for including pallet features when compiling the runtime with standard Rust libraries
 
-!!! note
+!!! tip
     If you’re importing a pallet that isn’t available on [`crates.io`](https://crates.io/){target=\_blank}, you can specify the pallet's location (either locally or from a remote repository) by using the `git` or `path` key. For example:
 
-    ```toml
+    ```toml title="Cargo.toml"
     pallet-example = { 
         version = "4.0.0-dev",
         default-features = false,
@@ -53,7 +53,7 @@ This line imports the `pallet-example` crate as a dependency and specifies the f
 
     In this case, replace `INSERT_PALLET_REMOTE_URL` with the correct repository URL. For local paths, use the path key like so:
 
-    ```toml
+    ```toml title="Cargo.toml"
     pallet-example = { 
         version = "4.0.0-dev",
         default-features = false,
@@ -65,13 +65,13 @@ This line imports the `pallet-example` crate as a dependency and specifies the f
 
 Next, add this dependency to the `[dependencies]` section of the `runtime/Cargo.toml` file, so it inherits from the main `Cargo.toml` file:
 
-```toml
+```toml title="runtime/Cargo.toml"
 pallet-examples.workspace = true
 ```
 
 To enable the `std` feature of the pallet, add the pallet to the following section:
 
-```toml
+```toml title="runtime/Cargo.toml"
 [features]
 default = ["std"]
 std = [
@@ -81,10 +81,9 @@ std = [
 ]
 ```
 
-This section specifies the default feature set for the runtime, which includes the `std` features for each pallet. When the runtime is compiled with the `std` feature set, the standard library features for all listed pallets are enabled. For more details on how the runtime is compiled as both a native binary (using `std`) and a Wasm binary (using `no_std`), refer to the [Wasm build](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/substrate/index.html#wasm-build){target=\_blank} section in the Polkadot SDK documentation.
+This section specifies the default feature set for the runtime, which includes the `std` features for each pallet. When the runtime is compiled with the `std` feature set, the standard library features for all listed pallets are enabled. If you forget to update the features section in the `Cargo.toml` file, you might encounter `cannot find function` errors when compiling the runtime.
 
-!!! note
-    If you forget to update the features section in the `Cargo.toml` file, you might encounter `cannot find function` errors when compiling the runtime.
+For more details about how the runtime is compiled as both a native binary (using `std`) and a Wasm binary (using `no_std`), refer to the [Wasm build](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/substrate/index.html#wasm-build){target=\_blank} section in the Polkadot SDK documentation.
 
 To ensure that the new dependencies resolve correctly for the runtime, you can run the following command:
 
@@ -108,14 +107,15 @@ At its core, the `Config` trait typically looks like this:
 
 This basic structure shows that every pallet must define certain types, such as `RuntimeEvent` and `WeightInfo`, to function within the runtime. The actual implementation can vary depending on the pallet’s specific needs.
 
-??? "Example - Utility Pallet"
-      For instance, in the [`utility pallet`](https://github.com/paritytech/polkadot-sdk/tree/{{dependencies.polkadot_sdk.stable_version}}/substrate/frame/utility){target=\_blank}, the `Config` trait is implemented with the following types:
+### Example - Utility Pallet
 
-      ```rust
-      --8<-- 'code/develop/parachains/customize-parachain/add-existing-pallets/utility-pallet-config-trait.rs'
-      ```
+For instance, in the [`utility pallet`](https://github.com/paritytech/polkadot-sdk/tree/{{dependencies.polkadot_sdk.stable_version}}/substrate/frame/utility){target=\_blank}, the `Config` trait is implemented with the following types:
 
-     This example shows how the `Config` trait defines types like `RuntimeEvent`, `RuntimeCall`, `PalletsOrigin`, and `WeightInfo`, which the pallet will use when interacting with the runtime.
+```rust
+--8<-- 'code/develop/parachains/customize-parachain/add-existing-pallets/utility-pallet-config-trait.rs'
+```
+
+This example shows how the `Config` trait defines types like `RuntimeEvent`, `RuntimeCall`, `PalletsOrigin`, and `WeightInfo`, which the pallet will use when interacting with the runtime.
 
 ## Parameter Configuration for Pallets
 
@@ -135,14 +135,13 @@ To integrate a new pallet into the runtime, you must implement its `Config` trai
 --8<-- 'code/develop/parachains/customize-parachain/add-existing-pallets/impl-pallet-example-in-runtime.rs'
 ```
 
-Finally, to compose the runtime, update the list of pallets in the same file by modifying the [`#[frame_support::runtime]`](https://paritytech.github.io/polkadot-sdk/master/frame_support/attr.runtime.html){target=\_blank} section. This Rust macro constructs the runtime with a specified name and the pallets you want to include. Use the following format when adding your pallet:
+Finally, to compose the runtime, update the list of pallets in the same file by modifying the [`#[frame_support::runtime]`](https://paritytech.github.io/polkadot-sdk/master/frame_support/attr.runtime.html){target=\_blank} section. This Rust macro constructs the runtime with your specified name and pallets, wraps the runtime's configuration, and automatically generates boilerplate code for pallet inclusion. 
+
+Use the following format when adding your pallet:
 
 ```rust
 --8<-- 'code/develop/parachains/customize-parachain/add-existing-pallets/frame-support-runtime-macro.rs'
 ```
-
-!!! note
-    The `#[frame_support::runtime]` macro wraps the runtime's configuration, automatically generating boilerplate code for pallet inclusion.
 
 ## Where to Go Next
 

--- a/develop/parachains/customize-parachain/add-existing-pallets.md
+++ b/develop/parachains/customize-parachain/add-existing-pallets.md
@@ -41,7 +41,7 @@ This line imports the `pallet-example` crate as a dependency and specifies the f
 - **`default-features`** - determines the behavior for including pallet features when compiling the runtime with standard Rust libraries
 
 !!! tip
-    If you’re importing a pallet that isn’t available on [`crates.io`](https://crates.io/){target=\_blank}, you can specify the pallet's location (either locally or from a remote repository) by using the `git` or `path` key. For example:
+    If you're importing a pallet that isn't available on [`crates.io`](https://crates.io/){target=\_blank}, you can specify the pallet's location (either locally or from a remote repository) by using the `git` or `path` key. For example:
 
     ```toml title="Cargo.toml"
     pallet-example = { 
@@ -107,9 +107,9 @@ At its core, the `Config` trait typically looks like this:
 
 This basic structure shows that every pallet must define certain types, such as `RuntimeEvent` and `WeightInfo`, to function within the runtime. The actual implementation can vary depending on the pallet’s specific needs.
 
-### Example - Utility Pallet
+### Utility Pallet Example
 
-For instance, in the [`utility pallet`](https://github.com/paritytech/polkadot-sdk/tree/{{dependencies.polkadot_sdk.stable_version}}/substrate/frame/utility){target=\_blank}, the `Config` trait is implemented with the following types:
+For instance, in the [`utility`](https://github.com/paritytech/polkadot-sdk/tree/{{dependencies.polkadot_sdk.stable_version}}/substrate/frame/utility){target=\_blank} pallet, the `Config` trait is implemented with the following types:
 
 ```rust
 --8<-- 'code/develop/parachains/customize-parachain/add-existing-pallets/utility-pallet-config-trait.rs'

--- a/develop/parachains/customize-parachain/make-custom-pallet.md
+++ b/develop/parachains/customize-parachain/make-custom-pallet.md
@@ -57,7 +57,7 @@ This section will guide you through the initial steps of creating the foundation
             - Use workspace inheritance in your pallet's `Cargo.toml` to maintain consistency across your project
         - Regularly check for updates to FRAME and Polkadot SDK dependencies to benefit from the latest features, performance improvements, and security patches
 
-        For detailed information on workspace inheritance and how to properly integrate your pallet with the runtime, refer to the [Add an Existing Pallet to the Runtime](/develop/parachains/customize-parachain/add-existing-pallets/){target=\_blank} page.
+    For detailed information about workspace inheritance and how to properly integrate your pallet with the runtime, see the [Add an Existing Pallet to the Runtime](/develop/parachains/customize-parachain/add-existing-pallets/){target=\_blank} page.
 
 3.  Initialize the pallet structure by replacing the contents of `src/lib.rs` with the following scaffold code:
 

--- a/develop/parachains/customize-parachain/overview.md
+++ b/develop/parachains/customize-parachain/overview.md
@@ -51,10 +51,9 @@ All pallets, including custom ones, can implement these attribute macros:
 - **`#[pallet::storage]`** - defines elements to be persisted in storage
 - **`#[pallet::call]`** - defines functions exposed as transactions, allowing dispatch to the runtime
 
-These macros are applied as attributes to Rust modules, functions, structures, enums, and types. They enable the pallet to be built and added to the runtime, exposing the custom logic to the outer world.
+These macros are applied as attributes to Rust modules, functions, structures, enums, and types and serve as the core components of a pallet. They enable the pallet to be built and added to the runtime, exposing the custom logic to the outer world.
 
-!!! note
-    The macros above are the core components of a pallet. For a comprehensive guide on these and additional macros, refer to the [`pallet_macros`](https://paritytech.github.io/polkadot-sdk/master/frame_support/pallet_macros/index.html){target=\_blank} section in the Polkadot SDK documentation.
+For a comprehensive guide on these and additional macros, see the [`pallet_macros`](https://paritytech.github.io/polkadot-sdk/master/frame_support/pallet_macros/index.html){target=\_blank} section in the Polkadot SDK documentation.
 
 ### Support Libraries
 

--- a/develop/parachains/intro-polkadot-sdk.md
+++ b/develop/parachains/intro-polkadot-sdk.md
@@ -18,8 +18,7 @@ Whether you're building a standalone chain or deploying a parachain on Polkadot,
 - A selection of pre-built modules, called [pallets](/polkadot-protocol/glossary#pallet){target=\_blank}
 - Benchmarking and testing suites
 
-!!!note
-    For an in-depth dive into the monorepo, the [Polkadot SDK Rust documentation](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/index.html){target=\_blank} is highly recommended.
+For an in-depth look at the monorepo, see the [Polkadot SDK Rust documentation](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/index.html){target=\_blank}.
 
 ## Polkadot SDK Overview
 


### PR DESCRIPTION
This PR makes the following changes:

- Removes instances of using admonitions for cross-references
- Updates  instances of improper messaging admonition usage

For these pages:

-develop/parachains index, intro SDK, install SDK
-develop/parachains/customize-parachain (all pages in this section)

To align with new style guide standards for admonitions.