### PR TITLE
Add temple for creating and issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs-issue.yml
@@ -1,0 +1,36 @@
+name: 📚 Report a documentation issue
+description: Found a typo, broken link, or unclear section? Let us know.
+title: "[Docs] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to improve our documentation!
+
+  - type: input
+    id: page
+    attributes:
+      label: Page URL
+      description: Link to the page where the issue appears
+      placeholder: https://docs.polkadot.network/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: What’s the issue?
+      description: Describe what you found confusing, incorrect or broken
+      placeholder: The section on staking is unclear because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: How could we improve this part?
+      placeholder: Maybe add a diagram, or explain the term 'nominator' earlier...
+    validations:
+      required: false


### PR DESCRIPTION
This PR adds a template for creating the issue button.
This PR needs to be merged with this one: https://github.com/papermoonio/polkadot-mkdocs/pull/94

*Reminder that it can only be tested in production*