### PR TITLE
add difficulty badges to smart contracts

### DIFF
--- a/tutorials/smart-contracts/deploy-erc20.md
+++ b/tutorials/smart-contracts/deploy-erc20.md
@@ -1,6 +1,7 @@
 ---
 title: Deploy an ERC-20 to Asset Hub
 description: Deploy an ERC-20 token on Asset Hub using PolkaVM. This guide covers contract creation, compilation, deployment, and interaction via Polkadot Remix IDE.
+tutorial_badge: Beginner
 ---
 
 # Deploy ERC-20 to Asset Hub

--- a/tutorials/smart-contracts/deploy-nft.md
+++ b/tutorials/smart-contracts/deploy-nft.md
@@ -1,6 +1,7 @@
 ---
 title: Deploy an NFT to Asset Hub
 description: Deploy an NFT on Asset Hub using PolkaVM and OpenZeppelin. Learn how to compile, deploy, and interact with your contract using Polkadot Remix IDE.
+tutorial_badge: Beginner
 ---
 
 # Deploy an NFT to Asset Hub

--- a/tutorials/smart-contracts/launch-your-first-project/create-contracts.md
+++ b/tutorials/smart-contracts/launch-your-first-project/create-contracts.md
@@ -1,6 +1,7 @@
 ---
 title: Create a Smart Contract
 description: Learn how to write a basic smart contract using just a text editor. This guide covers creating and preparing a contract for deployment on Asset Hub.
+tutorial_badge: Beginner
 ---
 
 # Create a Smart Contract

--- a/tutorials/smart-contracts/launch-your-first-project/test-and-deploy-with-hardhat.md
+++ b/tutorials/smart-contracts/launch-your-first-project/test-and-deploy-with-hardhat.md
@@ -1,6 +1,7 @@
 ---
 title: Test and Deploy with Hardhat
 description: Learn how to set up a Hardhat development environment, write comprehensive tests for a Solidity smart contract, and deploy it to local and Asset Hub networks.
+tutorial_badge: Intermediate
 ---
 
 # Test and Deploy with Hardhat


### PR DESCRIPTION
This PR introduces difficulty badges to the smart contracts tutorial sections, which will be shown in cards on both the index and content pages

It needs to be merged with the following: https://github.com/papermoonio/polkadot-mkdocs/pull/86