### PR TITLE
Update deploy-to-testnet.md

### DIFF
--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/deploy-to-testnet.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/deploy-to-testnet.md
@@ -159,7 +159,7 @@ To prepare the parachain collator to be registered on Paseo, follow these steps:
     --chain raw_chain_spec.json para-wasm
     ```
 
-2. Export the genesis state for the parachain by running the following command:
+2. Export the genesis state for the parachain by running the following command (This does not work anymore on Mac Silicon and Ubuntu 24.01):
 
     ```bash
     polkadot-omni-node export-genesis-state \


### PR DESCRIPTION
Exporting the genesis state for the parachain is no longer working.

Error: 
   0: Failed to get runtime version: Other error happened while constructing the runtime: runtime requires function imports which are not present on the host: 'env:ext_benchmarking_read_write_count_version_1', 'env:ext_benchmarking_current_time_version_1', 'env:ext_benchmarking_wipe_db_version_1', 'env:ext_benchmarking_commit_db_version_1', 'env:ext_benchmarking_set_whitelist_version_1', 'env:ext_benchmarking_get_read_and_written_keys_version_1', 'env:ext_benchmarking_proof_size_version_1', 'env:ext_benchmarking_reset_read_write_count_version_1', 'env:ext_benchmarking_add_to_whitelist_version_1'