### PR TITLE
Install with `--locked`

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -145,6 +145,7 @@ Doc-Page: https://docs.polkadot.com/tutorials/polkadot-sdk/system-chains/
 Doc-Page: https://docs.polkadot.com/tutorials/polkadot-sdk/testing/fork-live-chains/
 Doc-Page: https://docs.polkadot.com/tutorials/polkadot-sdk/testing/
 Doc-Page: https://docs.polkadot.com/tutorials/polkadot-sdk/testing/spawn-basic-chain/
+Doc-Page: https://docs.polkadot.com/venv/lib/python3.13/site-packages/idna-3.10.dist-info/LICENSE/
 
 # Full content for each doc page
 
@@ -26756,7 +26757,7 @@ This tutorial requires two essential tools:
     Install it by executing the following command:
     
     ```bash
-    cargo install staging-chain-spec-builder@{{dependencies.crates.chain_spec_builder.version}}
+    cargo install --locked staging-chain-spec-builder@{{dependencies.crates.chain_spec_builder.version}}
     ```
 
     This installs the `chain-spec-builder` binary.
@@ -26766,7 +26767,7 @@ This tutorial requires two essential tools:
     To install it, run the following command:
 
     ```bash
-    cargo install polkadot-omni-node@{{dependencies.crates.polkadot_omni_node.version}}
+    cargo install --locked polkadot-omni-node@{{dependencies.crates.polkadot_omni_node.version}}
     ```
 
     This installs the `polkadot-omni-node` binary.
@@ -26787,7 +26788,7 @@ The [Polkadot SDK Parachain Template](https://github.com/paritytech/polkadot-sdk
 
 3. Compile the runtime:
     ```bash
-    cargo build --release
+    cargo build --release --locked
     ```
 
     !!!tip
@@ -28164,5 +28165,40 @@ tail -f  /tmp/zombie-794af21178672e1ff32c612c3c7408dc_-2397036-6717MXDxcS55/alic
 ```
 
 After running this command, you will see the logs of the `alice` node in real-time, which can be useful for debugging purposes. The logs of the `bob` and `collator01` nodes can be checked similarly.
+--- END CONTENT ---
+
+Doc-Content: https://docs.polkadot.com/venv/lib/python3.13/site-packages/idna-3.10.dist-info/LICENSE/
+--- BEGIN CONTENT ---
+BSD 3-Clause License
+
+Copyright (c) 2013-2024, Kim Davies and contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --- END CONTENT ---
 

--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -38,7 +38,7 @@ This tutorial requires two essential tools:
     Install it by executing the following command:
     
     ```bash
-    cargo install staging-chain-spec-builder@{{dependencies.crates.chain_spec_builder.version}}
+    cargo install --locked staging-chain-spec-builder@{{dependencies.crates.chain_spec_builder.version}}
     ```
 
     This installs the `chain-spec-builder` binary.
@@ -48,7 +48,7 @@ This tutorial requires two essential tools:
     To install it, run the following command:
 
     ```bash
-    cargo install polkadot-omni-node@{{dependencies.crates.polkadot_omni_node.version}}
+    cargo install --locked polkadot-omni-node@{{dependencies.crates.polkadot_omni_node.version}}
     ```
 
     This installs the `polkadot-omni-node` binary.
@@ -69,7 +69,7 @@ The [Polkadot SDK Parachain Template](https://github.com/paritytech/polkadot-sdk
 
 3. Compile the runtime:
     ```bash
-    cargo build --release
+    cargo build --release --locked
     ```
 
     !!!tip


### PR DESCRIPTION
Issue reported in https://app.element.io/#/room/%23substratedevs:matrix.org

Need to install with locked to avoid this: https://substrate.stackexchange.com/questions/12302/compile-error-multiple-impls-satisfying-u32/12303#12303

Basically, `cargo install` without `--locked` can break without warning. Maybe worth reviewing the other usage as well.