### PR TITLE
updates admos for dev/toolkit section pages

### DIFF
--- a/develop/toolkit/api-libraries/polkadot-js-api.md
+++ b/develop/toolkit/api-libraries/polkadot-js-api.md
@@ -38,7 +38,7 @@ The available methods and interfaces will automatically reflect what's possible 
 
 ## Installation
 
-To add the Polkadot.js API to your project:
+To add the Polkadot.js API to your project, use the following command to install the latest stable release which supports any Polkadot SDK-based chain:
 
 === "npm"
     ```bash
@@ -55,10 +55,7 @@ To add the Polkadot.js API to your project:
     yarn add @polkadot/api
     ```
 
-This command installs the latest stable release, which supports any Polkadot SDK-based chain.
-
-!!!note
-    For more installation details, refer to the [Installation](https://polkadot.js.org/docs/api/start/install/){target=\_blank} section in the official Polkadot.js API documentation.
+For more detailed information about installation, see the [Installation](https://polkadot.js.org/docs/api/start/install/){target=\_blank} section in the official Polkadot.js API documentation.
 
 ## Get Started
 
@@ -72,7 +69,7 @@ To create an API connection:
 --8<-- 'code/develop/toolkit/api-libraries/polkadot-js-sdk/api-instance.js'
 ```
 
-!!!note
+!!!tip
     All `await` operations must be wrapped in an async function or block since the API uses promises for asynchronous operations.
 
 ### Reading Chain Data
@@ -104,8 +101,7 @@ To make a transfer:
 --8<-- 'code/develop/toolkit/api-libraries/polkadot-js-sdk/send-txs.js'
 ```
 
-!!!note
-    The `alice` keypair in the example comes from a Keyring object. See the [Keyring documentation](https://polkadot.js.org/docs/keyring){target=\_blank} for details on managing keypairs.
+The `alice` keypair in the example comes from a Keyring object. For more details about managing keypairs, see the [Keyring documentation](https://polkadot.js.org/docs/keyring){target=\_blank}.
 
 ## Where to Go Next
 

--- a/develop/toolkit/api-libraries/py-substrate-interface.md
+++ b/develop/toolkit/api-libraries/py-substrate-interface.md
@@ -23,8 +23,7 @@ Install the library using `pip`:
 pip install substrate-interface
 ```
 
-!!!note
-    For more installation details, refer to the [Installation](https://polkascan.github.io/py-substrate-interface/getting-started/installation/){target=\_blank} section in the official Python Substrate Interface documentation.
+For more installation details, see the [Installation](https://polkascan.github.io/py-substrate-interface/getting-started/installation/){target=\_blank} section in the official Python Substrate Interface documentation.
 
 ## Get Started
 
@@ -65,8 +64,7 @@ Here's how to create and submit a balance transfer:
 --8<-- 'code/develop/toolkit/api-libraries/py-substrate-interface/send_tx.py'
 ```
 
-!!!note
-    The `keypair` object is essential for signing transactions. See the [Keypair](https://polkascan.github.io/py-substrate-interface/usage/keypair-creation-and-signing/){target=\_blank} documentation for more details.
+The `keypair` object is essential for signing transactions. See the [Keypair](https://polkascan.github.io/py-substrate-interface/usage/keypair-creation-and-signing/){target=\_blank} documentation for more details.
 
 ## Where to Go Next
 
@@ -76,4 +74,4 @@ Now that you understand the basics, you can:
 - Learn about batch transactions and utility functions
 - Discover how to work with custom pallets and types
 
-For comprehensive reference materials and advanced features, visit the [py-substrate-interface](https://polkascan.github.io/py-substrate-interface/){target=\_blank} documentation.
+For comprehensive reference materials and advanced features, see the [py-substrate-interface](https://polkascan.github.io/py-substrate-interface/){target=\_blank} documentation.

--- a/develop/toolkit/api-libraries/sidecar.md
+++ b/develop/toolkit/api-libraries/sidecar.md
@@ -18,6 +18,16 @@ Some of the key features of the Sidecar API include:
 - **Caching layer** - acts as a caching layer to improve performance and reduce direct node requests
 - **Multiple chain support** - works with any Polkadot SDK-based chain, including Polkadot, Kusama, and custom chains
 
+## Prerequisites
+
+Sidecar API requires Node.js version 18.14 LTS or higher. Verify your Node.js version:
+
+```bash
+node --version
+```
+
+If you need to install or update Node.js, visit the [official Node.js website](https://nodejs.org/){target=\_blank} to download and install the latest LTS version.
+
 ## Installation
 
 To install Substrate API Sidecar, use one of the following commands:
@@ -40,22 +50,13 @@ To install Substrate API Sidecar, use one of the following commands:
     yarn global add @substrate/api-sidecar
     ```
 
-!!! note
-    Sidecar API requires Node.js version 18.14 LTS or higher. Verify your Node.js version:
-
-    ```bash
-    node --version
-    ```
-
-    If you need to install or update Node.js, visit the [official Node.js website](https://nodejs.org/){target=\_blank} to download and install the latest LTS version.
-
 You can confirm the installation by running:
 
 ```bash
 substrate-api-sidecar --version
 ```
 
-For more information about the Sidecar API installation, please refer to the [official documentation](https://github.com/paritytech/substrate-api-sidecar?tab=readme-ov-file#npm-package-installation-and-usage){target=\_blank}.
+For more information about the Sidecar API installation, see the [installation and usage](https://github.com/paritytech/substrate-api-sidecar?tab=readme-ov-file#npm-package-installation-and-usage){target=\_blank} section of the Sidecar API README.
 
 ## Usage
 
@@ -70,8 +71,7 @@ To use the Sidecar API, you have two options:
     SAS_SUBSTRATE_URL=wss://polkadot-asset-hub-rpc.polkadot.io substrate-api-sidecar
     ```
 
-    !!! note
-        More configuration details are available in the [Configuration](https://github.com/paritytech/substrate-api-sidecar?tab=readme-ov-file#configuration){target=\_blank} section of the Sidecar API documentation.
+    For more configuration details, see the [Configuration](https://github.com/paritytech/substrate-api-sidecar?tab=readme-ov-file#configuration){target=\_blank} section of the Sidecar API documentation.
 
 Once the Sidecar API is running, you’ll see output similar to this:
 
@@ -88,8 +88,8 @@ For example, to retrieve the version of the node, use the `/node/version` endpoi
 ```bash
 --8<-- 'code/develop/toolkit/api-libraries/sidecar/get-node-version.md'
 ```
-!!! note
-    Alternatively, you can access `http://127.0.0.1:8080/node/version` directly in a browser since it’s a `GET` request.
+
+Alternatively, you can access `http://127.0.0.1:8080/node/version` directly in a browser since it’s a `GET` request.
 
 In response, you’ll see output similar to this (assuming you’re connected to Polkadot Asset Hub):
 

--- a/develop/toolkit/interoperability/asset-transfer-api/overview.md
+++ b/develop/toolkit/interoperability/asset-transfer-api/overview.md
@@ -42,14 +42,11 @@ To use `asset-transfer-api`, you need a TypeScript project. If you don't have on
     && npx tsc --init
     ```
 
-Once you have a project set up, you can install the `asset-transfer-api` package:
+Once you have a project set up, you can install the `asset-transfer-api` package. This documentation covers version `{{dependencies.asset_transfer_api.version}}` of Asset Transfer API. Run the following command to install the package:
 
 ```bash
 npm install @substrate/asset-transfer-api@{{dependencies.asset_transfer_api.version}}
 ```
-
-!!!note
-    This documentation covers version `{{dependencies.asset_transfer_api.version}}` of Asset Transfer API.
 
 ## Set Up Asset Transfer API
 
@@ -67,7 +64,7 @@ Leverage the `constructApiPromise` helper function provided by the library for t
 --8<-- 'code/develop/toolkit/interoperability/asset-transfer-api/overview/setup.ts'
 ```
 
-!!!note
+!!!tip
     The code example is enclosed in an async main function to provide the necessary asynchronous context. However, you can use the code directly if you're already working within an async environment. The key is to ensure you're in an async context when working with these asynchronous operations, regardless of your specific setup.
 
 ## Asset Transfer API Reference

--- a/develop/toolkit/parachains/fork-chains/chopsticks/get-started.md
+++ b/develop/toolkit/parachains/fork-chains/chopsticks/get-started.md
@@ -13,7 +13,7 @@ This guide walks you through installing Chopsticks and provides information on c
 
 For additional support and information, please reach out through [GitHub Issues](https://github.com/AcalaNetwork/chopsticks/issues){target=_blank}.
 
-!!! note
+!!! tip
     Chopsticks uses [Smoldot](https://github.com/smol-dot/smoldot){target=_blank} light client, which only supports the native Polkadot SDK API. Consequently, a Chopsticks-based fork doesn't support Ethereum JSON-RPC calls, meaning you cannot use it to fork your chain and connect Metamask.
 
 ## Prerequisites
@@ -25,10 +25,7 @@ Before you begin, ensure you have the following installed:
 
 ## Install Chopsticks
 
-You can install Chopsticks globally or locally in your project. Choose the option that best fits your development workflow.
-
-!!! note
-    This documentation explains the features of Chopsticks version `{{ dependencies.chopsticks.version }}`. Make sure you're using the correct version to match these instructions.
+You can install Chopsticks globally or locally in your project. Choose the option that best fits your development workflow. This documentation explains the features of Chopsticks version `{{ dependencies.chopsticks.version }}`. Make sure you're using the correct version to match these instructions.
 
 ### Global Installation
 

--- a/develop/toolkit/parachains/spawn-chains/zombienet/get-started.md
+++ b/develop/toolkit/parachains/spawn-chains/zombienet/get-started.md
@@ -13,14 +13,6 @@ This guide will outline the different installation methods for Zombienet, provid
 
 By following this guide, Zombienet will be up and running quickly, ready to streamline your blockchain testing and development workflows.
 
-!!! note "Additional support resources"
-    [Parity Technologies](https://www.parity.io/){target=\_blank} has designed and developed this framework, now maintained by the Zombienet team. 
-
-    For further support and information, refer to the following contact points:
-
-    - [Zombienet repository](https://github.com/paritytech/zombienet){target=\_blank}
-    - [Element public channel](https://matrix.to/#/!FWyuEyNvIFygLnWNMh:parity.io?via=parity.io&via=matrix.org&via=web3.foundation){target=\_blank}
-
 ## Install Zombienet
 
 Zombienet releases are available on the [Zombienet repository](https://github.com/paritytech/zombienet){target=\_blank}.
@@ -30,8 +22,7 @@ Multiple options are available for installing Zombienet, depending on the user's
 === "Use the executable"
     Install Zombienet using executables by visiting the [latest release](https://github.com/paritytech/zombienet/releases){target=\_blank} page and selecting the appropriate asset for your operating system. You can download the executable and move it to a directory in your PATH. 
 
-    !!!note
-        Each release includes executables for Linux and macOS. Executables are generated using [pkg](https://github.com/vercel/pkg){target=\_blank}, which allows the Zombienet CLI to operate without requiring Node.js to be installed. 
+    Each release includes executables for Linux and macOS. Executables are generated using [pkg](https://github.com/vercel/pkg){target=\_blank}, which allows the Zombienet CLI to operate without requiring Node.js to be installed. 
 
     Then, ensure the downloaded file is executable:
 
@@ -67,9 +58,7 @@ Multiple options are available for installing Zombienet, depending on the user's
     spawn INSERT_ZOMBIENET_CONFIG_FILE_NAME.toml
     ```
 
-    !!! note
-        - Replace the `INSERT_ZOMBIENET_VERSION` with the desired version of Zombienet
-        - Replace the `INSERT_ZOMBIENET_CONFIG_FILE_NAME` with the name of the configuration file you want to use
+    Replace the `INSERT_ZOMBIENET_VERSION` with the desired version of Zombienet and the `INSERT_ZOMBIENET_CONFIG_FILE_NAME` with the name of the configuration file you want to use.
 
     To run the command above, you need to have [Flakes](https://nixos.wiki/wiki/Flakes#Enable_flakes){target=\_blank} enabled.
 
@@ -210,7 +199,7 @@ Finally, add the custom binary to your PATH as follows:
 export PATH=$PATH:INSERT_PATH_TO_RUNTIME_TEMPLATES/parachain-template-node/target/release
 ```
 
-Alternatively, you can specify the binary path in the network configuration file.
+Alternatively, you can specify the binary path in the network configuration file. The local provider exclusively utilizes the command configuration for nodes, which supports both relative and absolute paths. You can employ the `default_command` configuration to specify the binary for spawning all nodes in the relay chain.
 
 ```toml
 [relaychain]
@@ -229,9 +218,6 @@ id = 1000
 
 The local provider does not offer any additional features.
 
-!!! note
-    The local provider exclusively utilizes the command configuration for nodes, which supports both relative and absolute paths. You can employ the `default_command` configuration to specify the binary for spawning all nodes in the relay chain.
-
 ## Configure Zombienet
 
 Effective network configuration is crucial for deploying and managing blockchain systems. Zombienet simplifies this process by offering versatile configuration options in both JSON and TOML formats. Whether setting up a simple test network or a complex multi-node system, Zombienet's tools provide the flexibility to customize every aspect of your network's setup.
@@ -242,8 +228,7 @@ The following sections will explore the structure and usage of Zombienet configu
 
 The network configuration file can be either JSON or TOML format. The Zombienet repository also provides a collection of [example configuration files](https://github.com/paritytech/zombienet/tree/main/examples){target=\_blank} that can be used as a reference.
 
-!!! note
-    Each section may include provider-specific keys that aren't recognized by other providers. For example, if you use the local provider, any references to images for nodes will be disregarded.
+Each section may include provider-specific keys that aren't recognized by other providers. For example, if you use the local provider, any references to images for nodes will be disregarded.
 
 ### CLI Usage
 
@@ -839,6 +824,15 @@ You can use the `hrmp_channels` keyword to define further parameters for the XCM
         - `recipient` ++"number"++ - parachain ID of the recipient
         - `max_capacity` ++"number"++ - maximum capacity of the HRMP channel
         - `max_message_size` ++"number"++ - maximum message size allowed in the HRMP channel
+
+## Additional Support Resources
+
+[Parity Technologies](https://www.parity.io/){target=\_blank} has designed and developed this framework, now maintained by the Zombienet team. 
+
+For further support and information, refer to the following contact points:
+
+- [Zombienet repository](https://github.com/paritytech/zombienet){target=\_blank}
+- [Element public channel](https://matrix.to/#/!FWyuEyNvIFygLnWNMh:parity.io?via=parity.io&via=matrix.org&via=web3.foundation){target=\_blank}
 
 ## Where to Go Next
 

--- a/develop/toolkit/parachains/spawn-chains/zombienet/write-tests.md
+++ b/develop/toolkit/parachains/spawn-chains/zombienet/write-tests.md
@@ -25,8 +25,7 @@ Zombienet provides a Domain Specific Language (DSL) for writing tests. The DSL i
 
 These abstractions are expressed by sentences defined in a natural language style. Therefore, each test line will be mapped to a test to run. Also, the test file (`*.zndsl`) includes pre-defined header fields used to define information about the suite, such as network configuration and credentials location.
 
-!!! note
-    View the [Testing DSL](https://paritytech.github.io/zombienet/cli/test-dsl-definition-spec.html){target=\_blank} specification for more details on the Zombienet DSL.
+For more details about the Zombienet DSL, see the [Testing DSL](https://paritytech.github.io/zombienet/cli/test-dsl-definition-spec.html){target=\_blank} specification.
 
 ## The Test File
 


### PR DESCRIPTION
This PR makes the following changes:

Removes instances of using admonitions for cross-references
Updates instances of improper messaging admonition usage
For these pages:

-develop/toolkit (all pages in this section)

To align with new style guide standards for admonitions.