### PR TITLE
Update dependencies

### DIFF
--- a/.github/scripts/check_dependencies.py
+++ b/.github/scripts/check_dependencies.py
@@ -73,6 +73,10 @@ def check_releases(releases_source_file):
             continue
         
         for name, info in items.items():
+            # Skip dependencies marked with ignore_updates=true
+            if info.get("ignore_updates", False):
+                continue
+            
             current_version = info.get("version")
             latest_version, latest_url = REGISTRIES[category](info)
             

--- a/variables.yml
+++ b/variables.yml
@@ -53,7 +53,7 @@ dependencies:
       version: 5.9.1
     polkadot_js_api:
       name: '@polkadot/api'
-      version: 15.9.1
+      version: 15.9.2
     polkadot_api:
       name: polkadot-api
       version: 1.10.1

--- a/variables.yml
+++ b/variables.yml
@@ -60,5 +60,5 @@ dependencies:
       version: 15.9.1
     polkadot_api:
       name: polkadot-api
-      version: 1.9.9
+      version: 1.10.1
 #   python_packages:

--- a/variables.yml
+++ b/variables.yml
@@ -7,14 +7,10 @@ dependencies:
       architecture: macos-arm64
     asset_transfer_api:
       repository_url: https://github.com/paritytech/asset-transfer-api
-      version: v0.6.0
+      version: v0.6.1
     polkadot_sdk_solochain_template:
       repository_url: https://github.com/paritytech/polkadot-sdk-solochain-template
       version: v0.0.2
-    polkadot_js_api:
-      repository_url: https://github.com/polkadot-js/api
-      version: v15.0.2
-      ignore_updates: true # This specific version is used in asset-transfer-api. Should only be updated when asset-transfer-api is updated.
     srtool:
       repository_url: https://github.com/paritytech/srtool
       version: v0.18.2
@@ -50,8 +46,8 @@ dependencies:
       version: 1.0.4
     asset_transfer_api:
       name: '@substrate/asset-transfer-api'
-      version: 0.6.0
-      polkadot_js_api_version: v15.8.1 # Check changelog for pjs version bumps
+      version: 0.6.1
+      polkadot_js_api_version: v15.9.2 # Check changelog for pjs version bumps
     moonwall:
       name: '@moonwall/cli'
       version: 5.9.1

--- a/variables.yml
+++ b/variables.yml
@@ -14,6 +14,7 @@ dependencies:
     polkadot_js_api:
       repository_url: https://github.com/polkadot-js/api
       version: v15.0.2
+      ignore_updates: true # This specific version is used in asset-transfer-api. Should only be updated when asset-transfer-api is updated.
     srtool:
       repository_url: https://github.com/paritytech/srtool
       version: v0.18.2
@@ -36,6 +37,7 @@ dependencies:
     tokio:
       name: tokio
       version: 1.44.2
+      ignore_updates: true
     chain_spec_builder:
       name: staging-chain-spec-builder
       version: 10.0.0

--- a/variables.yml
+++ b/variables.yml
@@ -50,7 +50,7 @@ dependencies:
       polkadot_js_api_version: v15.9.2 # Check changelog for pjs version bumps
     moonwall:
       name: '@moonwall/cli'
-      version: 5.9.1
+      version: 5.11.0
     polkadot_js_api:
       name: '@polkadot/api'
       version: 15.9.2


### PR DESCRIPTION
Update dependencies to the latest versions:
- Polkadot JS Api
- PAPI
- Asset Transfer API
- Moonwall

Improve gh action to bypass dependency checks for any packages explicitly marked with `ignore_updates: true` flag.

