### PR TITLE
[FIX] - Evm vs polka vm page update

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -21893,7 +21893,7 @@ However, this architectural difference becomes relevant in specific scenarios. T
 
 This primarily affects contracts using [`EXTCODECOPY`](https://www.evm.codes/?fork=cancun#3c){target=\_blank} to manipulate code at runtime. A contract encounters problems specifically when it uses `EXTCODECOPY` to copy contract code into memory and then attempts to mutate it. This pattern is not possible in standard Solidity and requires dropping down to YUL assembly. An example would be a factory contract written in assembly that constructs and instantiates new contracts by generating code at runtime. Such contracts are rare in practice.
 
-PolkaVM offers an elegant alternative through its [on-chain constructors](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/struct.Pallet.html#method.bare_instantiate){target=\_blank}, enabling contract instantiation without runtime code modification, making this pattern unnecessary.
+PolkaVM offers an elegant alternative through its [on-chain constructors](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/struct.Pallet.html#method.bare_instantiate){target=\_blank}, enabling contract instantiation without runtime code modification, making this pattern unnecessary. This architectural difference also impacts how contract deployment works more broadly, as discussed in the [Contract Deployment](#contract-deployment) section.
 
 ### High-Level Architecture Comparison
 
@@ -21985,7 +21985,6 @@ Ethereum and Polkadot handle account persistence differently, affecting state ma
 |          Feature          |                   Ethereum Approach                   |               PolkaVM/Polkadot Approach                |
 | :-----------------------: | :---------------------------------------------------: | :----------------------------------------------------: |
 |  **Account Persistence**  | Accounts persist indefinitely, even with zero balance | Requires existential deposit (ED) to maintain account  |
-|  **Account Persistence**  |  Accounts exist indefinitely, even with zero balance  | Requires existential deposit (ED) to maintain account  |
 |    **Minimum Balance**    |                         None                          |                      ED required                       |
 |   **Account Deletion**    |               Accounts remain in state                |      Accounts below ED are automatically deleted       |
 |   **Contract Accounts**   |                  Exist indefinitely                   |                    Must maintain ED                    |
@@ -22017,11 +22016,7 @@ In the PolkaVM, contract deployment follows a fundamentally different model from
 - **Factory pattern limitations** - the common EVM pattern, where contracts dynamically create other contracts, will fail with `CodeNotFound` error unless the dependent contract code was previously uploaded
 - **Separate upload and instantiation** - this creates a two-step process where developers must first upload all contract code, then instantiate relationships between contracts
 
-This architecture impacts several common EVM patterns:
-
-- Factory contracts must be modified to work with pre-uploaded code rather than embedding bytecode
-- [`create`](https://www.evm.codes/?fork=cancun#f0){target=\_blank} and [`create2`](https://www.evm.codes/?fork=cancun#f5){target=\_blank} deployments need adaptation since they can't dynamically generate contract code
-- Runtime code generation is not supported due to PolkaVM's RISC-V bytecode format
+This architecture impacts several common EVM patterns and requires developers to adapt their deployment strategies accordingly. *Factory contracts must be modified to work with pre-uploaded code rather than embedding bytecode*, and runtime code generation is not supported due to PolkaVM's RISC-V bytecode format. The specific behavior of contract creation opcodes is detailed in the [YUL IR Translation](#yul-function-translation-differences) section.
 
 When migrating EVM projects to PolkaVM, developers should identify all contracts that will be instantiated at runtime and ensure they are pre-uploaded to the chain before any instantiation attempts.
 

--- a/llms.txt
+++ b/llms.txt
@@ -22012,7 +22012,7 @@ For most users deploying contracts (like ERC-20 tokens), contract deployment wor
 In the PolkaVM, contract deployment follows a fundamentally different model from EVM. The EVM allows contracts to be deployed with a single transaction, where the contract code is bundled with the deployment transaction. In contrast, PolkaVM has a different process for contract instantiation.
 
 - **Code must be pre-uploaded** - unlike EVM, where contract code is bundled within the deploying contract, PolkaVM requires all contract bytecode to be uploaded to the chain before instantiation
-- **Factory pattern limitations** - the common EVM pattern, where contracts dynamically create other contracts, will fail with `CodeNotFound` error unless the dependent contract code was previously uploaded
+- **Factory pattern limitations** - the common EVM pattern, where contracts dynamically create other contracts, will fail with a `CodeNotFound` error unless the dependent contract code was previously uploaded
 - **Separate upload and instantiation** - this creates a two-step process where developers must first upload all contract code, then instantiate relationships between contracts
 
 This architecture impacts several common EVM patterns and requires developers to adapt their deployment strategies accordingly. _Factory contracts must be modified to work with pre-uploaded code rather than embedding bytecode_, and runtime code generation is not supported due to PolkaVM's RISC-V bytecode format. The specific behavior of contract creation opcodes is detailed in the [YUL IR Translation](#yul-function-translation-differences) section.

--- a/llms.txt
+++ b/llms.txt
@@ -21936,8 +21936,8 @@ These resources can also be limited when making cross-contract calls, which is e
 
 When resources are "uncapped" in cross-contract calls, they remain constrained by transaction-specified limits, preventing abuse of the transaction signer.
 
-!!!info
-The runtime will provide a special precompile, allowing cross-contract calls with limits specified for all weight dimensions in the future.
+!!! note
+    The runtime will provide a special precompile, allowing cross-contract calls with limits specified for all weight dimensions in the future.
 
 All gas-related opcodes like [`GAS`](https://www.evm.codes/?fork=cancun#5a){target=\_blank} or [`GAS_LIMIT`](https://www.evm.codes/?fork=cancun#45){target=\_blank} return only the `ref_time` value as it's the closest match to traditional gas. Extended APIs will be provided through precompiles to make full use of all resources, including cross-contract calls with all three resources specified.
 
@@ -21972,8 +21972,8 @@ The following table depicts memory-related limits at the time of writing:
 |            Immutable variables             | 16 uint values  |
 |          Contract code blob size           | ~100 kilobytes  |
 
-!!! info
-Limits might be increased in the future. To guarantee existing contracts work as expected, limits will never be decreased.
+!!! note
+    Limits might be increased in the future. To guarantee existing contracts work as expected, limits will never be decreased.
 
 ## Account Management - Existential Deposit
 
@@ -22031,7 +22031,7 @@ In constructor code, the `codesize` instruction returns the call data size inste
 
 ### Solidity-Specific Differences
 
-Several Solidity constructs behave differently under PolkaVM:
+Solidity constructs behave differently under PolkaVM:
 
 - **`address.creationCode`** - returns the bytecode keccak256 hash instead of the actual creation code, reflecting PolkaVM's hash-based code referencing system
 
@@ -22066,10 +22066,8 @@ The following YUL functions exhibit notable behavioral differences in PolkaVM:
     - The compiler detects `address payable.{send,transfer}` patterns and disables call reentrancy as a protective heuristic
     - Using `address payable.{send,transfer}` is already deprecated; PolkaVM will provide dedicated precompiles for safe balance transfers
 
-    !!!warning
-    The 2300 gas stipend that is provided by solc for address payable.{send, transfer} calls offers no reentrancy protection in PolkaVM. While the compiler attempts to detect and mitigate this pattern, developers should avoid these deprecated functions.
-
-
+    !!! warning
+        The 2300 gas stipend that is provided by solc for address payable.{send, transfer} calls offers no reentrancy protection in PolkaVM. While the compiler attempts to detect and mitigate this pattern, developers should avoid these deprecated functions.
 
 - **Contract Creation:**
 
@@ -22080,15 +22078,15 @@ The following YUL functions exhibit notable behavioral differences in PolkaVM:
 
     PolkaVM translates `dataoffset` and `datasize` instructions to handle contract hashes instead of contract code, enabling seamless use of the `new` keyword in Solidity. However, this translation may fail for contracts creating other contracts within `assembly` blocks.
 
-    !!!warning
-    Avoid using `create` family opcodes for manual deployment crafting in `assembly` blocks. This pattern is discouraged due to translation complexity and offers no gas savings benefits in PolkaVM.
+    !!! warning
+        Avoid using `create` family opcodes for manual deployment crafting in `assembly` blocks. This pattern is discouraged due to translation complexity and offers no gas savings benefits in PolkaVM.
 
-- **Data Operations**
+- **Data Operations:**
 
   - **`dataoffset`** - returns the contract hash instead of code offset, aligning with PolkaVM's hash-based code referencing
   - **`datasize`** - returns the constant contract hash size (32 bytes) rather than variable code size
 
-- Resource Queries
+- **Resource Queries:**
 
   - **`gas`, `gaslimit`** - return only the `ref_time` component of PolkaVM's multi-dimensional weight system, providing the closest analog to traditional gas measurements
 

--- a/llms.txt
+++ b/llms.txt
@@ -21903,7 +21903,7 @@ PolkaVM offers an elegant alternative through its [on-chain constructors](https:
 |      **Bytecode Format**      |                                     EVM bytecode                                     |                     RISC-V format                      |
 |    **Contract Size Limit**    |                                 24KB code size limit                                 |            Contract-specific memory limits             |
 |         **Compiler**          |                                  Solidity Compiler                                   |                    Revive Compiler                     |
-|      **Inline Assembly**      |                                      Supported                                       |           Supported with compatibility layer           |
+|      **Inline Assembly**      |                                      Supported                                       |         Supported with the compatibility layer         |
 |    **Code Introspection**     | Supported via [`EXTCODECOPY`](https://www.evm.codes/?fork=cancun#3c){target=\_blank} | Limited support, alternative via on-chain constructors |
 |     **Resource Metering**     |                                  Single gas metric                                   |                   Multi-dimensional                    |
 | **Runtime Code Modification** |                                      Supported                                       |               Limited, with alternatives               |
@@ -21937,7 +21937,7 @@ These resources can also be limited when making cross-contract calls, which is e
 When resources are "uncapped" in cross-contract calls, they remain constrained by transaction-specified limits, preventing abuse of the transaction signer.
 
 !!!info
-    The runtime will provide a special precompile allowing cross-contract calls with limits specified for all weight dimensions in the future.
+The runtime will provide a special precompile, allowing cross-contract calls with limits specified for all weight dimensions in the future.
 
 All gas-related opcodes like [`GAS`](https://www.evm.codes/?fork=cancun#5a){target=\_blank} or [`GAS_LIMIT`](https://www.evm.codes/?fork=cancun#45){target=\_blank} return only the `ref_time` value as it's the closest match to traditional gas. Extended APIs will be provided through precompiles to make full use of all resources, including cross-contract calls with all three resources specified.
 
@@ -21962,19 +21962,18 @@ The architecture establishes a constant memory limit per contract, which is the 
 
 The following table depicts memory-related limits at the time of writing:
 
-| Limit                                      | Maximum         |
+|                   Limit                    |     Maximum     |
 | :----------------------------------------: | :-------------: |
-| Call stack depth                           | 5               |
-| Event topics                               | 4               |
-| Event data payload size (including topics) | 416 bytes       |
-| Storage value size                         | 416 bytes       |
-| Transient storage variables                | 128 uint values |
-| Immutable variables                        | 16 uint values  |
-| Contract code blob size                    | ~100 kilobytes  |
+|              Call stack depth              |        5        |
+|                Event topics                |        4        |
+| Event data payload size (including topics) |    416 bytes    |
+|             Storage value size             |    416 bytes    |
+|        Transient storage variables         | 128 uint values |
+|            Immutable variables             | 16 uint values  |
+|          Contract code blob size           | ~100 kilobytes  |
 
 !!! info
-    Limits might be increased in the future. To guarantee existing contracts work as expected, limits will never be decreased.
-
+Limits might be increased in the future. To guarantee existing contracts work as expected, limits will never be decreased.
 
 ## Account Management - Existential Deposit
 
@@ -22016,7 +22015,7 @@ In the PolkaVM, contract deployment follows a fundamentally different model from
 - **Factory pattern limitations** - the common EVM pattern, where contracts dynamically create other contracts, will fail with `CodeNotFound` error unless the dependent contract code was previously uploaded
 - **Separate upload and instantiation** - this creates a two-step process where developers must first upload all contract code, then instantiate relationships between contracts
 
-This architecture impacts several common EVM patterns and requires developers to adapt their deployment strategies accordingly. *Factory contracts must be modified to work with pre-uploaded code rather than embedding bytecode*, and runtime code generation is not supported due to PolkaVM's RISC-V bytecode format. The specific behavior of contract creation opcodes is detailed in the [YUL IR Translation](#yul-function-translation-differences) section.
+This architecture impacts several common EVM patterns and requires developers to adapt their deployment strategies accordingly. _Factory contracts must be modified to work with pre-uploaded code rather than embedding bytecode_, and runtime code generation is not supported due to PolkaVM's RISC-V bytecode format. The specific behavior of contract creation opcodes is detailed in the [YUL IR Translation](#yul-function-translation-differences) section.
 
 When migrating EVM projects to PolkaVM, developers should identify all contracts that will be instantiated at runtime and ensure they are pre-uploaded to the chain before any instantiation attempts.
 
@@ -22041,49 +22040,60 @@ Several Solidity constructs behave differently under PolkaVM:
 The following YUL functions exhibit notable behavioral differences in PolkaVM:
 
 - **Memory Operations:**
-    - **`mload`, `mstore`, `msize`, `mcopy`** - PolkaVM preserves memory layout but implements several constraints:
-        - EVM linear heap memory is emulated using a fixed 64KB byte buffer, limiting maximum contract memory usage
-        - Accessing memory offsets larger than the buffer size traps the contract with an `OutOfBound` error
-        - Compiler optimizations may eliminate unused memory operations, potentially causing `msize` to differ from EVM behavior
+
+  - **`mload`, `mstore`, `msize`, `mcopy`** - PolkaVM preserves memory layout but implements several constraints:
+    - EVM linear heap memory is emulated using a fixed 64KB byte buffer, limiting maximum contract memory usage
+    - Accessing memory offsets larger than the buffer size traps the contract with an `OutOfBound` error
+    - Compiler optimizations may eliminate unused memory operations, potentially causing `msize` to differ from EVM behavior
 
 - **Call Data Operations:**
-    - **`calldataload`, `calldatacopy`** - in constructor code, the offset parameter is ignored and these functions always return `0`, diverging from EVM behavior where call data represents constructor arguments
+
+  - **`calldataload`, `calldatacopy`** - in constructor code, the offset parameter is ignored and these functions always return `0`, diverging from EVM behavior where call data represents constructor arguments
 
 - **Code Operations:**
-    - **`codecopy`** - only supported within constructor code, reflecting PolkaVM's different approach to code handling and the unified code blob structure
+
+  - **`codecopy`** - only supported within constructor code, reflecting PolkaVM's different approach to code handling and the unified code blob structure
 
 - **Control Flow:**
-    - **`invalid`** - traps the contract execution but does not consume remaining gas, unlike EVM where it consumes all available gas
+
+  - **`invalid`** - traps the contract execution but does not consume remaining gas, unlike EVM where it consumes all available gas
 
 - **Cross-Contract Calls:**
-    - **`call`, `delegatecall`, `staticall`** - these functions ignore supplied gas limits and forward all remaining resources due to PolkaVM's multi-dimensional resource model. This creates important security implications:
 
-        - Contract authors must implement reentrancy protection since gas stipends don't provide protection
-        - The compiler detects `address payable.{send,transfer}` patterns and disables call reentrancy as a protective heuristic
-        - Using `address payable.{send,transfer}` is already deprecated; PolkaVM will provide dedicated precompiles for safe balance transfers
+  - **`call`, `delegatecall`, `staticall`** - these functions ignore supplied gas limits and forward all remaining resources due to PolkaVM's multi-dimensional resource model. This creates important security implications:
 
-        !!!warning
-            The 2300 gas stipend provided by `solc` for `address payable.{send,transfer}` calls offers no reentrancy protection in PolkaVM. While the compiler attempts to detect and mitigate this pattern, developers should avoid these deprecated functions.
+    - Contract authors must implement reentrancy protection since gas stipends don't provide protection
+    - The compiler detects `address payable.{send,transfer}` patterns and disables call reentrancy as a protective heuristic
+    - Using `address payable.{send,transfer}` is already deprecated; PolkaVM will provide dedicated precompiles for safe balance transfers
+
+    !!!warning
+    The 2300 gas stipend that is provided by solc for address payable.{send, transfer} calls offers no reentrancy protection in PolkaVM. While the compiler attempts to detect and mitigate this pattern, developers should avoid these deprecated functions.
+
+
 
 - **Contract Creation:**
-    - **`create`, `create2`** - contract instantiation works fundamentally differently in PolkaVM. Instead of supplying deploy code concatenated with constructor arguments, the runtime expects:
-        1. A buffer containing the code hash to deploy
-        2. The constructor arguments buffer
 
-        PolkaVM translates `dataoffset` and `datasize` instructions to handle contract hashes instead of contract code, enabling seamless use of the `new` keyword in Solidity. However, this translation may fail for contracts creating other contracts within `assembly` blocks.
+  - **`create`, `create2`** - contract instantiation works fundamentally differently in PolkaVM. Instead of supplying deploy code concatenated with constructor arguments, the runtime expects:
 
-        !!!warning
-            Avoid using `create` family opcodes for manual deployment crafting in `assembly` blocks. This pattern is discouraged due to translation complexity and offers no gas savings benefits in PolkaVM.
+    1. A buffer containing the code hash to deploy
+    2. The constructor arguments buffer
+
+    PolkaVM translates `dataoffset` and `datasize` instructions to handle contract hashes instead of contract code, enabling seamless use of the `new` keyword in Solidity. However, this translation may fail for contracts creating other contracts within `assembly` blocks.
+
+    !!!warning
+    Avoid using `create` family opcodes for manual deployment crafting in `assembly` blocks. This pattern is discouraged due to translation complexity and offers no gas savings benefits in PolkaVM.
 
 - **Data Operations**
-    - **`dataoffset`** - returns the contract hash instead of code offset, aligning with PolkaVM's hash-based code referencing
-    - **`datasize`** - returns the constant contract hash size (32 bytes) rather than variable code size
+
+  - **`dataoffset`** - returns the contract hash instead of code offset, aligning with PolkaVM's hash-based code referencing
+  - **`datasize`** - returns the constant contract hash size (32 bytes) rather than variable code size
 
 - Resource Queries
-    - **`gas`, `gaslimit`** - return only the `ref_time` component of PolkaVM's multi-dimensional weight system, providing the closest analog to traditional gas measurements
+
+  - **`gas`, `gaslimit`** - return only the `ref_time` component of PolkaVM's multi-dimensional weight system, providing the closest analog to traditional gas measurements
 
 - **Blockchain State:**
-    - **`prevrandao`, `difficulty`** - both translate to a constant value of `2500000000000000`, as PolkaVM doesn't implement Ethereum's difficulty adjustment or randomness mechanisms
+  - **`prevrandao`, `difficulty`** - both translate to a constant value of `2500000000000000`, as PolkaVM doesn't implement Ethereum's difficulty adjustment or randomness mechanisms
 
 ### Unsupported Operations
 

--- a/llms.txt
+++ b/llms.txt
@@ -6253,7 +6253,7 @@ You will need to collect some information related to the contract's compiler and
 
 Follow these steps to verify your contract on [Westend Hub Subscan](https://assethub-westend.subscan.io/){target=\_blank}:
 
-1. Navigate to the [Subscan explorer](https://assethub-westend.subscan.io/){target=\_blank} for the Westend Hub
+1. Navigate to the [Subscan explorer](https://assethub-westend.subscan.io/){target=\_blank} for Westend Hub
 2. Open the **Tools** dropdown and select **Contract Verification Tool**
 
     ![](/images/develop/smart-contracts/contract-verification/contract-verification-03.webp)
@@ -21860,6 +21860,8 @@ description: Compares EVM and PolkaVM, highlighting key architectural difference
 
 # EVM vs PolkaVM
 
+## Introduction
+
 While [PolkaVM](/polkadot-protocol/smart-contract-basics/polkavm-design/){target=\_blank} strives for maximum Ethereum compatibility, several fundamental design decisions create necessary divergences from the [EVM](https://ethereum.org/en/developers/docs/evm/){target=\_blank}. These differences represent trade-offs that enhance performance and resource management while maintaining accessibility for Solidity developers.
 
 ## Core Virtual Machine Architecture
@@ -21887,13 +21889,17 @@ graph TD
     PolkaExecution -.-> DifferencesNote
 ```
 
-However, this architectural difference becomes relevant in specific scenarios. Tools that attempt to download and inspect contract bytecode will fail, as they expect EVM bytecode rather than PolkaVM's RISC-V format. This primarily affects contracts using [`EXTCODECOPY`](https://www.evm.codes/?fork=cancun#3c){target=\_blank} to manipulate code at runtime, though such cases are rare. PolkaVM offers an elegant alternative through its [on-chain constructors](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/struct.Pallet.html#method.bare_instantiate){target=\_blank}, enabling contract instantiation without runtime code modification.
+However, this architectural difference becomes relevant in specific scenarios. Tools that attempt to download and inspect contract bytecode will fail, as they expect EVM bytecode rather than PolkaVM's RISC-V format. Most applications typically pass bytecode as an opaque blob, making this a non-issue for standard use cases.
+
+This primarily affects contracts using [`EXTCODECOPY`](https://www.evm.codes/?fork=cancun#3c){target=\_blank} to manipulate code at runtime. A contract encounters problems specifically when it uses `EXTCODECOPY` to copy contract code into memory and then attempts to mutate it. This pattern is not possible in standard Solidity and requires dropping down to YUL assembly. An example would be a factory contract written in assembly that constructs and instantiates new contracts by generating code at runtime. Such contracts are rare in practice.
+
+PolkaVM offers an elegant alternative through its [on-chain constructors](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/struct.Pallet.html#method.bare_instantiate){target=\_blank}, enabling contract instantiation without runtime code modification, making this pattern unnecessary.
 
 ### High-Level Architecture Comparison
 
 |            Feature            |                            Ethereum Virtual Machine (EVM)                            |                        PolkaVM                         |
 | :---------------------------: | :----------------------------------------------------------------------------------: | :----------------------------------------------------: |
-|      **Instruction Set**      |                           Stack-based architecture                                   |                 RISC-V instruction set                 |
+|      **Instruction Set**      |                               Stack-based architecture                               |                 RISC-V instruction set                 |
 |      **Bytecode Format**      |                                     EVM bytecode                                     |                     RISC-V format                      |
 |    **Contract Size Limit**    |                                 24KB code size limit                                 |            Contract-specific memory limits             |
 |         **Compiler**          |                                  Solidity Compiler                                   |                    Revive Compiler                     |
@@ -21921,30 +21927,54 @@ Moving beyond Ethereum's single gas metric, PolkaVM meters three distinct resour
 - **`proof_size`** - tracks state proof size for validator verification
 - **`storage_deposit`** - manages state bloat through a deposit system
 
-These three can be limited at the transaction level, just like gas on Ethereum. The Ethereum RPC proxy maps all three of these into the single dimension gas so that everything behaves as on Ethereum for users. This ensures that the transaction cost displayed in the wallet accurately represents the actual costs, even though it uses these three resources internally.
+All three resources can be limited at the transaction level, just like gas on Ethereum. The [Ethereum RPC proxy](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/frame/revive/rpc){target=\_blank} maps all three dimensions into the single gas dimension, ensuring everything behaves as expected for users.
 
-These resources can also be limited when making a cross-contract call. However, Solidity doesn't allow specifying anything other than `gas_limit` for a cross-contract call. The PolkaVM takes the `gas_limit` the contract supplies and uses that as `ref_time_limit.` The other two resources are just uncapped in this case. Please note that uncapped means the transaction-specified limits still constrain them, so this cannot be used to trick the signer of the transaction.
+These resources can also be limited when making cross-contract calls, which is essential for security when interacting with untrusted contracts. However, Solidity only allows specifying `gas_limit` for cross-contract calls. The `gas_limit` is most similar to Polkadots `ref_time_limit`, but the Revive compiler doesn't supply any imposed `gas_limit` for cross-contract calls for two key reasons:
 
-Resource limiting in cross-contract calls serves a critical security purpose, particularly when interacting with untrusted contracts.
+- **Semantic differences** - `gas_limit` and `ref_time_limit` are not semantically identical; blindly passing EVM gas as `ref_time_limit` can lead to unexpected behavior
+- **Incomplete protection** - the other two resources (`proof_size` and `storage_deposit`) would remain uncapped anyway, making it insufficient to prevent malicious callees from performing DOS attacks
 
-For compatibility, PolkaVM maps traditional gas-related operations to its `ref_time` metric, which is the closest analog to Ethereum's gas system.
+When resources are "uncapped" in cross-contract calls, they remain constrained by transaction-specified limits, preventing abuse of the transaction signer.
+
+!!!info
+    The runtime will provide a special precompile allowing cross-contract calls with limits specified for all weight dimensions in the future.
+
+All gas-related opcodes like [`GAS`](https://www.evm.codes/?fork=cancun#5a){target=\_blank} or [`GAS_LIMIT`](https://www.evm.codes/?fork=cancun#45){target=\_blank} return only the `ref_time` value as it's the closest match to traditional gas. Extended APIs will be provided through precompiles to make full use of all resources, including cross-contract calls with all three resources specified.
 
 ## Memory Management
 
 The EVM and the PolkaVM take fundamentally different approaches to memory constraints:
 
-|          Feature         |       Ethereum Virtual Machine (EVM)      |                   PolkaVM                      |
+|         Feature          |      Ethereum Virtual Machine (EVM)       |                    PolkaVM                     |
 | :----------------------: | :---------------------------------------: | :--------------------------------------------: |
-| **Memory Constraints**   | Indirect control via gas costs            | Hard memory limits per contract                |
-| **Cost Model**           | Increasing gas curve with allocation size | Fixed costs separated from execution gas       |
-| **Memory Limits**        | Soft limits through prohibitive gas costs | Hard fixed limits per contract                 |
-| **Pricing Efficiency**   | Potential overcharging for memory         | More efficient through separation of concerns  |
-| **Contract Nesting**     | Limited by available gas                  | Limited by constant memory per contract        |
-| **Memory Metering**      | Dynamic based on total allocation         | Static limits per contract instance            |
-| **Future Improvements**  | Incremental gas cost updates              | Potential dynamic metering for deeper nesting  |
-| **Cross-Contract Calls** | Handled through gas forwarding            | Requires careful boundary limit implementation |
+|  **Memory Constraints**  |      Indirect control via gas costs       |        Hard memory limits per contract         |
+|      **Cost Model**      | Increasing gas curve with allocation size |    Fixed costs separated from execution gas    |
+|    **Memory Limits**     | Soft limits through prohibitive gas costs |         Hard fixed limits per contract         |
+|  **Pricing Efficiency**  |     Potential overcharging for memory     | More efficient through separation of concerns  |
+|   **Contract Nesting**   |         Limited by available gas          |    Limited by constant memory per contract     |
+|   **Memory Metering**    |     Dynamic based on total allocation     |      Static limits per contract instance       |
+| **Future Improvements**  |       Incremental gas cost updates        | Potential dynamic metering for deeper nesting  |
+| **Cross-Contract Calls** |      Handled through gas forwarding       | Requires careful boundary limit implementation |
 
 The architecture establishes a constant memory limit per contract, which is the basis for calculating maximum contract nesting depth. This calculation assumes worst-case memory usage for each nested contract, resulting in a straightforward but conservative limit that operates independently of actual memory consumption. Future iterations may introduce dynamic memory metering, allowing deeper nesting depths for contracts with smaller memory footprints. However, such an enhancement would require careful implementation of cross-contract boundary limits before API stabilization, as it would introduce an additional resource metric to the system.
+
+### Current Memory Limits
+
+The following table depicts memory-related limits at the time of writing:
+
+| Limit                                      | Maximum         |
+| :----------------------------------------: | :-------------: |
+| Call stack depth                           | 5               |
+| Event topics                               | 4               |
+| Event data payload size (including topics) | 416 bytes       |
+| Storage value size                         | 416 bytes       |
+| Transient storage variables                | 128 uint values |
+| Immutable variables                        | 16 uint values  |
+| Contract code blob size                    | ~100 kilobytes  |
+
+!!! info
+    Limits might be increased in the future. To guarantee existing contracts work as expected, limits will never be decreased.
+
 
 ## Account Management - Existential Deposit
 
@@ -34444,7 +34474,7 @@ Let's start by setting up Hardhat for your Storage contract project:
     npm init -y
     ```
 
-3. Install `hardhat-polkadot` plugin and the required plugins:
+3. Install `hardhat-polkadot` and all required plugins:
 
     ```bash
     npm install --save-dev @parity/hardhat-polkadot @nomicfoundation/hardhat-toolbox solc@0.8.28 dotenv
@@ -34491,7 +34521,7 @@ module.exports = {
       polkavm: true,
       url: `http://127.0.0.1:8545`,
     },
-    westendAssetHub: {
+    westendHub: {
       polkavm: true,
       url: 'https://westend-asset-hub-eth-rpc.polkadot.io',
       accounts: [process.env.PRIVATE_KEY],

--- a/llms.txt
+++ b/llms.txt
@@ -22024,6 +22024,89 @@ This architecture impacts several common EVM patterns:
 - Runtime code generation is not supported due to PolkaVM's RISC-V bytecode format
 
 When migrating EVM projects to PolkaVM, developers should identify all contracts that will be instantiated at runtime and ensure they are pre-uploaded to the chain before any instantiation attempts.
+
+## Solidity and YUL IR Translation Incompatibilities
+
+While PolkaVM maintains high-level compatibility with Solidity, several low-level differences exist in the translation of YUL IR and specific Solidity constructs. These differences are particularly relevant for developers working with assembly code or utilizing advanced contract patterns.
+
+### Contract Code Structure
+
+PolkaVM's contract runtime does not differentiate between runtime code and deploy (constructor) code. Instead, both are emitted into a single PolkaVM contract code blob and live on-chain. Therefore, in EVM terminology, the deploy code equals the runtime code.
+
+In constructor code, the `codesize` instruction returns the call data size instead of the actual code blob size, which differs from standard EVM behavior.
+
+### Solidity-Specific Differences
+
+Several Solidity constructs behave differently under PolkaVM:
+
+- **`address.creationCode`** - returns the bytecode keccak256 hash instead of the actual creation code, reflecting PolkaVM's hash-based code referencing system
+
+### YUL Function Translation Differences
+
+The following YUL functions exhibit notable behavioral differences in PolkaVM:
+
+- **Memory Operations:**
+    - **`mload`, `mstore`, `msize`, `mcopy`** - PolkaVM preserves memory layout but implements several constraints:
+        - EVM linear heap memory is emulated using a fixed 64KB byte buffer, limiting maximum contract memory usage
+        - Accessing memory offsets larger than the buffer size traps the contract with an `OutOfBound` error
+        - Compiler optimizations may eliminate unused memory operations, potentially causing `msize` to differ from EVM behavior
+
+- **Call Data Operations:**
+    - **`calldataload`, `calldatacopy`** - in constructor code, the offset parameter is ignored and these functions always return `0`, diverging from EVM behavior where call data represents constructor arguments
+
+- **Code Operations:**
+    - **`codecopy`** - only supported within constructor code, reflecting PolkaVM's different approach to code handling and the unified code blob structure
+
+- **Control Flow:**
+    - **`invalid`** - traps the contract execution but does not consume remaining gas, unlike EVM where it consumes all available gas
+
+- **Cross-Contract Calls:**
+    - **`call`, `delegatecall`, `staticall`** - these functions ignore supplied gas limits and forward all remaining resources due to PolkaVM's multi-dimensional resource model. This creates important security implications:
+
+        - Contract authors must implement reentrancy protection since gas stipends don't provide protection
+        - The compiler detects `address payable.{send,transfer}` patterns and disables call reentrancy as a protective heuristic
+        - Using `address payable.{send,transfer}` is already deprecated; PolkaVM will provide dedicated precompiles for safe balance transfers
+
+        !!!warning
+            The 2300 gas stipend provided by `solc` for `address payable.{send,transfer}` calls offers no reentrancy protection in PolkaVM. While the compiler attempts to detect and mitigate this pattern, developers should avoid these deprecated functions.
+
+- **Contract Creation:**
+    - **`create`, `create2`** - contract instantiation works fundamentally differently in PolkaVM. Instead of supplying deploy code concatenated with constructor arguments, the runtime expects:
+        1. A buffer containing the code hash to deploy
+        2. The constructor arguments buffer
+
+        PolkaVM translates `dataoffset` and `datasize` instructions to handle contract hashes instead of contract code, enabling seamless use of the `new` keyword in Solidity. However, this translation may fail for contracts creating other contracts within `assembly` blocks.
+
+        !!!warning
+            Avoid using `create` family opcodes for manual deployment crafting in `assembly` blocks. This pattern is discouraged due to translation complexity and offers no gas savings benefits in PolkaVM.
+
+- **Data Operations**
+    - **`dataoffset`** - returns the contract hash instead of code offset, aligning with PolkaVM's hash-based code referencing
+    - **`datasize`** - returns the constant contract hash size (32 bytes) rather than variable code size
+
+- Resource Queries
+    - **`gas`, `gaslimit`** - return only the `ref_time` component of PolkaVM's multi-dimensional weight system, providing the closest analog to traditional gas measurements
+
+- **Blockchain State:**
+    - **`prevrandao`, `difficulty`** - both translate to a constant value of `2500000000000000`, as PolkaVM doesn't implement Ethereum's difficulty adjustment or randomness mechanisms
+
+### Unsupported Operations
+
+Several EVM operations are not supported in PolkaVM and produce compile-time errors:
+
+- **`pc`, `extcodecopy`** - these operations are EVM-specific and have no equivalent functionality in PolkaVM's RISC-V architecture
+- **`blobhash`, `blobbasefee`** - related to Ethereum's rollup model and blob data handling, these operations are unnecessary given Polkadot's superior rollup architecture
+- **`extcodecopy`, `selfdestruct`** - these deprecated operations are not supported and generate compile-time errors
+
+### Compilation Pipeline Considerations
+
+PolkaVM processes YUL IR exclusively, meaning all contracts exhibit behavior consistent with Solidity's `via-ir` compilation mode. Developers familiar with the legacy compilation pipeline should expect [IR-based codegen behavior](https://docs.soliditylang.org/en/latest/ir-breaking-changes.html){target=\_blank} when working with PolkaVM contracts.
+
+### Memory Pointer Limitations
+
+YUL functions accepting memory buffer offset pointers or size arguments are limited by PolkaVM's 32-bit pointer size. Supplying values above `2^32-1` will trap the contract immediately. The Solidity compiler typically generates valid memory references, making this primarily a concern for low-level assembly code.
+
+These incompatibilities reflect the fundamental architectural differences between EVM and PolkaVM while maintaining high-level Solidity compatibility. Most developers using standard Solidity patterns will encounter no issues, but those working with assembly code or advanced contract patterns should carefully review these differences during migration.
 --- END CONTENT ---
 
 Doc-Content: https://docs.polkadot.com/polkadot-protocol/smart-contract-basics/

--- a/polkadot-protocol/smart-contract-basics/evm-vs-polkavm.md
+++ b/polkadot-protocol/smart-contract-basics/evm-vs-polkavm.md
@@ -211,7 +211,7 @@ The following YUL functions exhibit notable behavioral differences in PolkaVM:
     - The compiler detects `address payable.{send,transfer}` patterns and disables call reentrancy as a protective heuristic
     - Using `address payable.{send,transfer}` is already deprecated; PolkaVM will provide dedicated precompiles for safe balance transfers
 
-    !!!warning
+    !!! warning
         The 2300 gas stipend that is provided by solc for address payable.{send, transfer} calls offers no reentrancy protection in PolkaVM. While the compiler attempts to detect and mitigate this pattern, developers should avoid these deprecated functions.
 
 - **Contract Creation:**
@@ -223,7 +223,7 @@ The following YUL functions exhibit notable behavioral differences in PolkaVM:
 
     PolkaVM translates `dataoffset` and `datasize` instructions to handle contract hashes instead of contract code, enabling seamless use of the `new` keyword in Solidity. However, this translation may fail for contracts creating other contracts within `assembly` blocks.
 
-    !!!warning
+    !!! warning
         Avoid using `create` family opcodes for manual deployment crafting in `assembly` blocks. This pattern is discouraged due to translation complexity and offers no gas savings benefits in PolkaVM.
 
 - **Data Operations:**

--- a/polkadot-protocol/smart-contract-basics/evm-vs-polkavm.md
+++ b/polkadot-protocol/smart-contract-basics/evm-vs-polkavm.md
@@ -81,8 +81,8 @@ These resources can also be limited when making cross-contract calls, which is e
 
 When resources are "uncapped" in cross-contract calls, they remain constrained by transaction-specified limits, preventing abuse of the transaction signer.
 
-!!!info
-The runtime will provide a special precompile, allowing cross-contract calls with limits specified for all weight dimensions in the future.
+!!! note
+    The runtime will provide a special precompile, allowing cross-contract calls with limits specified for all weight dimensions in the future.
 
 All gas-related opcodes like [`GAS`](https://www.evm.codes/?fork=cancun#5a){target=\_blank} or [`GAS_LIMIT`](https://www.evm.codes/?fork=cancun#45){target=\_blank} return only the `ref_time` value as it's the closest match to traditional gas. Extended APIs will be provided through precompiles to make full use of all resources, including cross-contract calls with all three resources specified.
 
@@ -117,8 +117,8 @@ The following table depicts memory-related limits at the time of writing:
 |            Immutable variables             | 16 uint values  |
 |          Contract code blob size           | ~100 kilobytes  |
 
-!!! info
-Limits might be increased in the future. To guarantee existing contracts work as expected, limits will never be decreased.
+!!! note
+    Limits might be increased in the future. To guarantee existing contracts work as expected, limits will never be decreased.
 
 ## Account Management - Existential Deposit
 
@@ -176,7 +176,7 @@ In constructor code, the `codesize` instruction returns the call data size inste
 
 ### Solidity-Specific Differences
 
-Several Solidity constructs behave differently under PolkaVM:
+Solidity constructs behave differently under PolkaVM:
 
 - **`address.creationCode`** - returns the bytecode keccak256 hash instead of the actual creation code, reflecting PolkaVM's hash-based code referencing system
 
@@ -212,9 +212,7 @@ The following YUL functions exhibit notable behavioral differences in PolkaVM:
     - Using `address payable.{send,transfer}` is already deprecated; PolkaVM will provide dedicated precompiles for safe balance transfers
 
     !!!warning
-    The 2300 gas stipend that is provided by solc for address payable.{send, transfer} calls offers no reentrancy protection in PolkaVM. While the compiler attempts to detect and mitigate this pattern, developers should avoid these deprecated functions.
-
-
+        The 2300 gas stipend that is provided by solc for address payable.{send, transfer} calls offers no reentrancy protection in PolkaVM. While the compiler attempts to detect and mitigate this pattern, developers should avoid these deprecated functions.
 
 - **Contract Creation:**
 
@@ -226,14 +224,14 @@ The following YUL functions exhibit notable behavioral differences in PolkaVM:
     PolkaVM translates `dataoffset` and `datasize` instructions to handle contract hashes instead of contract code, enabling seamless use of the `new` keyword in Solidity. However, this translation may fail for contracts creating other contracts within `assembly` blocks.
 
     !!!warning
-    Avoid using `create` family opcodes for manual deployment crafting in `assembly` blocks. This pattern is discouraged due to translation complexity and offers no gas savings benefits in PolkaVM.
+        Avoid using `create` family opcodes for manual deployment crafting in `assembly` blocks. This pattern is discouraged due to translation complexity and offers no gas savings benefits in PolkaVM.
 
-- **Data Operations**
+- **Data Operations:**
 
   - **`dataoffset`** - returns the contract hash instead of code offset, aligning with PolkaVM's hash-based code referencing
   - **`datasize`** - returns the constant contract hash size (32 bytes) rather than variable code size
 
-- Resource Queries
+- **Resource Queries:**
 
   - **`gas`, `gaslimit`** - return only the `ref_time` component of PolkaVM's multi-dimensional weight system, providing the closest analog to traditional gas measurements
 

--- a/polkadot-protocol/smart-contract-basics/evm-vs-polkavm.md
+++ b/polkadot-protocol/smart-contract-basics/evm-vs-polkavm.md
@@ -48,7 +48,7 @@ PolkaVM offers an elegant alternative through its [on-chain constructors](https:
 |      **Bytecode Format**      |                                     EVM bytecode                                     |                     RISC-V format                      |
 |    **Contract Size Limit**    |                                 24KB code size limit                                 |            Contract-specific memory limits             |
 |         **Compiler**          |                                  Solidity Compiler                                   |                    Revive Compiler                     |
-|      **Inline Assembly**      |                                      Supported                                       |           Supported with compatibility layer           |
+|      **Inline Assembly**      |                                      Supported                                       |         Supported with the compatibility layer         |
 |    **Code Introspection**     | Supported via [`EXTCODECOPY`](https://www.evm.codes/?fork=cancun#3c){target=\_blank} | Limited support, alternative via on-chain constructors |
 |     **Resource Metering**     |                                  Single gas metric                                   |                   Multi-dimensional                    |
 | **Runtime Code Modification** |                                      Supported                                       |               Limited, with alternatives               |
@@ -82,7 +82,7 @@ These resources can also be limited when making cross-contract calls, which is e
 When resources are "uncapped" in cross-contract calls, they remain constrained by transaction-specified limits, preventing abuse of the transaction signer.
 
 !!!info
-    The runtime will provide a special precompile allowing cross-contract calls with limits specified for all weight dimensions in the future.
+The runtime will provide a special precompile, allowing cross-contract calls with limits specified for all weight dimensions in the future.
 
 All gas-related opcodes like [`GAS`](https://www.evm.codes/?fork=cancun#5a){target=\_blank} or [`GAS_LIMIT`](https://www.evm.codes/?fork=cancun#45){target=\_blank} return only the `ref_time` value as it's the closest match to traditional gas. Extended APIs will be provided through precompiles to make full use of all resources, including cross-contract calls with all three resources specified.
 
@@ -107,19 +107,18 @@ The architecture establishes a constant memory limit per contract, which is the 
 
 The following table depicts memory-related limits at the time of writing:
 
-| Limit                                      | Maximum         |
+|                   Limit                    |     Maximum     |
 | :----------------------------------------: | :-------------: |
-| Call stack depth                           | 5               |
-| Event topics                               | 4               |
-| Event data payload size (including topics) | 416 bytes       |
-| Storage value size                         | 416 bytes       |
-| Transient storage variables                | 128 uint values |
-| Immutable variables                        | 16 uint values  |
-| Contract code blob size                    | ~100 kilobytes  |
+|              Call stack depth              |        5        |
+|                Event topics                |        4        |
+| Event data payload size (including topics) |    416 bytes    |
+|             Storage value size             |    416 bytes    |
+|        Transient storage variables         | 128 uint values |
+|            Immutable variables             | 16 uint values  |
+|          Contract code blob size           | ~100 kilobytes  |
 
 !!! info
-    Limits might be increased in the future. To guarantee existing contracts work as expected, limits will never be decreased.
-
+Limits might be increased in the future. To guarantee existing contracts work as expected, limits will never be decreased.
 
 ## Account Management - Existential Deposit
 
@@ -161,7 +160,7 @@ In the PolkaVM, contract deployment follows a fundamentally different model from
 - **Factory pattern limitations** - the common EVM pattern, where contracts dynamically create other contracts, will fail with `CodeNotFound` error unless the dependent contract code was previously uploaded
 - **Separate upload and instantiation** - this creates a two-step process where developers must first upload all contract code, then instantiate relationships between contracts
 
-This architecture impacts several common EVM patterns and requires developers to adapt their deployment strategies accordingly. *Factory contracts must be modified to work with pre-uploaded code rather than embedding bytecode*, and runtime code generation is not supported due to PolkaVM's RISC-V bytecode format. The specific behavior of contract creation opcodes is detailed in the [YUL IR Translation](#yul-function-translation-differences) section.
+This architecture impacts several common EVM patterns and requires developers to adapt their deployment strategies accordingly. _Factory contracts must be modified to work with pre-uploaded code rather than embedding bytecode_, and runtime code generation is not supported due to PolkaVM's RISC-V bytecode format. The specific behavior of contract creation opcodes is detailed in the [YUL IR Translation](#yul-function-translation-differences) section.
 
 When migrating EVM projects to PolkaVM, developers should identify all contracts that will be instantiated at runtime and ensure they are pre-uploaded to the chain before any instantiation attempts.
 
@@ -186,49 +185,60 @@ Several Solidity constructs behave differently under PolkaVM:
 The following YUL functions exhibit notable behavioral differences in PolkaVM:
 
 - **Memory Operations:**
-    - **`mload`, `mstore`, `msize`, `mcopy`** - PolkaVM preserves memory layout but implements several constraints:
-        - EVM linear heap memory is emulated using a fixed 64KB byte buffer, limiting maximum contract memory usage
-        - Accessing memory offsets larger than the buffer size traps the contract with an `OutOfBound` error
-        - Compiler optimizations may eliminate unused memory operations, potentially causing `msize` to differ from EVM behavior
+
+  - **`mload`, `mstore`, `msize`, `mcopy`** - PolkaVM preserves memory layout but implements several constraints:
+    - EVM linear heap memory is emulated using a fixed 64KB byte buffer, limiting maximum contract memory usage
+    - Accessing memory offsets larger than the buffer size traps the contract with an `OutOfBound` error
+    - Compiler optimizations may eliminate unused memory operations, potentially causing `msize` to differ from EVM behavior
 
 - **Call Data Operations:**
-    - **`calldataload`, `calldatacopy`** - in constructor code, the offset parameter is ignored and these functions always return `0`, diverging from EVM behavior where call data represents constructor arguments
+
+  - **`calldataload`, `calldatacopy`** - in constructor code, the offset parameter is ignored and these functions always return `0`, diverging from EVM behavior where call data represents constructor arguments
 
 - **Code Operations:**
-    - **`codecopy`** - only supported within constructor code, reflecting PolkaVM's different approach to code handling and the unified code blob structure
+
+  - **`codecopy`** - only supported within constructor code, reflecting PolkaVM's different approach to code handling and the unified code blob structure
 
 - **Control Flow:**
-    - **`invalid`** - traps the contract execution but does not consume remaining gas, unlike EVM where it consumes all available gas
+
+  - **`invalid`** - traps the contract execution but does not consume remaining gas, unlike EVM where it consumes all available gas
 
 - **Cross-Contract Calls:**
-    - **`call`, `delegatecall`, `staticall`** - these functions ignore supplied gas limits and forward all remaining resources due to PolkaVM's multi-dimensional resource model. This creates important security implications:
 
-        - Contract authors must implement reentrancy protection since gas stipends don't provide protection
-        - The compiler detects `address payable.{send,transfer}` patterns and disables call reentrancy as a protective heuristic
-        - Using `address payable.{send,transfer}` is already deprecated; PolkaVM will provide dedicated precompiles for safe balance transfers
+  - **`call`, `delegatecall`, `staticall`** - these functions ignore supplied gas limits and forward all remaining resources due to PolkaVM's multi-dimensional resource model. This creates important security implications:
 
-        !!!warning
-            The 2300 gas stipend provided by `solc` for `address payable.{send,transfer}` calls offers no reentrancy protection in PolkaVM. While the compiler attempts to detect and mitigate this pattern, developers should avoid these deprecated functions.
+    - Contract authors must implement reentrancy protection since gas stipends don't provide protection
+    - The compiler detects `address payable.{send,transfer}` patterns and disables call reentrancy as a protective heuristic
+    - Using `address payable.{send,transfer}` is already deprecated; PolkaVM will provide dedicated precompiles for safe balance transfers
+
+    !!!warning
+    The 2300 gas stipend that is provided by solc for address payable.{send, transfer} calls offers no reentrancy protection in PolkaVM. While the compiler attempts to detect and mitigate this pattern, developers should avoid these deprecated functions.
+
+
 
 - **Contract Creation:**
-    - **`create`, `create2`** - contract instantiation works fundamentally differently in PolkaVM. Instead of supplying deploy code concatenated with constructor arguments, the runtime expects:
-        1. A buffer containing the code hash to deploy
-        2. The constructor arguments buffer
 
-        PolkaVM translates `dataoffset` and `datasize` instructions to handle contract hashes instead of contract code, enabling seamless use of the `new` keyword in Solidity. However, this translation may fail for contracts creating other contracts within `assembly` blocks.
+  - **`create`, `create2`** - contract instantiation works fundamentally differently in PolkaVM. Instead of supplying deploy code concatenated with constructor arguments, the runtime expects:
 
-        !!!warning
-            Avoid using `create` family opcodes for manual deployment crafting in `assembly` blocks. This pattern is discouraged due to translation complexity and offers no gas savings benefits in PolkaVM.
+    1. A buffer containing the code hash to deploy
+    2. The constructor arguments buffer
+
+    PolkaVM translates `dataoffset` and `datasize` instructions to handle contract hashes instead of contract code, enabling seamless use of the `new` keyword in Solidity. However, this translation may fail for contracts creating other contracts within `assembly` blocks.
+
+    !!!warning
+    Avoid using `create` family opcodes for manual deployment crafting in `assembly` blocks. This pattern is discouraged due to translation complexity and offers no gas savings benefits in PolkaVM.
 
 - **Data Operations**
-    - **`dataoffset`** - returns the contract hash instead of code offset, aligning with PolkaVM's hash-based code referencing
-    - **`datasize`** - returns the constant contract hash size (32 bytes) rather than variable code size
+
+  - **`dataoffset`** - returns the contract hash instead of code offset, aligning with PolkaVM's hash-based code referencing
+  - **`datasize`** - returns the constant contract hash size (32 bytes) rather than variable code size
 
 - Resource Queries
-    - **`gas`, `gaslimit`** - return only the `ref_time` component of PolkaVM's multi-dimensional weight system, providing the closest analog to traditional gas measurements
+
+  - **`gas`, `gaslimit`** - return only the `ref_time` component of PolkaVM's multi-dimensional weight system, providing the closest analog to traditional gas measurements
 
 - **Blockchain State:**
-    - **`prevrandao`, `difficulty`** - both translate to a constant value of `2500000000000000`, as PolkaVM doesn't implement Ethereum's difficulty adjustment or randomness mechanisms
+  - **`prevrandao`, `difficulty`** - both translate to a constant value of `2500000000000000`, as PolkaVM doesn't implement Ethereum's difficulty adjustment or randomness mechanisms
 
 ### Unsupported Operations
 

--- a/polkadot-protocol/smart-contract-basics/evm-vs-polkavm.md
+++ b/polkadot-protocol/smart-contract-basics/evm-vs-polkavm.md
@@ -38,7 +38,7 @@ However, this architectural difference becomes relevant in specific scenarios. T
 
 This primarily affects contracts using [`EXTCODECOPY`](https://www.evm.codes/?fork=cancun#3c){target=\_blank} to manipulate code at runtime. A contract encounters problems specifically when it uses `EXTCODECOPY` to copy contract code into memory and then attempts to mutate it. This pattern is not possible in standard Solidity and requires dropping down to YUL assembly. An example would be a factory contract written in assembly that constructs and instantiates new contracts by generating code at runtime. Such contracts are rare in practice.
 
-PolkaVM offers an elegant alternative through its [on-chain constructors](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/struct.Pallet.html#method.bare_instantiate){target=\_blank}, enabling contract instantiation without runtime code modification, making this pattern unnecessary.
+PolkaVM offers an elegant alternative through its [on-chain constructors](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/struct.Pallet.html#method.bare_instantiate){target=\_blank}, enabling contract instantiation without runtime code modification, making this pattern unnecessary. This architectural difference also impacts how contract deployment works more broadly, as discussed in the [Contract Deployment](#contract-deployment) section.
 
 ### High-Level Architecture Comparison
 
@@ -130,7 +130,6 @@ Ethereum and Polkadot handle account persistence differently, affecting state ma
 |          Feature          |                   Ethereum Approach                   |               PolkaVM/Polkadot Approach                |
 | :-----------------------: | :---------------------------------------------------: | :----------------------------------------------------: |
 |  **Account Persistence**  | Accounts persist indefinitely, even with zero balance | Requires existential deposit (ED) to maintain account  |
-|  **Account Persistence**  |  Accounts exist indefinitely, even with zero balance  | Requires existential deposit (ED) to maintain account  |
 |    **Minimum Balance**    |                         None                          |                      ED required                       |
 |   **Account Deletion**    |               Accounts remain in state                |      Accounts below ED are automatically deleted       |
 |   **Contract Accounts**   |                  Exist indefinitely                   |                    Must maintain ED                    |
@@ -162,11 +161,7 @@ In the PolkaVM, contract deployment follows a fundamentally different model from
 - **Factory pattern limitations** - the common EVM pattern, where contracts dynamically create other contracts, will fail with `CodeNotFound` error unless the dependent contract code was previously uploaded
 - **Separate upload and instantiation** - this creates a two-step process where developers must first upload all contract code, then instantiate relationships between contracts
 
-This architecture impacts several common EVM patterns:
-
-- Factory contracts must be modified to work with pre-uploaded code rather than embedding bytecode
-- [`create`](https://www.evm.codes/?fork=cancun#f0){target=\_blank} and [`create2`](https://www.evm.codes/?fork=cancun#f5){target=\_blank} deployments need adaptation since they can't dynamically generate contract code
-- Runtime code generation is not supported due to PolkaVM's RISC-V bytecode format
+This architecture impacts several common EVM patterns and requires developers to adapt their deployment strategies accordingly. *Factory contracts must be modified to work with pre-uploaded code rather than embedding bytecode*, and runtime code generation is not supported due to PolkaVM's RISC-V bytecode format. The specific behavior of contract creation opcodes is detailed in the [YUL IR Translation](#yul-function-translation-differences) section.
 
 When migrating EVM projects to PolkaVM, developers should identify all contracts that will be instantiated at runtime and ensure they are pre-uploaded to the chain before any instantiation attempts.
 

--- a/polkadot-protocol/smart-contract-basics/evm-vs-polkavm.md
+++ b/polkadot-protocol/smart-contract-basics/evm-vs-polkavm.md
@@ -157,7 +157,7 @@ For most users deploying contracts (like ERC-20 tokens), contract deployment wor
 In the PolkaVM, contract deployment follows a fundamentally different model from EVM. The EVM allows contracts to be deployed with a single transaction, where the contract code is bundled with the deployment transaction. In contrast, PolkaVM has a different process for contract instantiation.
 
 - **Code must be pre-uploaded** - unlike EVM, where contract code is bundled within the deploying contract, PolkaVM requires all contract bytecode to be uploaded to the chain before instantiation
-- **Factory pattern limitations** - the common EVM pattern, where contracts dynamically create other contracts, will fail with `CodeNotFound` error unless the dependent contract code was previously uploaded
+- **Factory pattern limitations** - the common EVM pattern, where contracts dynamically create other contracts, will fail with a `CodeNotFound` error unless the dependent contract code was previously uploaded
 - **Separate upload and instantiation** - this creates a two-step process where developers must first upload all contract code, then instantiate relationships between contracts
 
 This architecture impacts several common EVM patterns and requires developers to adapt their deployment strategies accordingly. _Factory contracts must be modified to work with pre-uploaded code rather than embedding bytecode_, and runtime code generation is not supported due to PolkaVM's RISC-V bytecode format. The specific behavior of contract creation opcodes is detailed in the [YUL IR Translation](#yul-function-translation-differences) section.


### PR DESCRIPTION
This PR updates the [EVM vs PolkaVM](https://papermoonio.github.io/polkadot-mkdocs/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/) page to incorporate the latest in https://contracts.polkadot.io/differences_to_eth