### PR TITLE
[FIX]- adding Hardhat binary configuration section and path instructions

### DIFF
--- a/develop/smart-contracts/dev-environments/hardhat.md
+++ b/develop/smart-contracts/dev-environments/hardhat.md
@@ -146,7 +146,7 @@ To run your test:
     Ensure to replace `INSERT_PATH_TO_SUBSTRATE_NODE` and `INSERT_PATH_TO_ETH_RPC_ADAPTER` with the proper paths to the compiled binaries. To obtain these binaries, you can run the following commands:
 
     ```bash
-    git clone https://github.com/paritytech/polkadot-sdk.git
+    git clone https://github.com/paritytech/polkadot-sdk.git && cd polkadot-sdk
     ```
 
     And then build the binaries:

--- a/develop/smart-contracts/dev-environments/hardhat.md
+++ b/develop/smart-contracts/dev-environments/hardhat.md
@@ -84,7 +84,7 @@ To compile your project, follow these instructions:
 
     === "npm Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="10-21"
+        ```javascript title="hardhat.config.js" hl_lines="9-20"
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:1:21'
           --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:37:39'
             --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:49:49'
@@ -93,7 +93,7 @@ To compile your project, follow these instructions:
 
     === "Binary Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="10-23"
+        ```javascript title="hardhat.config.js" hl_lines="9-22"
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:1:8'
           --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:22:36'
           --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:37:39'
@@ -129,7 +129,7 @@ To run your test:
 
     === "npm Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="25-33"
+        ```javascript title="hardhat.config.js" hl_lines="24-32"
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:1:21'
           --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:37:49'
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:59:60'
@@ -137,7 +137,7 @@ To run your test:
 
     === "Binary Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="27-35"
+        ```javascript title="hardhat.config.js" hl_lines="26-34"
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:1:8'
           --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:22:49'
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:59:60'
@@ -150,10 +150,10 @@ To run your test:
 
     For example, if you cloned the polkadot-sdk repository to your home directory, the paths might look like:
 
-        ```javascript
-        nodeBinaryPath: '/home/username/polkadot-sdk/target/release/substrate-node',
-        adapterBinaryPath: '/home/username/polkadot-sdk/target/release/eth-rpc',
-        ```
+    ```javascript
+    nodeBinaryPath: '/home/username/polkadot-sdk/target/release/substrate-node',
+    adapterBinaryPath: '/home/username/polkadot-sdk/target/release/eth-rpc',
+    ```
 
 2. Execute the following command:
 
@@ -183,7 +183,7 @@ Before deploying to a live network, you can deploy your contract to a local node
 
     === "npm Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="35-38"
+        ```javascript title="hardhat.config.js" hl_lines="34-37"
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:1:21'
           --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:37:53'
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:59:60'
@@ -191,7 +191,7 @@ Before deploying to a live network, you can deploy your contract to a local node
 
     === "Binary Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="37-40"
+        ```javascript title="hardhat.config.js" hl_lines="36-39"
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:1:8'
           --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:22:53'
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:59:60'
@@ -236,7 +236,7 @@ After testing your contract locally, you can deploy it to a live network. This g
 
 4. Update your config to load it:
 
-    ```javascript title="hardhat.config.js" hl_lines="6"
+    ```javascript title="hardhat.config.js" hl_lines="5"
     --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:1:4'
 
     require('dotenv').config();
@@ -250,7 +250,7 @@ After testing your contract locally, you can deploy it to a live network. This g
 
     === "npm Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="42-46"
+        ```javascript title="hardhat.config.js" hl_lines="41-45"
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:1:4'
 
         require('dotenv').config();
@@ -263,7 +263,7 @@ After testing your contract locally, you can deploy it to a live network. This g
 
     === "Binary Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="46-50"
+        ```javascript title="hardhat.config.js" hl_lines="45-49"
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:1:4'
 
         require('dotenv').config();

--- a/develop/smart-contracts/dev-environments/hardhat.md
+++ b/develop/smart-contracts/dev-environments/hardhat.md
@@ -158,8 +158,8 @@ To run your test:
     
     Since you compiled these from source using Rust's Cargo build system, you can find them at:
 
-    - Substrate node path - `polkadot-sdk/target/release/substrate-node`
-    - ETH-RPC adapter path - `polkadot-sdk/target/release/eth-rpc`
+    - **Substrate node path** - `polkadot-sdk/target/release/substrate-node`
+    - **ETH-RPC adapter path** - `polkadot-sdk/target/release/eth-rpc`
 
     For example, if you cloned the polkadot-sdk repository to your home directory, the paths might look like:
 

