### PR TITLE
Fix cargo install omni node

### DIFF
--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -38,7 +38,7 @@ This tutorial requires two essential tools:
     Install it by executing the following command:
     
     ```bash
-    cargo install staging-chain-spec-builder
+    cargo install staging-chain-spec-builder@9.0.0
     ```
 
     This installs the `chain-spec-builder` binary. Refer to the [Generate Chain Specs](/develop/parachains/deployment/generate-chain-specs/){target=\_blank} documentation for detailed usage.

--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -38,7 +38,7 @@ This tutorial requires two essential tools:
     Install it by executing the following command:
     
     ```bash
-    cargo install --git https://github.com/paritytech/polkadot-sdk --tag {{dependencies.polkadot_sdk.stable_version}} --force staging-chain-spec-builder
+    cargo install staging-chain-spec-builder
     ```
 
     This installs the `chain-spec-builder` binary. Refer to the [Generate Chain Specs](/develop/parachains/deployment/generate-chain-specs/){target=\_blank} documentation for detailed usage.
@@ -49,7 +49,7 @@ This tutorial requires two essential tools:
     To install it, run the following command:
 
     ```bash
-    cargo install --git https://github.com/paritytech/polkadot-sdk --tag {{dependencies.polkadot_sdk.stable_version}} --force polkadot-omni-node
+    cargo install polkadot-omni-node
     ```
 
     This installs the `polkadot-omni-node` binary.

--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -49,7 +49,7 @@ This tutorial requires two essential tools:
     To install it, run the following command:
 
     ```bash
-    cargo install polkadot-omni-node
+    cargo install polkadot-omni-node@0.4.0
     ```
 
     This installs the `polkadot-omni-node` binary.


### PR DESCRIPTION
Installation command was found to be broken, see https://github.com/paritytech/polkadot-sdk/issues/7653#issuecomment-2678085930  

Changed it to use crates-io registry. How is the version locking in this repo working? The template does not have a version?