### PR TITLE
updates admos for dev/smart contracts

### DIFF
--- a/develop/smart-contracts/index.md
+++ b/develop/smart-contracts/index.md
@@ -15,16 +15,12 @@ This section guides you through the tools, resources, and guides to help you bui
 For developers building smart contracts in the Polkadot ecosystem, the choice between parachains supporting ink! (for Wasm contracts) and EVM-compatible parachains (for Solidity contracts) depend on the preferred development environment and language. By selecting the right parachain, developers can leverage Polkadot's scalability and interoperability while utilizing the framework that best suits their needs.
 
 !!! tip
-    The Polkadot smart contract ecosystem is in active development. Please expect frequent changes. You can follow progress, or join the discussion, by visiting this [Contracts on AssetHub Roadmap](https://forum.polkadot.network/t/contracts-on-assethub-roadmap/9513/57){target=\_blank} Polkadot Network Forum post.
+    Significant advancements in Polkadot's native smart contract functionality are in active development. Frequent changes should be expected. See this [Contracts on AssetHub Roadmap](https://forum.polkadot.network/t/contracts-on-assethub-roadmap/9513/57){target=\_blank} Polkadot Network Forum post for updates.
 
 Here are some key considerations:
 
 - [**Wasm (ink!) contracts**](/develop/smart-contracts/wasm-ink/){target=\_blank} - contracts are written in Rust and compiled to Wasm. The advantage of Wasm is that it allows for more flexibility, speed, and potentially lower execution costs compared to EVM, especially in the context of Polkadot's multi-chain architecture
 - [**EVM-compatible contracts**](/develop/smart-contracts/evm/parachain-contracts/){target=\_blank} - contracts are written in languages like Solidity or Vyper and executed by the Ethereum Virtual Machine (EVM). The EVM is widely standardized across blockchains, including Polkadot parachains like Astar, Moonbeam, and Acala. This compatibility allows contracts to be deployed across multiple networks with minimal modifications, benefiting from a well-established, broad development ecosystem
-
-!!! info "Upcoming Updates"
-
-    Significant advancements in Polkadot's native smart contract functionality are in development. Detailed updates will be available soon.
 
 <!-- This content is temporarily hidden and has been commented out to ensure it is preserved. -->
 <!-- - [**PolkaVM-compatible contracts**](/develop/smart-contracts/evm/native-evm-contracts/){target=\_blank} - contracts are written in languages like Solidity or Vyper and executed by the PolkaVM. This compatibility provides a seamless transition for developers coming from EVM environments while also enabling interactions with other Polkadot parachains and leveraging Polkadot's interoperability -->

--- a/develop/smart-contracts/overview.md
+++ b/develop/smart-contracts/overview.md
@@ -18,8 +18,7 @@ This guide outlines the primary approaches to developing smart contracts in the 
 
 You'll explore the key differences between these development paths, along with considerations for parachain developers integrating smart contract functionality.
 
-!!!info "Parachain Developer?"
-    If you are a parachain developer looking to add smart contract functionality to your chain, please refer to the [Add Smart Contract Functionality](/develop/parachains/customize-parachain/add-smart-contract-functionality/){target=\_blank} page, which covers both Wasm and EVM-based contract implementations.
+If you are a parachain developer looking to add smart contract functionality to your chain, please refer to the [Add Smart Contract Functionality](/develop/parachains/customize-parachain/add-smart-contract-functionality/){target=\_blank} page, which covers both Wasm and EVM-based contract implementations.
 
 ## Smart Contracts Versus Parachains
 
@@ -57,8 +56,7 @@ flowchart LR
 
 Parachains inherently offer features such as logic upgradeability, flexible transaction fee mechanisms, and chain abstraction logic. More so, by using Polkadot, parachains can benefit from robust consensus guarantees with little engineering overhead.
 
-!!!info "Additional information"
-    To read more about the differences between smart contracts and parachain runtimes, please Refer to the [Runtime vs. Smart Contracts](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/runtime_vs_smart_contract/index.html){target=\_blank} section of the Polkadot SDK Rust docs. For a more in-depth discussion on choosing between runtime development and smart contract development, you can check the post ["When should one build a Polkadot SDK runtime versus a Substrate (Polkadot SDK) smart contract?"](https://stackoverflow.com/a/56041305){target=\_blank} from Stack Overflow.
+To learn more about the differences between smart contracts and parachain runtimes, please see the [Runtime vs. Smart Contracts](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/runtime_vs_smart_contract/index.html){target=\_blank} section of the Polkadot SDK Rust docs. For a more in-depth discussion on choosing between runtime development and smart contract development, see the post ["When should one build a Polkadot SDK runtime versus a Substrate (Polkadot SDK) smart contract?"](https://stackoverflow.com/a/56041305){target=\_blank} from Stack Overflow.
 
 ## Building a Smart Contract
 

--- a/develop/smart-contracts/wasm-ink.md
+++ b/develop/smart-contracts/wasm-ink.md
@@ -104,8 +104,7 @@ Example:
 --8<-- 'code/develop/smart-contracts/wasm-ink/constructors.rs'
 ```
 
-!!!note
-    In this example, `new(init_value: u32)` initializes `number` with a specified value, while `default()` initializes it with the type’s default value (0 for `u32`). These constructors provide flexibility in contract deployment by supporting custom and default initialization options.
+In this example, `new(init_value: u32)` initializes `number` with a specified value, while `default()` initializes it with the type’s default value (0 for `u32`). These constructors provide flexibility in contract deployment by supporting custom and default initialization options.
 
 For more information, refer to the official documentation for the [`#[ink(constructor)]`](https://use.ink/macros-attributes/constructor){target=\_blank} macro definition.
 
@@ -118,8 +117,7 @@ There are two types of messages:
 - **Immutable messages (`&self`)** - these messages can only read the contract's state and cannot modify it
 - **Mutable messages (`&mut self`)** - these messages can read and modify the contract's state
 
-!!!note
-    `&self` is a reference to the contract's storage.
+In the example above, `&self` is a reference to the contract's storage.
 
 Example:
 
@@ -127,8 +125,7 @@ Example:
 --8<-- 'code/develop/smart-contracts/wasm-ink/messages.rs'
 ```
 
-!!!note
-    In the example above, `my_getter` is an immutable message that reads state, while `my_setter` is a mutable message that updates state.
+In the example above, `my_getter` is an immutable message that reads state, while `my_setter` is a mutable message that updates state.
 
 For more information, refer to the official documentation on the [`#[ink(message)]`](https://use.ink/macros-attributes/message){target=\_blank} macro.
 
@@ -145,8 +142,7 @@ Example:
 --8<-- 'code/develop/smart-contracts/wasm-ink/errors.rs'
 ```
 
-!!!note
-    In this example, the `Error` enum defines custom error types `InsufficientBalance` and `InsufficientAllowance`. When `transfer_from` is called, it checks if the allowance is sufficient. If not, it returns an `InsufficientAllowance` error, causing the contract to revert. This approach ensures robust error handling for smart contracts.
+In this example, the `Error` enum defines custom error types `InsufficientBalance` and `InsufficientAllowance`. When `transfer_from` is called, it checks if the allowance is sufficient. If not, it returns an `InsufficientAllowance` error, causing the contract to revert. This approach ensures robust error handling for smart contracts.
 
 ### Events
 
@@ -160,8 +156,7 @@ Example:
 --8<-- 'code/develop/smart-contracts/wasm-ink/events.rs'
 ```
 
-!!!note
-    In this example, the `Transfer` event records the sender (`from`), the receiver (`to`), and the amount transferred (`value`). The event is emitted in the `transfer_from` function to notify external listeners whenever a transfer occurs.
+In this example, the `Transfer` event records the sender (`from`), the receiver (`to`), and the amount transferred (`value`). The event is emitted in the `transfer_from` function to notify external listeners whenever a transfer occurs.
 
 For more details, check the [Events](https://use.ink/basics/events){target=\_blank} section and the [`#[ink(event)]`](https://use.ink/macros-attributes/event){target=\_blank} macro documentation.
 


### PR DESCRIPTION
This PR makes the following changes:

Removes instances of using admonitions for cross-references
Updates instances of improper messaging admonition usage
For these pages:

-develop/smart-contracts (all pages in this section)

To align with new style guide standards for admonitions.