### PR TITLE
Fixes cloning of template that causes the node to panic

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -28260,7 +28260,7 @@ The [Polkadot SDK Parachain Template](https://github.com/paritytech/polkadot-sdk
 
 1. Clone the template repository:
     ```bash
-    git clone -b stable2412 https://github.com/paritytech/polkadot-sdk-parachain-template.git parachain-template
+    git clone https://github.com/paritytech/polkadot-sdk-parachain-template.git parachain-template
     ```
 
 2. Navigate into the project directory:

--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -60,7 +60,7 @@ The [Polkadot SDK Parachain Template](https://github.com/paritytech/polkadot-sdk
 
 1. Clone the template repository:
     ```bash
-    git clone -b stable2412 https://github.com/paritytech/polkadot-sdk-parachain-template.git parachain-template
+    git clone https://github.com/paritytech/polkadot-sdk-parachain-template.git parachain-template
     ```
 
 2. Navigate into the project directory:


### PR DESCRIPTION
I get the error in the image below when I try to start the omni node.
<img width="1434" alt="Screenshot 2025-05-22 at 18 30 12" src="https://github.com/user-attachments/assets/6932c547-10e2-4d35-b79c-57aa7d7aee3e" />

After many hours of debugging, I realised that the error disappears and the node appears to run smoothly when I clone the parachain template directly instead of targeting the `stable2412` release.

This PR changes the command so the learner clones the node directly and hopefully avoids the frustration I encountered.

I hope this is the optimal solution for this.

For context, I was running this on an M1 Mac.