### PR TITLE
update omni node variable

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -42,7 +42,7 @@ dependencies:
     chain_spec_builder:
       name: staging-chain-spec-builder
       version: 9.0.0
-    polkadot-omni-node:
+    polkadot_omni_node:
       name: polkadot-omni-node
       version: 0.4.0
   javascript_packages:


### PR DESCRIPTION
Update the omni node variable, so it matches what the the tutorial expects (`cargo install polkadot-omni-node@{{dependencies.crates.polkadot_omni_node.version}}`): https://github.com/polkadot-developers/polkadot-docs/pull/444/files#diff-d5405921056a533696168f2b519d4313487cd6ceec6f4cc762715d0750c1a1fcR52