### PR TITLE
update build flag tip

### DIFF
--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -74,7 +74,7 @@ The [Polkadot SDK Parachain Template](https://github.com/paritytech/polkadot-sdk
     ```
 
     !!!tip
-        Initial compilation may take several minutes, depending on your machine specifications. Use the `--release` flag to build binaries for optimized runtimes. 
+        Initial compilation may take several minutes, depending on your machine specifications. Use the `--release` flag to build binaries with improved runtime performance compared to a ``--debug`` build. 
 
 4. Upon successful compilation, you should see output similar to:
     --8<-- 'code/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template/compilation-output.html'

--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -74,7 +74,7 @@ The [Polkadot SDK Parachain Template](https://github.com/paritytech/polkadot-sdk
     ```
 
     !!!tip
-        Initial compilation may take several minutes, depending on your machine specifications. Always use the `--release` flag to build optimized, production-ready artifacts.
+        Initial compilation may take several minutes, depending on your machine specifications. Use the `--release` flag to build binaries for optimized runtimes. 
 
 4. Upon successful compilation, you should see output similar to:
     --8<-- 'code/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template/compilation-output.html'


### PR DESCRIPTION
attempt to fix #534 

Since this is a most basic tutorial to start a Parachain, most likely no visitor is in a position to immediately learn about the right flags for production ready compilation. Instead I suggest to remove the misleading wording and simply mention that ``--release`` yields a binary for improved runtime performance compared to a regular (debug) build.
