### PR TITLE
Apply improvements to Zombienet docs

### DIFF
--- a/develop/toolkit/parachains/spawn-chains/zombienet/get-started.md
+++ b/develop/toolkit/parachains/spawn-chains/zombienet/get-started.md
@@ -175,9 +175,6 @@ zombienet setup polkadot polkadot-parachain
 
 This command will download and prepare the necessary binaries for Zombienet's use.
 
-!!! warning
-    The `polkadot` and `polkadot-parachain` binaries releases aren't compatible with macOS. As a result, macOS users will need to clone the [Polkadot repository](https://github.com/paritytech/polkadot-sdk){target=\_blank}, build the Polkadot binary, and manually add it to their PATH for `polkadot` and `polkadot-parachain` to work.
-
 If you need to use a custom binary, ensure the binary is available in your PATH. You can also specify the binary path in the network configuration file. The following example uses the custom [OpenZeppelin template](https://github.com/OpenZeppelin/polkadot-runtime-templates){target=\_blank}:
 
 First, clone the OpenZeppelin template repository using the following command:
@@ -243,9 +240,6 @@ The following sections will guide you through the primary usage of the Zombienet
 #### CLI Commands
 
 - **`spawn <networkConfig>`** - spawn the network defined in the [configuration file](#configuration-files)
-
-    !!! warning
-        The Polkadot binary is currently not compatible with macOS. For the `spawn` command to work on macOS, users will need to clone the [Polkadot repository](https://github.com/paritytech/polkadot-sdk){target=\_blank}, build the Polkadot binary, and manually add it to their PATH.
 
 - **`test <testFile>`** - run tests on the spawned network using the assertions and tests defined in the [test file](/develop/toolkit/parachains/spawn-chains/zombienet/write-tests/#the-test-file){target=\_blank}
 

--- a/llms.txt
+++ b/llms.txt
@@ -10633,9 +10633,6 @@ zombienet setup polkadot polkadot-parachain
 
 This command will download and prepare the necessary binaries for Zombienet's use.
 
-!!! warning
-    The `polkadot` and `polkadot-parachain` binaries releases aren't compatible with macOS. As a result, macOS users will need to clone the [Polkadot repository](https://github.com/paritytech/polkadot-sdk){target=\_blank}, build the Polkadot binary, and manually add it to their PATH for `polkadot` and `polkadot-parachain` to work.
-
 If you need to use a custom binary, ensure the binary is available in your PATH. You can also specify the binary path in the network configuration file. The following example uses the custom [OpenZeppelin template](https://github.com/OpenZeppelin/polkadot-runtime-templates){target=\_blank}:
 
 First, clone the OpenZeppelin template repository using the following command:
@@ -10701,9 +10698,6 @@ The following sections will guide you through the primary usage of the Zombienet
 #### CLI Commands
 
 - **`spawn <networkConfig>`** - spawn the network defined in the [configuration file](#configuration-files)
-
-    !!! warning
-        The Polkadot binary is currently not compatible with macOS. For the `spawn` command to work on macOS, users will need to clone the [Polkadot repository](https://github.com/paritytech/polkadot-sdk){target=\_blank}, build the Polkadot binary, and manually add it to their PATH.
 
 - **`test <testFile>`** - run tests on the spawned network using the assertions and tests defined in the [test file](/develop/toolkit/parachains/spawn-chains/zombienet/write-tests/#the-test-file){target=\_blank}
 
@@ -27976,6 +27970,35 @@ To successfully complete this tutorial, you must ensure you've first:
 
 - [Installed Zombienet](/develop/toolkit/parachains/spawn-chains/zombienet/get-started/#install-zombienet){target=\_blank}. This tutorial requires Zombienet version `{{ dependencies.repositories.zombienet.version }}`. Verify that you're using the specified version to ensure compatibility with the instructions.
 - Reviewed the information in [Configure Zombienet](/develop/toolkit/parachains/spawn-chains/zombienet/get-started/#configure-zombienet){target=\_blank} and understand how to customize a spawned network
+
+## Set Up Local Provider
+
+In this tutorial, you will use the the Zombienet , also called native, that enables you to run nodes as local processes in your environment. 
+
+In this tutorial, you will use the Zombienet [local provider](/develop/toolkit/parachains/spawn-chains/zombienet/get-started/#local-provider){target=\_blank} (also called native provider) that enables you to run nodes as local processes in your development environment.
+
+You must have the necessary binaries installed (such as `polkadot` and `polkadot-parachain`) to spin up your network successfully.
+
+To install the required binaries, use the following Zombienet CLI command:
+
+```bash
+zombienet setup polkadot polkadot-parachain
+```
+
+This command downloads the following binaries:
+
+- **polkadot**
+- **polkadot-execute-worker**
+- **polkadot-parachain**
+- **polkadot-prepare-worker**
+
+Finally, add these binaries to your PATH environment variable to ensure Zombienet can locate them when spawning the network.
+
+For example, you can move the binaries to a directory in your PATH, such as `/usr/local/bin`:
+
+```bash
+sudo mv ./polkadot ./polkadot-execute-worker ./polkadot-parachain ./polkadot-prepare-worker /usr/local/bin
+```
 
 ## Define the Network
 

--- a/tutorials/polkadot-sdk/testing/spawn-basic-chain.md
+++ b/tutorials/polkadot-sdk/testing/spawn-basic-chain.md
@@ -20,6 +20,35 @@ To successfully complete this tutorial, you must ensure you've first:
 - [Installed Zombienet](/develop/toolkit/parachains/spawn-chains/zombienet/get-started/#install-zombienet){target=\_blank}. This tutorial requires Zombienet version `{{ dependencies.repositories.zombienet.version }}`. Verify that you're using the specified version to ensure compatibility with the instructions.
 - Reviewed the information in [Configure Zombienet](/develop/toolkit/parachains/spawn-chains/zombienet/get-started/#configure-zombienet){target=\_blank} and understand how to customize a spawned network
 
+## Set Up Local Provider
+
+In this tutorial, you will use the the Zombienet , also called native, that enables you to run nodes as local processes in your environment. 
+
+In this tutorial, you will use the Zombienet [local provider](/develop/toolkit/parachains/spawn-chains/zombienet/get-started/#local-provider){target=\_blank} (also called native provider) that enables you to run nodes as local processes in your development environment.
+
+You must have the necessary binaries installed (such as `polkadot` and `polkadot-parachain`) to spin up your network successfully.
+
+To install the required binaries, use the following Zombienet CLI command:
+
+```bash
+zombienet setup polkadot polkadot-parachain
+```
+
+This command downloads the following binaries:
+
+- **polkadot**
+- **polkadot-execute-worker**
+- **polkadot-parachain**
+- **polkadot-prepare-worker**
+
+Finally, add these binaries to your PATH environment variable to ensure Zombienet can locate them when spawning the network.
+
+For example, you can move the binaries to a directory in your PATH, such as `/usr/local/bin`:
+
+```bash
+sudo mv ./polkadot ./polkadot-execute-worker ./polkadot-parachain ./polkadot-prepare-worker /usr/local/bin
+```
+
 ## Define the Network
 
 Zombienet uses a [configuration file](/develop/toolkit/parachains/spawn-chains/zombienet/get-started/#configuration-files){target=\_blank} to define the ephemeral network that will be spawned. Follow these steps to create and define the configuration file:


### PR DESCRIPTION
- Remove the warning that macOS users had to compile polkadot binaries manually.
- Add a section that explains how to download and set up the required binaries in the Zombienet tutorial