### PR TITLE
Add --help flag to command in Chopsticks  page

### DIFF
--- a/develop/toolkit/parachains/fork-chains/chopsticks/get-started.md
+++ b/develop/toolkit/parachains/fork-chains/chopsticks/get-started.md
@@ -56,10 +56,10 @@ Then, install Chopsticks as a local dependency:
 npm i @acala-network/chopsticks@{{ dependencies.chopsticks.version }}
 ```
 
-Finally, you can run Chopsticks using the `npx` command:
+Finally, you can run Chopsticks using the `npx` command. To see all available options and commands, run it with the `--help` flag:
 
 ```bash
-npx @acala-network/chopsticks
+npx @acala-network/chopsticks --help
 ```
 
 ## Configure Chopsticks


### PR DESCRIPTION
Previously, running `npx @acala-network/chopsticks` without flags or commands would hang without providing useful information. Updated the command showing how to run it with the `--help` flag to display available options and commands, making it more helpful for new users.