--- a/develop/smart-contracts/dev-environments/hardhat.md
+++ b/develop/smart-contracts/dev-environments/hardhat.md
@@ -143,6 +143,18 @@ To run your test:
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:59:60'
         ```
 
+    Ensure to replace `INSERT_PATH_TO_SUBSTRATE_NODE` and `INSERT_PATH_TO_ETH_RPC_ADAPTER` with the proper paths to the compiled binaries. Since you compiled these from source using Rust's Cargo build system, you can find them at:
+
+    - Substrate node path - `polkadot-sdk/target/release/substrate-node`
+    - ETH-RPC adapter path - `polkadot-sdk/target/release/eth-rpc`
+
+    For example, if you cloned the polkadot-sdk repository to your home directory, the paths might look like:
+
+        ```javascript
+        nodeBinaryPath: '/home/username/polkadot-sdk/target/release/substrate-node',
+        adapterBinaryPath: '/home/username/polkadot-sdk/target/release/eth-rpc',
+        ```
+
 2. Execute the following command:
 
     ```bash

--- a/develop/smart-contracts/dev-environments/hardhat.md
+++ b/develop/smart-contracts/dev-environments/hardhat.md
@@ -143,7 +143,20 @@ To run your test:
         --8<-- 'code/develop/smart-contracts/dev-environments/hardhat/hardhat.config.js:59:60'
         ```
 
-    Ensure to replace `INSERT_PATH_TO_SUBSTRATE_NODE` and `INSERT_PATH_TO_ETH_RPC_ADAPTER` with the proper paths to the compiled binaries. Since you compiled these from source using Rust's Cargo build system, you can find them at:
+    Ensure to replace `INSERT_PATH_TO_SUBSTRATE_NODE` and `INSERT_PATH_TO_ETH_RPC_ADAPTER` with the proper paths to the compiled binaries. To obtain these binaries, you can run the following commands:
+
+    ```bash
+    git clone https://github.com/paritytech/polkadot-sdk.git
+    ```
+
+    And then build the binaries:
+
+    ```bash
+    cargo build --bin substrate-node --release
+    cargo build -p pallet-revive-eth-rpc --bin eth-rpc --release
+    ```
+    
+    Since you compiled these from source using Rust's Cargo build system, you can find them at:
 
     - Substrate node path - `polkadot-sdk/target/release/substrate-node`
     - ETH-RPC adapter path - `polkadot-sdk/target/release/eth-rpc`

--- a/llms.txt
+++ b/llms.txt
@@ -6316,7 +6316,7 @@ To compile your project, follow these instructions:
 
     === "npm Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="10-21"
+        ```javascript title="hardhat.config.js" hl_lines="9-20"
         require('@nomicfoundation/hardhat-toolbox');
 
 require('@parity/hardhat-polkadot');
