### PR TITLE
develop/parachains testing, deployment, maintenance admo

### DIFF
--- a/develop/parachains/deployment/generate-chain-specs.md
+++ b/develop/parachains/deployment/generate-chain-specs.md
@@ -81,17 +81,15 @@ chain-spec-builder --help
 
 ### Plain Chain Specifications
 
-To create a plain chain specification, you can use the following utility within your project:
+To create a plain chain specification, first ensure that the runtime has been compiled and is available at the specified path. Next, you can use the following utility within your project:
 
 ```bash
 chain-spec-builder create -r <INSERT_RUNTIME_WASM_PATH> <INSERT_COMMAND> 
 ```
 
-!!! note
+Replace `<INSERT_RUNTIME_WASM_PATH>` with the path to the runtime Wasm file and `<INSERT_COMMAND>` with the command to insert the runtime into the chain specification. 
 
-    Before running the command, ensure that the runtime has been compiled and is available at the specified path.
-
-Ensure to replace `<INSERT_RUNTIME_WASM_PATH>` with the path to the runtime Wasm file and `<INSERT_COMMAND>` with the command to insert the runtime into the chain specification. The available commands are:
+The available commands are:
 
 - **`patch`** - overwrites the runtime's default genesis config with the provided patch. You can check the following [patch file](https://github.com/paritytech/polkadot-sdk/blob/{{dependencies.polkadot_sdk.stable_version}}/substrate/bin/utils/chain-spec-builder/tests/input/patch.json){target=\_blank} as a reference
 - **`full`** - build the genesis config for runtime using the JSON file. No defaults will be used. As a reference, you can check the following [full file](https://github.com/paritytech/polkadot-sdk/blob/{{dependencies.polkadot_sdk.stable_version}}/substrate/bin/utils/chain-spec-builder/tests/input/full.json){target=\_blank}

--- a/develop/parachains/deployment/generate-chain-specs.md
+++ b/develop/parachains/deployment/generate-chain-specs.md
@@ -84,10 +84,10 @@ chain-spec-builder --help
 To create a plain chain specification, first ensure that the runtime has been compiled and is available at the specified path. Next, you can use the following utility within your project:
 
 ```bash
-chain-spec-builder create -r <INSERT_RUNTIME_WASM_PATH> <INSERT_COMMAND> 
+chain-spec-builder create -r INSERT_RUNTIME_WASM_PATH INSERT_COMMAND
 ```
 
-Replace `<INSERT_RUNTIME_WASM_PATH>` with the path to the runtime Wasm file and `<INSERT_COMMAND>` with the command to insert the runtime into the chain specification. 
+Replace `INSERT_RUNTIME_WASM_PATH` with the path to the runtime Wasm file and `INSERT_COMMAND` with the command to insert the runtime into the chain specification. 
 
 The available commands are:
 

--- a/develop/parachains/deployment/index.md
+++ b/develop/parachains/deployment/index.md
@@ -55,7 +55,7 @@ flowchart TD
 
 - **Acquire coretime** - to build on top of the Polkadot network, users need to acquire coretime (either on-demand or in bulk) to access the computational resources of the relay chain. This allows for the secure validation of parachain blocks through a randomized selection of relay chain validators
 
-    !!! note
+    !!! tip
         If you’re building a standalone blockchain (solochain) that won’t connect to Polkadot as a parachain, you can skip this step, as there’s no need to acquire coretime or implement [Cumulus](https://wiki.polkadot.network/docs/build-pdk#cumulus){target=\_blank}.
 
 - **Launch and monitor** - once everything is configured, you can launch the blockchain, initiating the network with your chain spec and Wasm runtime. Validators or collators will begin producing blocks, and the network will go live. Post-launch, monitoring is vital to ensuring network health—tracking block production, node performance, and overall security

--- a/develop/parachains/deployment/index.md
+++ b/develop/parachains/deployment/index.md
@@ -55,8 +55,7 @@ flowchart TD
 
 - **Acquire coretime** - to build on top of the Polkadot network, users need to acquire coretime (either on-demand or in bulk) to access the computational resources of the relay chain. This allows for the secure validation of parachain blocks through a randomized selection of relay chain validators
 
-    !!! tip
-        If you’re building a standalone blockchain (solochain) that won’t connect to Polkadot as a parachain, you can skip this step, as there’s no need to acquire coretime or implement [Cumulus](https://wiki.polkadot.network/docs/build-pdk#cumulus){target=\_blank}.
+If you’re building a standalone blockchain (solochain) that won’t connect to Polkadot as a parachain, you can skip the preceding step, as there’s no need to acquire coretime or implement [Cumulus](https://wiki.polkadot.network/docs/build-pdk#cumulus){target=\_blank}.
 
 - **Launch and monitor** - once everything is configured, you can launch the blockchain, initiating the network with your chain spec and Wasm runtime. Validators or collators will begin producing blocks, and the network will go live. Post-launch, monitoring is vital to ensuring network health—tracking block production, node performance, and overall security
 

--- a/develop/parachains/testing/benchmarking.md
+++ b/develop/parachains/testing/benchmarking.md
@@ -142,7 +142,7 @@ You can now compile your runtime with the `runtime-benchmarks` feature flag. Thi
     --output weights.rs
     ```
 
-    !!! info "Flag definitions"
+    !!! tip "Flag definitions"
         - `--runtime` - the path to your runtime's Wasm
         - `--pallet` - the name of the pallet you wish to benchmark. This pallet must be configured in your runtime and defined in `define_benchmarks`
         - `--extrinsic` - which extrinsic to test. Using `'*'` implies all extrinsics will be benchmarked

--- a/develop/parachains/testing/mock-runtime.md
+++ b/develop/parachains/testing/mock-runtime.md
@@ -22,10 +22,7 @@ Here's a simple example of how to create a testing module that simulates these i
 --8<-- 'code/develop/parachains/testing/mock-runtime/integration-testing-module.rs'
 ```
 
-!!! note
-    The `crate::*;` snippet imports all the components from your crate (including runtime configurations, pallet modules, and utility functions) into the `tests` module. This allows you to write tests without manually importing each piece, making the code more concise and readable.
-
-Alternatively, you can create a separate `mock.rs` file to define the configuration for your mock runtime and a companion `tests.rs` file to house the specific logic for each test.
+The `crate::*;` snippet imports all the components from your crate (including runtime configurations, pallet modules, and utility functions) into the `tests` module. This allows you to write tests without manually importing each piece, making the code more concise and readable. You can opt to instead create a separate `mock.rs` file to define the configuration for your mock runtime and a companion `tests.rs` file to house the specific logic for each test.
 
 Once the testing module is configured, you can craft your mock runtime using the [`frame_support::runtime`](https://paritytech.github.io/polkadot-sdk/master/frame_support/attr.runtime.html){target=\_blank} macro. This macro allows you to define a runtime environment that will be created for testing purposes:
 
@@ -52,8 +49,7 @@ You can also customize the genesis storage to set initial values for your runtim
 --8<-- 'code/develop/parachains/testing/mock-runtime/genesis-config-custom.rs'
 ```
 
-!!! note
-    For a more idiomatic approach, consult the [`Your first pallet`](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html#better-test-setup){target=\_blank} guide from the Polkadot SDK rust documentation.
+For a more idiomatic approach, see the [Your First Pallet](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html#better-test-setup){target=\_blank} guide from the Polkadot SDK rust documentation.
 
 ### Pallet Configuration
 
@@ -63,14 +59,11 @@ Each pallet in the mocked runtime requires an associated configuration, specifyi
 --8<-- 'code/develop/parachains/testing/mock-runtime/pallets-configurations.rs'
 ```
 
-The configuration should be set for each pallet existing in the mocked runtime.
+The configuration should be set for each pallet existing in the mocked runtime. The simplification of types is for simplifying the testing process. For example, `AccountId` is `u64`, meaning a valid account address can be an unsigned integer:
 
-!!! note
-    The simplification of types is for simplifying the testing process. For example, `AccountId` is `u64`, meaning a valid account address can be an unsigned integer:
-
-    ```rust
-    let alice_account: u64 = 1;
-    ```
+```rust
+let alice_account: u64 = 1;
+```
 
 ## Where to Go Next
 

--- a/develop/parachains/testing/mock-runtime.md
+++ b/develop/parachains/testing/mock-runtime.md
@@ -49,7 +49,7 @@ You can also customize the genesis storage to set initial values for your runtim
 --8<-- 'code/develop/parachains/testing/mock-runtime/genesis-config-custom.rs'
 ```
 
-For a more idiomatic approach, see the [Your First Pallet](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html#better-test-setup){target=\_blank} guide from the Polkadot SDK rust documentation.
+For a more idiomatic approach, see the [Your First Pallet](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html#better-test-setup){target=\_blank} guide from the Polkadot SDK Rust documentation.
 
 ### Pallet Configuration
 


### PR DESCRIPTION
This PR makes the following changes:

Removes instances of using admonitions for cross-references
Updates instances of improper messaging admonition usage
For these pages:

-develop/parachains testing, deployment, and maintenance (all pages in these sections

To align with new style guide standards for admonitions.