### PR TITLE
Update the layout of the JSON RPC page

### DIFF
--- a/.snippets/code/develop/smart-contracts/evm-toolkit/ethers-js/checkStorage.js
+++ b/.snippets/code/develop/smart-contracts/evm-toolkit/ethers-js/checkStorage.js
@@ -28,7 +28,7 @@ const interactWithStorageContract = async (
   contractAddress,
   mnemonic,
   providerConfig,
-  numberToSet
+  numberToSet,
 ) => {
   try {
     console.log(`Setting new number in Storage contract: ${numberToSet}`);
@@ -79,5 +79,5 @@ interactWithStorageContract(
   contractAddress,
   mnemonic,
   providerConfig,
-  newNumber
+  newNumber,
 );

--- a/.snippets/code/develop/smart-contracts/evm-toolkit/ethers-js/compile.js
+++ b/.snippets/code/develop/smart-contracts/evm-toolkit/ethers-js/compile.js
@@ -30,7 +30,7 @@ const compileContract = async (solidityFilePath, outputDir) => {
         const bytecodePath = join(outputDir, `${name}.polkavm`);
         writeFileSync(
           bytecodePath,
-          Buffer.from(contract.evm.bytecode.object, 'hex')
+          Buffer.from(contract.evm.bytecode.object, 'hex'),
         );
         console.log(`Bytecode saved to ${bytecodePath}`);
       }

--- a/.snippets/code/develop/smart-contracts/evm-toolkit/ethers-js/deploy.js
+++ b/.snippets/code/develop/smart-contracts/evm-toolkit/ethers-js/deploy.js
@@ -17,12 +17,12 @@ const createProvider = (rpcUrl, chainId, chainName) => {
 const getAbi = (contractName) => {
   try {
     return JSON.parse(
-      readFileSync(join(codegenDir, `${contractName}.json`), 'utf8')
+      readFileSync(join(codegenDir, `${contractName}.json`), 'utf8'),
     );
   } catch (error) {
     console.error(
       `Could not find ABI for contract ${contractName}:`,
-      error.message
+      error.message,
     );
     throw error;
   }
@@ -32,12 +32,12 @@ const getAbi = (contractName) => {
 const getByteCode = (contractName) => {
   try {
     return `0x${readFileSync(
-      join(codegenDir, `${contractName}.polkavm`)
+      join(codegenDir, `${contractName}.polkavm`),
     ).toString('hex')}`;
   } catch (error) {
     console.error(
       `Could not find bytecode for contract ${contractName}:`,
-      error.message
+      error.message,
     );
     throw error;
   }
@@ -51,7 +51,7 @@ const deployContract = async (contractName, mnemonic, providerConfig) => {
     const provider = createProvider(
       providerConfig.rpc,
       providerConfig.chainId,
-      providerConfig.name
+      providerConfig.name,
     );
     const walletMnemonic = ethers.Wallet.fromPhrase(mnemonic);
     const wallet = walletMnemonic.connect(provider);
@@ -60,7 +60,7 @@ const deployContract = async (contractName, mnemonic, providerConfig) => {
     const factory = new ethers.ContractFactory(
       getAbi(contractName),
       getByteCode(contractName),
-      wallet
+      wallet,
     );
     const contract = await factory.deploy();
     await contract.waitForDeployment();

--- a/.snippets/code/develop/smart-contracts/evm-toolkit/ethers-js/fetchLastBlock.js
+++ b/.snippets/code/develop/smart-contracts/evm-toolkit/ethers-js/fetchLastBlock.js
@@ -20,7 +20,7 @@ const main = async () => {
     const provider = createProvider(
       PROVIDER_RPC.rpc,
       PROVIDER_RPC.chainId,
-      PROVIDER_RPC.name
+      PROVIDER_RPC.name,
     );
     const latestBlock = await provider.getBlockNumber();
     console.log(`Latest block: ${latestBlock}`);

--- a/.snippets/code/develop/smart-contracts/native-evm-contracts/ether-js-server-connection.js
+++ b/.snippets/code/develop/smart-contracts/native-evm-contracts/ether-js-server-connection.js
@@ -1,5 +1,5 @@
 import { JsonRpcProvider } from 'ethers';
 
 const provider = new JsonRpcProvider(
-  'https://westend-asset-hub-eth-rpc.polkadot.io'
+  'https://westend-asset-hub-eth-rpc.polkadot.io',
 );

--- a/.snippets/code/tutorials/interoperability/xcm-transfers/from-relaychain-to-parachain/reserve-backed-transfer.js
+++ b/.snippets/code/tutorials/interoperability/xcm-transfers/from-relaychain-to-parachain/reserve-backed-transfer.js
@@ -25,13 +25,13 @@ import { Binary } from 'polkadot-api';
 
 // Create Polkadot client using WebSocket provider for Polkadot chain
 const polkadotClient = createClient(
-  withPolkadotSdkCompat(getWsProvider('ws://127.0.0.1:8001'))
+  withPolkadotSdkCompat(getWsProvider('ws://127.0.0.1:8001')),
 );
 const dotApi = polkadotClient.getTypedApi(dot);
 
 // Create Astar client using WebSocket provider for Astar chain
 const astarClient = createClient(
-  withPolkadotSdkCompat(getWsProvider('ws://localhost:8000'))
+  withPolkadotSdkCompat(getWsProvider('ws://localhost:8000')),
 );
 const astarApi = astarClient.getTypedApi(astar);
 
@@ -42,7 +42,7 @@ const aliceKeyPair = derive('//Alice');
 const alice = getPolkadotSigner(
   aliceKeyPair.publicKey,
   'Sr25519',
-  aliceKeyPair.sign
+  aliceKeyPair.sign,
 );
 
 // Define recipient (Dave) address on Astar chain
@@ -56,7 +56,7 @@ const polkadotAssetId = 340282366920938463463374607431768211455n;
 // Fetch asset balance of recipient (Dave) before transaction
 let assetMetadata = await astarApi.query.Assets.Account.getValue(
   polkadotAssetId,
-  daveAddress
+  daveAddress,
 );
 console.log('Asset balance before tx:', assetMetadata?.balance ?? 0);
 
@@ -65,7 +65,7 @@ const tx = dotApi.tx.XcmPallet.limited_reserve_transfer_assets({
   dest: XcmVersionedLocation.V3({
     parents: 0,
     interior: XcmV3Junctions.X1(
-      XcmV3Junction.Parachain(2006) // Destination is the Astar parachain
+      XcmV3Junction.Parachain(2006), // Destination is the Astar parachain
     ),
   }),
   beneficiary: XcmVersionedLocation.V3({
@@ -75,7 +75,7 @@ const tx = dotApi.tx.XcmPallet.limited_reserve_transfer_assets({
         // Beneficiary address on Astar
         network: undefined,
         id: idBenef,
-      })
+      }),
     ),
   }),
   assets: XcmVersionedAssets.V3([
@@ -110,7 +110,7 @@ await new Promise((resolve) => setTimeout(resolve, 20000));
 // Fetch asset balance of recipient (Dave) after transaction
 assetMetadata = await astarApi.query.Assets.Account.getValue(
   polkadotAssetId,
-  daveAddress
+  daveAddress,
 );
 console.log('Asset balance after tx:', assetMetadata?.balance ?? 0);
 

--- a/.snippets/code/tutorials/polkadot-sdk/testing/spawn-basic-chain/connect-to-alice-01.js
+++ b/.snippets/code/tutorials/polkadot-sdk/testing/spawn-basic-chain/connect-to-alice-01.js
@@ -12,7 +12,7 @@ async function main() {
   ]);
 
   console.log(
-    `You are connected to chain ${chain} using ${nodeName} v${nodeVersion}`
+    `You are connected to chain ${chain} using ${nodeName} v${nodeVersion}`,
   );
 }
 

--- a/develop/smart-contracts/json-rpc-apis.md
+++ b/develop/smart-contracts/json-rpc-apis.md
@@ -17,348 +17,431 @@ https://westend-asset-hub-eth-rpc.polkadot.io
 
 ## Available Methods
 
-### Chain Information
-
-- [`eth_chainId`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_chainid){target=\_blank} - returns the chain ID used for signing transactions
-
-    ???- code "Query Example" 
-
-        ```bash title="eth_chainId"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_chainId",
-            "params":[],
-            "id":1
-        }'
-        ```
-
-- [`net_version`](https://ethereum.org/en/developers/docs/apis/json-rpc/#net_version){target=\_blank} - returns the current network ID as a string
-
-    ???- code "Query Example" 
-
-        ```bash title="net_version"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"net_version",
-            "params":[],
-            "id":1
-        }'
-        ```
-
-### Block Information
-
-- [`eth_blockNumber`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_blocknumber){target=\_blank} - returns the number of the most recent block
-
-    ???- code "Query Example" 
-
-        ```bash title="eth_blockNumber"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_blockNumber",
-            "params":[],
-            "id":1
-        }'
-        ```
-
-- [`eth_getBlockByHash`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbyhash){target=\_blank} - returns information about a block by its hash
-
-    - Parameters
-        - Block Hash - The block hash of the block to retrieve
-        - Boolean - `true` returns full transaction details, while `false` provides only transaction hashes
-
-    ???- code "Query Example"
-
-        ```bash title="eth_getBlockByHash"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_getBlockByHash",
-            "params":["INSERT_BLOCK_HASH", INSERT_BOOLEAN],
-            "id":1
-        }'
-        ```
-    
-        Ensure to replace the `INSERT_BLOCK_HASH` and `INSERT_BOOLEAN` with the proper values.
-
-- [`eth_getBlockByNumber`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbynumber){target=\_blank} - returns information about a block by its number
-
-    - Parameters
-        - Block Value - quantity or tag of the block value to be fetched
-        - Boolean - `true` returns full transaction details, while `false` provides only transaction hashes
-
-    ???- code "Query Example" 
-
-        ```bash title="eth_getBlockByNumber"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_getBlockByNumber",
-            "params":["INSERT_BLOCK_VALUE", INSERT_BOOLEAN],
-            "id":1
-        }'
-        ```
-
-        Ensure to replace the `INSERT_BLOCK_VALUE` and `INSERT_BOOLEAN` with the proper values.
-
-### Account Information
-
-- [`eth_accounts`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_accounts){target=\_blank} - returns a list of addresses owned by the client
-
-    ???- code "Query Example" 
-
-        ```bash
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_accounts",
-            "params":[],
-            "id":1
-        }'
-        ```
-
-- [`eth_getBalance`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getbalance){target=\_blank} - returns the balance of a given address
-
-    - Parameters
-        - Address - address to query balance
-        - Block Value - quantity or tag of the block value to be fetched
-
-    ???- code "Query Example" 
-
-        ```bash title="eth_getBalance"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_getBalance",
-            "params":["INSERT_ADDRESS", "INSERT_BLOCK_VALUE"],
-            "id":1
-        }'
-        ```
-
-        Ensure to replace the `INSERT_ADDRESS` and `INSERT_BLOCK_VALUE` with the proper values.
-
-### Transaction Operations
-
-- [`eth_sendTransaction`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sendtransaction){target=\_blank} - creates and sends a new transaction
-
-    - Parameters
-        - From - address sending the transaction  
-        - To - (optional when deploying a contract) recipient address  
-        - Gas - (optional, default: 90000) gas limit for execution  
-        - Gas Price - (optional) gas price per unit  
-        - Value - (optional) amount of Ether to send  
-        - Input - contract bytecode or encoded method call  
-        - Nonce - (optional) transaction nonce
-    
-    ???- code "Query Example" 
-
-        ```bash title="eth_sendtransaction"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_sendTransaction",
-            "params":[{
-                "from": "INSERT_SENDER_ADDRESS",
-                "to": "INSERT_RECIPIENT_ADDRESS",
-                "gas": "INSERT_GAS_LIMIT",
-                "gasPrice": "INSERT_GAS_PRICE",
-                "value": "INSERT_VALUE",
-                "input": "INSERT_INPUT_DATA",
-                "nonce": "INSERT_NONCE"
-            }],
-            "id":1
-        }'
-        ```
-
-        Ensure to replace the `INSERT_SENDER_ADDRESS`, `INSERT_RECIPIENT_ADDRESS`, `INSERT_GAS_LIMIT`, `INSERT_GAS_PRICE`, `INSERT_VALUE`, `INSERT_INPUT_DATA` and `INSERT_NONCE` with the proper values.
-
-- [`eth_sendRawTransaction`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sendrawtransaction){target=\_blank} - submits a raw transaction
-
-    - Parameters
-        - Call Data - signed transaction data 
-
-    ???- code "Query Example" 
-
-        ```bash title="eth_sendRawTransaction"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_sendRawTransaction",
-            "params":["INSERT_CALL_DATA"],
-            "id":1
-        }'
-        ```
-
-        Ensure to replace the `INSERT_CALL_DATA` with the proper values.
-
-- [`eth_getTransactionCount`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactioncount){target=\_blank} - returns the number of transactions sent from an address (nonce)
-
-    - Parameters
-        - Address - address to query balance
-        - Block Value - quantity or tag of the block value to be fetched
-
-    ???- code "Query Example" 
-
-        ```bash title="eth_getTransactionCount"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_getTransactionCount",
-            "params":["INSERT_ADDRESS", "INSERT_BLOCK_VALUE"],
-            "id":1
-        }'
-        ```
-
-        Ensure to replace the `INSERT_ADDRESS` and `INSERT_BLOCK_VALUE` with the proper values.
-
-### Smart Contract Interaction
-
-- [`eth_call`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_call){target=\_blank} - executes a new message call immediately without creating a transaction
-
-    - Parameters
-        - From (optional) - address initiating the call
-        - To - recipient address of the call
-        - Gas (optional) - gas limit for execution (not consumed by `eth_call`)
-        - Gas Price (optional) - gas price for execution
-        - Value (optional) - amount of token sent with the call
-        - Input (optional) - hash of the method signature and encoded parameters
-        - Block Value - quantity or tag of the block value to be fetched
-
-    ???- code "Query Example" 
-
-        ```bash title="eth_call"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_call",
-            "params":[{
-                "to": "INSERT_RECIPIENT_ADDRESS",
-                "data": "INSERT_ENCODED_CALL"
-            }, "INSERT_BLOCK_VALUE"],
-            "id":1
-        }'
-        ```
-
-        Ensure to replace the `INSERT_RECIPIENT_ADDRESS`, `INSERT_ENCODED_CALL` and `INSERT_BLOCK_VALUE` with the proper values.
-
-- [`eth_estimateGas`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_estimategas){target=\_blank} - estimates gas required for a transaction
-
-    - Parameters
-        - From (optional) - address initiating the call
-        - To (optional) - recipient address of the call
-        - Gas (optional) - gas limit for execution
-        - Gas Price (optional) - gas price for execution
-        - Value (optional) - amount of token sent with the call
-        - Input (optional) - hash of the method signature and encoded parameters
-        - Block Value (optional) - quantity or tag of the block value to be fetched
-
-    ???- code "Query Example" 
-
-        ```bash title="eth_estimateGas"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_estimateGas",
-            "params":[{
-                "to": "INSERT_RECIPIENT_ADDRESS",
-                "data": "INSERT_ENCODED_FUNCTION_CALL"
-            }],
-            "id":1
-        }'
-        ```
-
-        Ensure to replace the `INSERT_RECIPIENT_ADDRESS` and `INSERT_ENCODED_CALL` with the proper values.
-
-### Gas and Fees
-
-- [`eth_gasPrice`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gasprice){target=\_blank} - returns the current gas price in wei
-
-    ???- code "Query Example" 
-
-        ```bash title="eth_gasPrice"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_gasPrice",
-            "params":[],
-            "id":1
-        }'
-        ```
-
-- [`eth_maxPriorityFeePerGas`](){target=\_blank} - returns the current maxPriorityFeePerGas in wei
-
-    ???- code "Query Example" 
-
-        ```bash title="eth_maxPriorityFeePerGas"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_maxPriorityFeePerGas",
-            "params":[],
-            "id":1
-        }'
-        ```
-
-### State and Storage
-
-- [`eth_getCode`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getcode){target=\_blank} - returns the code at a given address
-
-    - Parameters
-      - Address - contract or account address to query code
-      - Block Value (optional) - quantity or tag of the block value to be fetched
-
-    ???- code "Query Example" 
-
-        ```bash title "eth_getCode"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_getCode",
-            "params":["INSERT_ADDRESS", "INSERT_BLOCK_VALUE"],
-            "id":1
-        }'
-        ```
-
-        Ensure to replace the `INSERT_ADDRESS` and `INSERT_BLOCK_VALUE` with the proper values.
-
-- [`eth_getStorageAt`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat){target=\_blank} - returns the value from a storage position at a given address
-
-    - Parameters
-        - Address - contract or account address to query storage
-        - Storage Key - position in storage to retrieve data from
-        - Block Value (optional) - quantity or tag of the block value to be fetched
-
-    ???- code "Query Example" 
-
-        ```bash title="eth_getStorageAt"
-        curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
-        -H "Content-Type: application/json" \
-        --data '{
-            "jsonrpc":"2.0",
-            "method":"eth_getStorageAt",
-            "params":["INSERT_ADDRESS", "INSERT_STORAGE_KEY", "INSERT_BLOCK_VALUE"],
-            "id":1
-        }'
-        ```
-
-        Ensure to replace the `INSERT_ADDRESS`, `INSERT_STORAGE_KEY` and `INSERT_BLOCK_VALUE` with the proper values.
+### eth_accounts
+
+Returns a list of addresses owned by the client. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_accounts){target=\_blank}.
+
+**Parameters**:
+
+None
+
+**Example**:
+
+```bash title="eth_accounts"
+curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_accounts",
+    "params":[],
+    "id":1
+}'
+```
+
+---
+
+### eth_blockNumber
+
+Returns the number of the most recent block. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_blocknumber){target=\_blank}.
+
+**Parameters**:
+
+None
+
+**Example**:
+
+```bash title="eth_blockNumber"
+curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_blockNumber",
+    "params":[],
+    "id":1
+}'
+```
+
+---
+
+### eth_call
+
+Executes a new message call immediately without creating a transaction. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_call){target=\_blank}.
+
+**Parameters**:
+
+- `transaction` ++"object"++ - the transaction call object:
+    - `to` ++"string"++ - recipient address of the call. Must be a [20-byte data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+    - `data` ++"string"++ - hash of the method signature and encoded parameters. Must be a [data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+    - `from` ++"string"++ - (optional) sender's address for the call. Must be a [20-byte data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+    - `gas` ++"string"++ - (optional) gas limit to execute the call. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string
+    - `gasPrice` ++"string"++ - (optional) gas price per unit of gas. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string
+    - `value` ++"string"++ - (optional) value in wei to send with the call. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string
+- `blockValue` ++"string"++ - (optional) block tag or block number to execute the call at. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string or a [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block){target=\_blank}
+
+**Example**:
+
+```bash title="eth_call"
+curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_call",
+    "params":[{
+        "to": "INSERT_RECIPIENT_ADDRESS",
+        "data": "INSERT_ENCODED_CALL"
+    }, "INSERT_BLOCK_VALUE"],
+    "id":1
+}'
+```
+
+Ensure to replace the `INSERT_RECIPIENT_ADDRESS`, `INSERT_ENCODED_CALL` and `INSERT_BLOCK_VALUE` with the proper values.
+
+---
+
+### eth_chainId
+
+Returns the chain ID used for signing transactions. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_chainid){target=\_blank}.
+
+**Parameters**:
+
+None
+
+**Example**:
+
+```bash title="eth_chainId"
+curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_chainId",
+    "params":[],
+    "id":1
+}'
+```
+
+---
+
+### eth_estimateGas
+
+Estimates gas required for a transaction. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_estimategas){target=\_blank}.
+
+**Parameters**:
+
+- `transaction` ++"object"++ - the transaction call object:
+    - `to` ++"string"++ - recipient address of the call. Must be a [20-byte data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+    - `data` ++"string"++ - hash of the method signature and encoded parameters. Must be a [data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+    - `from` ++"string"++ - (optional) sender's address for the call. Must be a [20-byte data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+    - `gas` ++"string"++ - (optional) gas limit to execute the call. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string
+    - `gasPrice` ++"string"++ - (optional) gas price per unit of gas. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string
+    - `value` ++"string"++ - (optional) value in wei to send with the call. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string
+- `blockValue` ++"string"++ - (optional) block tag or block number to execute the call at. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string or a [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block){target=\_blank}
+
+**Example**:
+
+```bash title="eth_estimateGas"
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_estimateGas",
+    "params":[{
+        "to": "INSERT_RECIPIENT_ADDRESS",
+        "data": "INSERT_ENCODED_FUNCTION_CALL"
+    }],
+    "id":1
+}'
+```
+
+Ensure to replace the `INSERT_RECIPIENT_ADDRESS` and `INSERT_ENCODED_CALL` with the proper values.
+
+---
+
+### eth_gasPrice
+
+Returns the current gas price in Wei. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gasprice){target=\_blank}.
+
+**Parameters**:
+
+None
+
+**Example**:
+
+```bash title="eth_gasPrice"
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_gasPrice",
+    "params":[],
+    "id":1
+}'
+```
+
+---
+
+### eth_getBalance
+
+Returns the balance of a given address. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getbalance){target=\_blank}.
+
+**Parameters**:
+
+- `address` ++"string"++ - address to query balance. Must be a [20-byte data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+- `blockValue` ++"string"++ - (optional) the block value to be fetched. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string or a [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block){target=\_blank}
+
+**Example**:
+
+```bash title="eth_getBalance"
+curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_getBalance",
+    "params":["INSERT_ADDRESS", "INSERT_BLOCK_VALUE"],
+    "id":1
+}'
+```
+
+Ensure to replace the `INSERT_ADDRESS` and `INSERT_BLOCK_VALUE` with the proper values.
+
+---
+
+### eth_getBlockByHash
+
+Returns information about a block by its hash. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbyhash){target=\_blank}.
+
+**Parameters**:
+
+- `blockHash` ++"string"++ – the hash of the block to retrieve. Must be a [32 byte data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+- `fullTransactions` ++"boolean"++ – if `true`, returns full transaction details; if `false`, returns only transaction hashes
+
+**Example**:
+
+```bash title="eth_getBlockByHash"
+curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_getBlockByHash",
+    "params":["INSERT_BLOCK_HASH", INSERT_BOOLEAN],
+    "id":1
+}'
+```
+
+Ensure to replace the `INSERT_BLOCK_HASH` and `INSERT_BOOLEAN` with the proper values.
+
+---
+
+### eth_getBlockByNumber
+
+Returns information about a block by its number. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbynumber){target=\_blank}.
+
+**Parameters**:
+
+- `blockValue` ++"string"++ - (optional) the block value to be fetched. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string or a [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block){target=\_blank}
+- `fullTransactions` ++"boolean"++ – if `true`, returns full transaction details; if `false`, returns only transaction hashes
+
+**Example**:
+
+```bash title="eth_getBlockByNumber"
+curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_getBlockByNumber",
+    "params":["INSERT_BLOCK_VALUE", INSERT_BOOLEAN],
+    "id":1
+}'
+```
+
+Ensure to replace the `INSERT_BLOCK_VALUE` and `INSERT_BOOLEAN` with the proper values.
+
+---
+
+### eth_getCode
+
+Returns the code at a given address. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getcode){target=\_blank}.
+
+**Parameters**:
+
+- `address` ++"string"++ - contract or account address to query code. Must be a [20-byte data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+- `blockValue` ++"string"++ - (optional) the block value to be fetched. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string or a [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block)
+
+**Example**:
+
+```bash title="eth_getCode"
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_getCode",
+    "params":["INSERT_ADDRESS", "INSERT_BLOCK_VALUE"],
+    "id":1
+}'
+```
+
+Ensure to replace the `INSERT_ADDRESS` and `INSERT_BLOCK_VALUE` with the proper values.
+
+---
+
+### eth_getStorageAt
+
+Returns the value from a storage position at a given address. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat){target=\_blank}.
+
+**Parameters**:
+
+- `address` ++"string"++ - contract or account address to query code. Must be a [20-byte data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+- `storageKey` ++"string"++ - position in storage to retrieve data from. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string
+- `blockValue` ++"string"++ - (optional) the block value to be fetched. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string or a [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block)
+
+**Example**:
+
+```bash title="eth_getStorageAt"
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_getStorageAt",
+    "params":["INSERT_ADDRESS", "INSERT_STORAGE_KEY", "INSERT_BLOCK_VALUE"],
+    "id":1
+}'
+```
+
+Ensure to replace the `INSERT_ADDRESS`, `INSERT_STORAGE_KEY` and `INSERT_BLOCK_VALUE` with the proper values.
+
+### eth_getTransactionCount
+
+Returns the number of transactions sent from an address (nonce). [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactioncount){target=\_blank}.
+
+**Parameters**:
+
+- `address` ++"string"++ - address to query balance. Must be a [20-byte data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+- `blockValue` ++"string"++ - (optional) the block value to be fetched. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string or a [default block parameter](https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block)
+
+**Example**:
+
+```bash title="eth_getTransactionCount"
+curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_getTransactionCount",
+    "params":["INSERT_ADDRESS", "INSERT_BLOCK_VALUE"],
+    "id":1
+}'
+```
+
+Ensure to replace the `INSERT_ADDRESS` and `INSERT_BLOCK_VALUE` with the proper values.
+
+---
+
+### eth_maxPriorityFeePerGas
+
+Returns an estimate of the current priority fee per gas, in Wei, to be included in a block.
+
+**Parameters**:
+
+None
+
+**Example**:
+
+```bash title="eth_maxPriorityFeePerGas"
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_maxPriorityFeePerGas",
+    "params":[],
+    "id":1
+}'
+```
+
+---
+
+### eth_sendRawTransaction
+
+Submits a raw transaction. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sendrawtransaction){target=\_blank}.
+
+**Parameters**:
+
+- `callData` ++"string"++ - signed transaction data. Must be a [data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+
+**Example**:
+
+```bash title="eth_sendRawTransaction"
+curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_sendRawTransaction",
+    "params":["INSERT_CALL_DATA"],
+    "id":1
+}'
+```
+
+Ensure to replace the `INSERT_CALL_DATA` with the proper values.
+
+---
+
+### eth_sendTransaction
+
+Creates and sends a new transaction. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sendtransaction){target=\_blank}.
+
+**Parameters**:
+
+- `transaction` ++"object"++ - the transaction object:
+    - `from` ++"string"++ - address sending the transaction. Must be a [20-byte data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+    - `to` ++"string"++ - (optional) recipient address. No need to provide this value when deploying a contract. Must be a [20-byte data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+    - `gas` ++"string"++ - (optional, default: `90000`) gas limit for execution. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string
+    - `gasPrice` ++"string"++ - (optional) gas price per unit. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string
+    - `value` ++"string"++ - (optional) amount of Ether to send. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string
+    - `data` ++"string"++ - (optional) contract bytecode or encoded method call. Must be a [data](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding){target=\_blank} string
+    - `nonce` ++"string"++ - (optional) transaction nonce. Must be a [quantity](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding){target=\_blank} string
+
+**Example**:
+
+```bash title="eth_sendTransaction"
+curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"eth_sendTransaction",
+    "params":[{
+        "from": "INSERT_SENDER_ADDRESS",
+        "to": "INSERT_RECIPIENT_ADDRESS",
+        "gas": "INSERT_GAS_LIMIT",
+        "gasPrice": "INSERT_GAS_PRICE",
+        "value": "INSERT_VALUE",
+        "input": "INSERT_INPUT_DATA",
+        "nonce": "INSERT_NONCE"
+    }],
+    "id":1
+}'
+```
+
+Ensure to replace the `INSERT_SENDER_ADDRESS`, `INSERT_RECIPIENT_ADDRESS`, `INSERT_GAS_LIMIT`, `INSERT_GAS_PRICE`, `INSERT_VALUE`, `INSERT_INPUT_DATA` and `INSERT_NONCE` with the proper values.
+
+---
+
+### net_version
+
+Returns the current network ID as a string. [Reference](https://ethereum.org/en/developers/docs/apis/json-rpc/#net_version){target=\_blank}.
+
+**Parameters**:
+
+None
+
+**Example**:
+
+```bash title="net_version"
+curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+-H "Content-Type: application/json" \
+--data '{
+    "jsonrpc":"2.0",
+    "method":"net_version",
+    "params":[],
+    "id":1
+}'
+```
 
 ## Response Format
 

--- a/develop/smart-contracts/json-rpc-apis.md
+++ b/develop/smart-contracts/json-rpc-apis.md
@@ -94,7 +94,7 @@ curl -X POST https://westend-asset-hub-rpc.polkadot.io \
 }'
 ```
 
-Ensure to replace the `INSERT_RECIPIENT_ADDRESS`, `INSERT_ENCODED_CALL` and `INSERT_BLOCK_VALUE` with the proper values.
+Ensure to replace the `INSERT_RECIPIENT_ADDRESS`, `INSERT_ENCODED_CALL`, and `INSERT_BLOCK_VALUE` with the proper values.
 
 ---
 
@@ -306,7 +306,7 @@ curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 }'
 ```
 
-Ensure to replace the `INSERT_ADDRESS`, `INSERT_STORAGE_KEY` and `INSERT_BLOCK_VALUE` with the proper values.
+Ensure to replace the `INSERT_ADDRESS`, `INSERT_STORAGE_KEY`, and `INSERT_BLOCK_VALUE` with the proper values.
 
 ### eth_getTransactionCount
 
@@ -418,7 +418,7 @@ curl -X POST https://westend-asset-hub-rpc.polkadot.io \
 }'
 ```
 
-Ensure to replace the `INSERT_SENDER_ADDRESS`, `INSERT_RECIPIENT_ADDRESS`, `INSERT_GAS_LIMIT`, `INSERT_GAS_PRICE`, `INSERT_VALUE`, `INSERT_INPUT_DATA` and `INSERT_NONCE` with the proper values.
+Ensure to replace the `INSERT_SENDER_ADDRESS`, `INSERT_RECIPIENT_ADDRESS`, `INSERT_GAS_LIMIT`, `INSERT_GAS_PRICE`, `INSERT_VALUE`, `INSERT_INPUT_DATA`, and `INSERT_NONCE` with the proper values.
 
 ---
 


### PR DESCRIPTION
This PR reformats the JSON RPC page as follows:

- Removes the section categorization because I feel like people are going to use this page as a quick reference so it should just be alphabetized so users can more easily find what they're looking for
- Sets the section headers to be the rpc method name for the same reason as above
- Defines parameters even when there are none and sets the parameter types along with links back to the Ethereum docs for more info on data, quantities, and default block parameters
- Moves the examples out of admonitions, as they shouldn't be hidden or be highlighted. Especially since the main purpose of this page is to showcase what's available along with quick copy/paste examples

Looks like people have been skipping the formatter cause a bunch of pages were committed too 👀 🙅🏻‍♀️