### PR TITLE
Fix Installation Commands to Use Stable Release Tag

### DIFF
--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -38,7 +38,7 @@ This tutorial requires two essential tools:
     Install it by executing the following command:
     
     ```bash
-    cargo install --git https://github.com/paritytech/polkadot-sdk --force staging-chain-spec-builder
+    cargo install --git https://github.com/paritytech/polkadot-sdk --tag {{dependencies.polkadot_sdk.stable_version}} --force staging-chain-spec-builder
     ```
 
     This installs the `chain-spec-builder` binary. Refer to the [Generate Chain Specs](/develop/parachains/deployment/generate-chain-specs/){target=\_blank} documentation for detailed usage.
@@ -49,7 +49,7 @@ This tutorial requires two essential tools:
     To install it, run the following command:
 
     ```bash
-    cargo install --git https://github.com/paritytech/polkadot-sdk --force polkadot-omni-node
+    cargo install --git https://github.com/paritytech/polkadot-sdk --tag {{dependencies.polkadot_sdk.stable_version}} --force polkadot-omni-node
     ```
 
     This installs the `polkadot-omni-node` binary.


### PR DESCRIPTION
This PR fixes #327  by ensuring Omni Node and Chain Spec Builder install using the stable release tag.

- Added the --tag {{dependencies.polkadot_sdk.stable_version}} flag to enforce version consistency.
- Ensures both tools match the stable release, preventing unintended updates.