@@ -6345,7 +6345,7 @@ module.exports = {
 
     === "Binary Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="10-23"
+        ```javascript title="hardhat.config.js" hl_lines="9-22"
         require('@nomicfoundation/hardhat-toolbox');
 
 require('@parity/hardhat-polkadot');
@@ -6401,7 +6401,7 @@ To run your test:
 
     === "npm Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="25-33"
+        ```javascript title="hardhat.config.js" hl_lines="24-32"
         require('@nomicfoundation/hardhat-toolbox');
 
 require('@parity/hardhat-polkadot');
@@ -6439,7 +6439,7 @@ module.exports = {
 
     === "Binary Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="27-35"
+        ```javascript title="hardhat.config.js" hl_lines="26-34"
         require('@nomicfoundation/hardhat-toolbox');
 
 require('@parity/hardhat-polkadot');
@@ -6484,10 +6484,10 @@ module.exports = {
 
     For example, if you cloned the polkadot-sdk repository to your home directory, the paths might look like:
 
-        ```javascript
-        nodeBinaryPath: '/home/username/polkadot-sdk/target/release/substrate-node',
-        adapterBinaryPath: '/home/username/polkadot-sdk/target/release/eth-rpc',
-        ```
+    ```javascript
+    nodeBinaryPath: '/home/username/polkadot-sdk/target/release/substrate-node',
+    adapterBinaryPath: '/home/username/polkadot-sdk/target/release/eth-rpc',
+    ```
 
 2. Execute the following command:
 
@@ -6527,7 +6527,7 @@ const contract = await ContractFactory.deploy(...constructorArgs);
 
     === "npm Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="35-38"
+        ```javascript title="hardhat.config.js" hl_lines="34-37"
         require('@nomicfoundation/hardhat-toolbox');
 
 require('@parity/hardhat-polkadot');
@@ -6569,7 +6569,7 @@ module.exports = {
 
     === "Binary Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="37-40"
+        ```javascript title="hardhat.config.js" hl_lines="36-39"
         require('@nomicfoundation/hardhat-toolbox');
 
 require('@parity/hardhat-polkadot');
@@ -6650,7 +6650,7 @@ After testing your contract locally, you can deploy it to a live network. This g
 
 4. Update your config to load it:
 
-    ```javascript title="hardhat.config.js" hl_lines="6"
+    ```javascript title="hardhat.config.js" hl_lines="5"
     require('@nomicfoundation/hardhat-toolbox');
 
 require('@parity/hardhat-polkadot');
@@ -6666,7 +6666,7 @@ require('@parity/hardhat-polkadot');
 
     === "npm Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="42-46"
+        ```javascript title="hardhat.config.js" hl_lines="41-45"
         require('@nomicfoundation/hardhat-toolbox');
 
 require('@parity/hardhat-polkadot');
@@ -6715,7 +6715,7 @@ require('@parity/hardhat-polkadot');
 
     === "Binary Configuration"
 
-        ```javascript title="hardhat.config.js" hl_lines="46-50"
+        ```javascript title="hardhat.config.js" hl_lines="45-49"
         require('@nomicfoundation/hardhat-toolbox');
 
 require('@parity/hardhat-polkadot');

--- a/llms.txt
+++ b/llms.txt
@@ -6477,6 +6477,18 @@ module.exports = {
         };
         ```
 
+    Ensure to replace `INSERT_PATH_TO_SUBSTRATE_NODE` and `INSERT_PATH_TO_ETH_RPC_ADAPTER` with the proper paths to the compiled binaries. Since you compiled these from source using Rust's Cargo build system, you can find them at:
+
+    - Substrate node path - `polkadot-sdk/target/release/substrate-node`
+    - ETH-RPC adapter path - `polkadot-sdk/target/release/eth-rpc`
+
+    For example, if you cloned the polkadot-sdk repository to your home directory, the paths might look like:
+
+        ```javascript
+        nodeBinaryPath: '/home/username/polkadot-sdk/target/release/substrate-node',
+        adapterBinaryPath: '/home/username/polkadot-sdk/target/release/eth-rpc',
+        ```
+
 2. Execute the following command:
 
     ```bash

--- a/llms.txt
+++ b/llms.txt
@@ -6477,7 +6477,20 @@ module.exports = {
         };
         ```
 
-    Ensure to replace `INSERT_PATH_TO_SUBSTRATE_NODE` and `INSERT_PATH_TO_ETH_RPC_ADAPTER` with the proper paths to the compiled binaries. Since you compiled these from source using Rust's Cargo build system, you can find them at:
+    Ensure to replace `INSERT_PATH_TO_SUBSTRATE_NODE` and `INSERT_PATH_TO_ETH_RPC_ADAPTER` with the proper paths to the compiled binaries. To obtain these binaries, you can run the following commands:
+
+    ```bash
+    git clone https://github.com/paritytech/polkadot-sdk.git
+    ```
+
+    And then build the binaries:
+
+    ```bash
+    cargo build --bin substrate-node --release
+    cargo build -p pallet-revive-eth-rpc --bin eth-rpc --release
+    ```
+    
+    Since you compiled these from source using Rust's Cargo build system, you can find them at:
 
     - Substrate node path - `polkadot-sdk/target/release/substrate-node`
     - ETH-RPC adapter path - `polkadot-sdk/target/release/eth-rpc`

--- a/llms.txt
+++ b/llms.txt
@@ -6480,7 +6480,7 @@ module.exports = {
     Ensure to replace `INSERT_PATH_TO_SUBSTRATE_NODE` and `INSERT_PATH_TO_ETH_RPC_ADAPTER` with the proper paths to the compiled binaries. To obtain these binaries, you can run the following commands:
 
     ```bash
-    git clone https://github.com/paritytech/polkadot-sdk.git
+    git clone https://github.com/paritytech/polkadot-sdk.git && cd polkadot-sdk
     ```
 
     And then build the binaries:


### PR DESCRIPTION
Fixing highlights in hardhat guide snippets and enhancing the Binary Configuration section with a clear disclaimer on binary paths.