### PR TITLE
[FIX] - Rollback json rpc api endpoint

### DIFF
--- a/develop/smart-contracts/json-rpc-apis.md
+++ b/develop/smart-contracts/json-rpc-apis.md
@@ -12,7 +12,7 @@ Asset Hub provides Ethereum compatibility through its JSON-RPC interface, allowi
 This article uses the Westend Asset Hub endpoint to interact with:
 
 ```text
-https://westend-asset-hub-rpc.polkadot.io
+https://westend-asset-hub-eth-rpc.polkadot.io
 ```
 
 ## Available Methods
@@ -28,7 +28,7 @@ None
 **Example**:
 
 ```bash title="eth_accounts"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -51,7 +51,7 @@ None
 **Example**:
 
 ```bash title="eth_blockNumber"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -81,7 +81,7 @@ Executes a new message call immediately without creating a transaction. [Referen
 **Example**:
 
 ```bash title="eth_call"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -109,7 +109,7 @@ None
 **Example**:
 
 ```bash title="eth_chainId"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -139,7 +139,7 @@ Estimates gas required for a transaction. [Reference](https://ethereum.org/en/de
 **Example**:
 
 ```bash title="eth_estimateGas"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -167,7 +167,7 @@ None
 **Example**:
 
 ```bash title="eth_gasPrice"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -191,7 +191,7 @@ Returns the balance of a given address. [Reference](https://ethereum.org/en/deve
 **Example**:
 
 ```bash title="eth_getBalance"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -217,7 +217,7 @@ Returns information about a block by its hash. [Reference](https://ethereum.org/
 **Example**:
 
 ```bash title="eth_getBlockByHash"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -243,7 +243,7 @@ Returns information about a block by its number. [Reference](https://ethereum.or
 **Example**:
 
 ```bash title="eth_getBlockByNumber"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -269,7 +269,7 @@ Returns the code at a given address. [Reference](https://ethereum.org/en/develop
 **Example**:
 
 ```bash title="eth_getCode"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -296,7 +296,7 @@ Returns the value from a storage position at a given address. [Reference](https:
 **Example**:
 
 ```bash title="eth_getStorageAt"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -320,7 +320,7 @@ Returns the number of transactions sent from an address (nonce). [Reference](htt
 **Example**:
 
 ```bash title="eth_getTransactionCount"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -345,7 +345,7 @@ None
 **Example**:
 
 ```bash title="eth_maxPriorityFeePerGas"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -368,7 +368,7 @@ Submits a raw transaction. [Reference](https://ethereum.org/en/developers/docs/a
 **Example**:
 
 ```bash title="eth_sendRawTransaction"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -400,7 +400,7 @@ Creates and sends a new transaction. [Reference](https://ethereum.org/en/develop
 **Example**:
 
 ```bash title="eth_sendTransaction"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -433,7 +433,7 @@ None
 **Example**:
 
 ```bash title="net_version"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",

--- a/llms.txt
+++ b/llms.txt
@@ -7214,7 +7214,7 @@ Asset Hub provides Ethereum compatibility through its JSON-RPC interface, allowi
 This article uses the Westend Asset Hub endpoint to interact with:
 
 ```text
-https://westend-asset-hub-rpc.polkadot.io
+https://westend-asset-hub-eth-rpc.polkadot.io
 ```
 
 ## Available Methods
@@ -7230,7 +7230,7 @@ None
 **Example**:
 
 ```bash title="eth_accounts"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7253,7 +7253,7 @@ None
 **Example**:
 
 ```bash title="eth_blockNumber"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7283,7 +7283,7 @@ Executes a new message call immediately without creating a transaction. [Referen
 **Example**:
 
 ```bash title="eth_call"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7311,7 +7311,7 @@ None
 **Example**:
 
 ```bash title="eth_chainId"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7341,7 +7341,7 @@ Estimates gas required for a transaction. [Reference](https://ethereum.org/en/de
 **Example**:
 
 ```bash title="eth_estimateGas"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7369,7 +7369,7 @@ None
 **Example**:
 
 ```bash title="eth_gasPrice"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7393,7 +7393,7 @@ Returns the balance of a given address. [Reference](https://ethereum.org/en/deve
 **Example**:
 
 ```bash title="eth_getBalance"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7419,7 +7419,7 @@ Returns information about a block by its hash. [Reference](https://ethereum.org/
 **Example**:
 
 ```bash title="eth_getBlockByHash"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7445,7 +7445,7 @@ Returns information about a block by its number. [Reference](https://ethereum.or
 **Example**:
 
 ```bash title="eth_getBlockByNumber"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7471,7 +7471,7 @@ Returns the code at a given address. [Reference](https://ethereum.org/en/develop
 **Example**:
 
 ```bash title="eth_getCode"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7498,7 +7498,7 @@ Returns the value from a storage position at a given address. [Reference](https:
 **Example**:
 
 ```bash title="eth_getStorageAt"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7522,7 +7522,7 @@ Returns the number of transactions sent from an address (nonce). [Reference](htt
 **Example**:
 
 ```bash title="eth_getTransactionCount"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7547,7 +7547,7 @@ None
 **Example**:
 
 ```bash title="eth_maxPriorityFeePerGas"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7570,7 +7570,7 @@ Submits a raw transaction. [Reference](https://ethereum.org/en/developers/docs/a
 **Example**:
 
 ```bash title="eth_sendRawTransaction"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7602,7 +7602,7 @@ Creates and sends a new transaction. [Reference](https://ethereum.org/en/develop
 **Example**:
 
 ```bash title="eth_sendTransaction"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -7635,7 +7635,7 @@ None
 **Example**:
 
 ```bash title="net_version"
-curl -X POST https://westend-asset-hub-rpc.polkadot.io \
+curl -X POST https://westend-asset-hub-eth-rpc.polkadot.io \
 -H "Content-Type: application/json" \
 --data '{
     "jsonrpc":"2.0",
@@ -31857,6 +31857,7 @@ Doc-Content: https://docs.polkadot.com/tutorials/smart-contracts/deploy-erc20/
 ---
 title: Deploy an ERC-20 to Asset Hub
 description: Deploy an ERC-20 token on Asset Hub using PolkaVM. This guide covers contract creation, compilation, deployment, and interaction via Polkadot Remix IDE.
+tutorial_badge: Beginner
 ---
 
 # Deploy ERC-20 to Asset Hub
@@ -32019,6 +32020,7 @@ Doc-Content: https://docs.polkadot.com/tutorials/smart-contracts/deploy-nft/
 ---
 title: Deploy an NFT to Asset Hub
 description: Deploy an NFT on Asset Hub using PolkaVM and OpenZeppelin. Learn how to compile, deploy, and interact with your contract using Polkadot Remix IDE.
+tutorial_badge: Beginner
 ---
 
 # Deploy an NFT to Asset Hub
@@ -32213,6 +32215,7 @@ Doc-Content: https://docs.polkadot.com/tutorials/smart-contracts/launch-your-fir
 ---
 title: Create a Smart Contract
 description: Learn how to write a basic smart contract using just a text editor. This guide covers creating and preparing a contract for deployment on Asset Hub.
+tutorial_badge: Beginner
 ---
 
 # Create a Smart Contract
@@ -33905,6 +33908,7 @@ Doc-Content: https://docs.polkadot.com/tutorials/smart-contracts/launch-your-fir
 ---
 title: Test and Deploy with Hardhat
 description: Learn how to set up a Hardhat development environment, write comprehensive tests for a Solidity smart contract, and deploy it to local and Asset Hub networks.
+tutorial_badge: Intermediate
 ---
 
 # Test and Deploy with Hardhat


### PR DESCRIPTION
This PR fixes the endpoint used in https://papermoonio.github.io/polkadot-mkdocs/develop/smart-contracts/json-rpc-apis/, since when executing an eth request to https://westend-asset-hub-rpc.polkadot.io it would not work. Instead, the proper endpoint to use when calling eth methods is - https://westend-asset-hub-eth-rpc.polkadot.io.