### PR TITLE
Apply temporary fix to Set Up a Template tutorial

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -26782,9 +26782,10 @@ The [Polkadot SDK Parachain Template](https://github.com/paritytech/polkadot-sdk
     git clone https://github.com/paritytech/polkadot-sdk-parachain-template.git parachain-template
     ```
 
-2. Navigate to the root of the template directory:
+2. Navigate into the project directory and check out the specific commit:
     ```bash
     cd parachain-template
+    git checkout ecaf71d
     ```
 
 3. Compile the runtime:

--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -63,9 +63,10 @@ The [Polkadot SDK Parachain Template](https://github.com/paritytech/polkadot-sdk
     git clone https://github.com/paritytech/polkadot-sdk-parachain-template.git parachain-template
     ```
 
-2. Navigate to the root of the template directory:
+2. Navigate into the project directory and check out the specific commit:
     ```bash
     cd parachain-template
+    git checkout ecaf71d
     ```
 
 3. Compile the runtime:


### PR DESCRIPTION
The parachain-template was [recently updated](https://github.com/paritytech/polkadot-sdk-parachain-template/issues/24#issuecomment-2815076325) to use the stable-2412 release, which introduces changes that are not yet reflected in the Zero-to-Hero pallet tutorial.

This PR temporarily pins the template to a known working commit (ecaf71d) to ensure the tutorial remains functional while we work on updating the docs to match the latest changes.