### PR TITLE
branch stable2412 instructions fail with rustc 1.87

### DIFF
--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -60,7 +60,7 @@ The [Polkadot SDK Parachain Template](https://github.com/paritytech/polkadot-sdk
 
 1. Clone the template repository:
     ```bash
-    git clone -b stable2412 https://github.com/paritytech/polkadot-sdk-parachain-template.git parachain-template
+    git clone https://github.com/paritytech/polkadot-sdk-parachain-template.git parachain-template
     ```
 
 2. Navigate into the project directory:


### PR DESCRIPTION
In order to compile the runtime in this page it was instructed to clone the branch stable2412.

A recent update of rustc to version 1.87 generates an error solved with this:https://github.com/paritytech/polkadot-sdk/pull/8198 and merged to main
hence
If we indicate to the user to clone main, the fix will be there and the user will be able to follow the instructions successfully