### PR TITLE
Add workflow to detect url changes

### DIFF
--- a/.github/workflows/check-url-changes.yml
+++ b/.github/workflows/check-url-changes.yml
@@ -1,0 +1,72 @@
+name: Check Documentation URL Changes
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-url-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Identify deleted and renamed files
+        run: |
+          # Store deleted files
+          DELETED_FILES=$(git diff --name-status origin/master ${{ github.event.pull_request.head.sha }} | grep '^D' | cut -f2- || true)
+          echo "DELETED_FILES<<EOF" >> $GITHUB_ENV
+          echo "$DELETED_FILES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          
+          # Store renamed files
+          RENAMED_FILES=$(git diff --name-status origin/master ${{ github.event.pull_request.head.sha }} | grep '^R' | awk '{print $2 " -> " $3}' || true)
+          echo "RENAMED_FILES<<EOF" >> $GITHUB_ENV
+          echo "$RENAMED_FILES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          
+          # Set warning flag if there are any changes
+          if [ ! -z "$DELETED_FILES" ] || [ ! -z "$RENAMED_FILES" ]; then
+            echo "warning=true" >> $GITHUB_ENV
+          else
+            echo "warning=false" >> $GITHUB_ENV
+          fi
+          
+          # Print to console for logging
+          echo "Deleted files:"
+          echo "$DELETED_FILES"
+          echo -e "\nRenamed files:"
+          echo "$RENAMED_FILES"
+
+      - name: Post PR warning
+        if: env.warning == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue_number = context.payload.pull_request.number;
+            const repo = context.repo;
+            const deletedFiles = `${process.env.DELETED_FILES}`.trim();
+            const renamedFiles = `${process.env.RENAMED_FILES}`.trim();
+            
+            let message = `⚠️ **Documentation Warning**\n\n`;
+            
+            if (deletedFiles) {
+              message += `**Deleted files:**\n\`\`\`\n${deletedFiles}\n\`\`\`\n\n`;
+            }
+            
+            if (renamedFiles) {
+              message += `**Renamed files:**\n\`\`\`\n${renamedFiles}\n\`\`\`\n\n`;
+            }
+            
+            message += `Please verify these changes before merging.`;
+            
+            github.rest.issues.createComment({
+              owner: repo.owner,
+              repo: repo.repo,
+              issue_number: issue_number,
+              body: message
+            });

--- a/.github/workflows/check-url-changes.yml
+++ b/.github/workflows/check-url-changes.yml
@@ -16,14 +16,14 @@ jobs:
 
       - name: Identify deleted and renamed files
         run: |
-          # Store deleted files
-          DELETED_FILES=$(git diff --name-status origin/master ${{ github.event.pull_request.head.sha }} | grep '^D' | cut -f2- || true)
+          # Store deleted markdown files
+          DELETED_FILES=$(git diff --name-status origin/master ${{ github.event.pull_request.head.sha }} | grep '^D.*\.md$' | cut -f2- || true)
           echo "DELETED_FILES<<EOF" >> $GITHUB_ENV
           echo "$DELETED_FILES" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
           
-          # Store renamed files
-          RENAMED_FILES=$(git diff --name-status origin/master ${{ github.event.pull_request.head.sha }} | grep '^R' | awk '{print $2 " -> " $3}' || true)
+          # Store renamed markdown files
+          RENAMED_FILES=$(git diff --name-status origin/master ${{ github.event.pull_request.head.sha }} | grep '^R.*\.md$' | awk '{print $2 " -> " $3}' || true)
           echo "RENAMED_FILES<<EOF" >> $GITHUB_ENV
           echo "$RENAMED_FILES" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
@@ -38,7 +38,7 @@ jobs:
           # Print to console for logging
           echo "Deleted files:"
           echo "$DELETED_FILES"
-          echo -e "\nRenamed files:"
+          echo -e "\nRenamed/Moved files:"
           echo "$RENAMED_FILES"
 
       - name: Post PR warning
@@ -52,17 +52,17 @@ jobs:
             const deletedFiles = `${process.env.DELETED_FILES}`.trim();
             const renamedFiles = `${process.env.RENAMED_FILES}`.trim();
             
-            let message = `⚠️ **Documentation Warning**\n\n`;
+            let message = `🔍 **Documentation URL Checker**\n\nThis PR modifies documentation files in ways that could potentially create broken links.\n\n`;
             
             if (deletedFiles) {
               message += `**Deleted files:**\n\`\`\`\n${deletedFiles}\n\`\`\`\n\n`;
             }
             
             if (renamedFiles) {
-              message += `**Renamed files:**\n\`\`\`\n${renamedFiles}\n\`\`\`\n\n`;
+              message += `**Renamed/Moved files:**\n\`\`\`\n${renamedFiles}\n\`\`\`\n\n`;
             }
             
-            message += `Please verify these changes before merging.`;
+            message += `🚨 Please review these changes carefully 🚨\n\n If not handled properly, broken links (404 errors) could appear. To maintain a smooth user experience, consider:\n- Adding redirects in the \`mkdocs.yml\` file from the old URLs to the new ones\n- Updating internal references to these files`;
             
             github.rest.issues.createComment({
               owner: repo.owner,

--- a/.github/workflows/check-url-changes.yml
+++ b/.github/workflows/check-url-changes.yml
@@ -16,13 +16,13 @@ jobs:
 
       - name: Identify deleted and renamed files
         run: |
-          # Store deleted markdown files
+          # Store deleted files
           DELETED_FILES=$(git diff --name-status origin/master ${{ github.event.pull_request.head.sha }} | grep '^D.*\.md$' | cut -f2- || true)
           echo "DELETED_FILES<<EOF" >> $GITHUB_ENV
           echo "$DELETED_FILES" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
           
-          # Store renamed markdown files
+          # Store renamed/moved files
           RENAMED_FILES=$(git diff --name-status origin/master ${{ github.event.pull_request.head.sha }} | grep '^R.*\.md$' | awk '{print $2 " -> " $3}' || true)
           echo "RENAMED_FILES<<EOF" >> $GITHUB_ENV
           echo "$RENAMED_FILES" >> $GITHUB_ENV


### PR DESCRIPTION
Adds a GitHub Action workflow that detects when documentation files are deleted or renamed in PRs to prevent broken links and 404s for users. The workflow automatically posts a warning in PRs that looks like this:

🔍 **Documentation URL Checker**

This PR modifies documentation files in ways that could potentially create broken links.

**Deleted markdown files:**
```
develop/networks.md
```

**Renamed markdown files:**
```
tutorials/polkadot-sdk/testing/fork-live-chains.md -> develop/toolkit/parachains/fork-chains/chopsticks/fork-live-chains.md
tutorials/interoperability/xcm-channels/index.md -> tutorials/interoperability/hrmp-channels/index.md
tutorials/interoperability/xcm-channels/para-to-para.md -> tutorials/interoperability/hrmp-channels/para-to-para.md
tutorials/interoperability/xcm-channels/para-to-system.md -> tutorials/interoperability/hrmp-channels/para-to-system.md
```

🚨 Please review these changes carefully 🚨

 If not handled properly, broken links (404 errors) could appear. To maintain a smooth user experience, consider:
- Adding redirects in the `mkdocs.yml` file from the old URLs to the new ones
- Updating internal references to these files