### PR TITLE
adds timeline element to parachain zero to hero index page, updates llms

### DIFF
--- a/.snippets/text/tutorials/polkadot-sdk/parachains/zero-to-hero/zero-to-hero-timeline.json
+++ b/.snippets/text/tutorials/polkadot-sdk/parachains/zero-to-hero/zero-to-hero-timeline.json
@@ -1,0 +1,37 @@
+[
+    {
+        "title": "[Set Up a Template](/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template/)",
+        "content": "Learn to compile and run a local parachain node using Polkadot SDK. Launch, run, and interact with a pre-configured runtime template.",
+        "icon": ":fontawesome-solid-1:"
+    },
+    {
+        "title": "[Build a Custom Pallet](/tutorials/polkadot-sdk/parachains/zero-to-hero/build-custom-pallet/)",
+        "content": "Learn how to build a custom pallet for Polkadot SDK-based blockchains with this step-by-step guide. Create and configure a simple counter pallet from scratch.",
+        "icon": ":fontawesome-solid-2:"
+    },
+    {
+        "title": "[Pallet Unit Testing](/tutorials/polkadot-sdk/parachains/zero-to-hero/pallet-unit-testing/)",
+        "content": "Discover how to create thorough unit tests for pallets built with the Polkadot SDK, using a custom pallet as a practical example.",
+        "icon": ":fontawesome-solid-3:"
+    },
+    {
+        "title": "[Add Pallets to the Runtime](/tutorials/polkadot-sdk/parachains/zero-to-hero/add-pallets-to-runtime/)",
+        "content": "Add pallets to your runtime for custom functionality. Learn to configure and integrate pallets in Polkadot SDK-based blockchains.",
+        "icon": ":fontawesome-solid-4:"
+    },
+    {
+        "title": "[Pallet Benchmarking](/tutorials/polkadot-sdk/parachains/zero-to-hero/pallet-benchmarking/)",
+        "content": "Learn how to benchmark Polkadot SDK-based pallets, assigning precise weights to extrinsics for accurate fee calculation and runtime optimization.",
+        "icon": ":fontawesome-solid-5:"
+    },
+    {
+        "title": "[Deploy on Paseo TestNet](/tutorials/polkadot-sdk/parachains/zero-to-hero/deploy-to-testnet/)",
+        "content": "This guide walks you through the journey of deploying your Polkadot SDK blockchain on Paseo, detailing each step to a successful TestNet deployment.",
+        "icon": ":fontawesome-solid-6:"
+    },
+    {
+        "title": "[Obtain Coretime](/tutorials/polkadot-sdk/parachains/zero-to-hero/obtain-coretime/)",
+        "content": "Learn how to obtain coretime for block production with this guide, covering both on-demand and bulk options for smooth operations.",
+        "icon": ":fontawesome-solid-7:"
+    }
+]

--- a/llms.txt
+++ b/llms.txt
@@ -25441,13 +25441,13 @@ template: index-page.html
 
 # Parachain Zero To Hero Tutorials
 
-The **Parachain Zero To Hero Tutorials** provide developers with a series of step-by-step guides to building, testing, and deploying custom pallets and runtimes using the Polkadot SDK. These tutorials are designed to help you gain hands-on experience and understand the core concepts necessary to create efficient and scalable blockchains.  
+The **Parachain Zero To Hero Tutorials** provide developers with a series of step-by-step guides to building, testing, and deploying custom pallets and runtimes using the Polkadot SDK. These tutorials are designed to help you gain hands-on experience and understand the core concepts necessary to create efficient and scalable blockchains.
 
-To get the most from this section, start with the [Set Up a Template](/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template/){target=\_blank} guide. As you complete each guide, look for **Where to Go Next** to move to the following guide in the series.
+To get the most from this section, complete the guides in the order shown, starting with the [Set Up a Template](/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template/){target=\_blank} guide. As you complete each guide, look for **Where to Go Next** to move to the next guide in the series.
 
-## In This Section
+## Parachain Development Cycle
 
-:::INSERT_IN_THIS_SECTION:::
+[timeline(polkadot-docs/.snippets/text/tutorials/polkadot-sdk/parachains/zero-to-hero/zero-to-hero-timeline.json)]
 --- END CONTENT ---
 
 Doc-Content: https://docs.polkadot.com/tutorials/polkadot-sdk/parachains/zero-to-hero/obtain-coretime/

--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/index.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/index.md
@@ -6,10 +6,10 @@ template: index-page.html
 
 # Parachain Zero To Hero Tutorials
 
-The **Parachain Zero To Hero Tutorials** provide developers with a series of step-by-step guides to building, testing, and deploying custom pallets and runtimes using the Polkadot SDK. These tutorials are designed to help you gain hands-on experience and understand the core concepts necessary to create efficient and scalable blockchains.  
+The **Parachain Zero To Hero Tutorials** provide developers with a series of step-by-step guides to building, testing, and deploying custom pallets and runtimes using the Polkadot SDK. These tutorials are designed to help you gain hands-on experience and understand the core concepts necessary to create efficient and scalable blockchains.
 
-To get the most from this section, start with the [Set Up a Template](/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template/){target=\_blank} guide. As you complete each guide, look for **Where to Go Next** to move to the following guide in the series.
+To get the most from this section, complete the guides in the order shown, starting with the [Set Up a Template](/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template/){target=\_blank} guide. As you complete each guide, look for **Where to Go Next** to move to the next guide in the series.
 
-## In This Section
+## Parachain Development Cycle
 
-:::INSERT_IN_THIS_SECTION:::
+[timeline(polkadot-docs/.snippets/text/tutorials/polkadot-sdk/parachains/zero-to-hero/zero-to-hero-timeline.json)]


### PR DESCRIPTION
This PR adds the timeline element to the parachains zero-to-hero index page to replace the In This Section cards.  To view locally, use with [mkdocs PR 83](https://github.com/papermoonio/polkadot-mkdocs/pull/83)