### PR TITLE
[FIX] -  Quick fixes before SC launch

### DIFF
--- a/.snippets/text/smart-contracts/code-size.md
+++ b/.snippets/text/smart-contracts/code-size.md
@@ -1,7 +1,4 @@
 !!! note "Contracts Code Blob Size Disclaimer"
     The maximum contract code blob size on Polkadot Hub networks is _100 kilobytes_, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
 
-    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
-    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
-
     For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.

--- a/.snippets/text/smart-contracts/code-size.md
+++ b/.snippets/text/smart-contracts/code-size.md
@@ -1,5 +1,5 @@
 !!! note "Contracts Code Blob Size Disclaimer"
-    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
+    The maximum contract code blob size on Polkadot Hub networks is _100 kilobytes_, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
 
     - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
     - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations

--- a/.snippets/text/smart-contracts/code-size.md
+++ b/.snippets/text/smart-contracts/code-size.md
@@ -1,4 +1,4 @@
 !!! note "Contracts Code Blob Size Disclaimer"
-    The maximum contract code blob size on Polkadot Hub networks is _100 kilobytes_, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
+    The maximum contract code blob size on Polkadot Hub networks is _100 kilobytes_, significantly larger than Ethereum’s EVM limit of 24 kilobytes.
 
     For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.

--- a/.snippets/text/smart-contracts/code-size.md
+++ b/.snippets/text/smart-contracts/code-size.md
@@ -1,0 +1,7 @@
+!!! note "Contracts Code Blob Size Disclaimer"
+    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
+
+    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
+    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
+
+    For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.

--- a/develop/smart-contracts/dev-environments/hardhat.md
+++ b/develop/smart-contracts/dev-environments/hardhat.md
@@ -17,6 +17,8 @@ description: Learn how to create, compile, test, and deploy smart contracts on P
 
 </div>
 
+--8<-- 'text/smart-contracts/code-size.md'
+
 ## Overview
 
 Hardhat is a robust development environment for Ethereum-compatible chains that makes smart contract development more efficient. This guide walks you through the essentials of using Hardhat to create, compile, test, and deploy smart contracts on Polkadot Hub.

--- a/develop/smart-contracts/dev-environments/remix.md
+++ b/develop/smart-contracts/dev-environments/remix.md
@@ -28,6 +28,7 @@ description: Explore the smart contract development and deployment process on Po
 !!! warning
     The Polkadot Remix IDE's contract compilation functionality is currently limited to Google Chrome. Alternative browsers are not recommended for this task.
 
+--8<-- 'text/smart-contracts/code-size.md'
 
 ## Overview
 

--- a/develop/smart-contracts/libraries/ethers-js.md
+++ b/develop/smart-contracts/libraries/ethers-js.md
@@ -99,6 +99,8 @@ With the provider set up, you can start querying the blockchain. For instance, t
 
 ## Compile Contracts
 
+--8<-- 'text/smart-contracts/code-size.md'
+
 The `revive` compiler transforms Solidity smart contracts into [PolkaVM](/develop/smart-contracts/native-evm-contracts/#polkavm){target=\_blank} bytecode for deployment on Polkadot Hub. Revive's Ethereum RPC interface allows you to use familiar tools like Ethers.js and MetaMask to interact with contracts.
 
 ### Install the Revive Library

--- a/develop/smart-contracts/libraries/viem.md
+++ b/develop/smart-contracts/libraries/viem.md
@@ -141,6 +141,8 @@ You can use the following contract to interact with the blockchain. Paste the fo
 
 ## Compile the Contract
 
+--8<-- 'text/smart-contracts/code-size.md'
+
 Create a new file at `src/compile.ts` for handling contract compilation:
 
 ```typescript title="src/compile.ts"

--- a/develop/smart-contracts/libraries/web3-js.md
+++ b/develop/smart-contracts/libraries/web3-js.md
@@ -93,6 +93,8 @@ For instance, to fetch the latest block number of the chain, you can use the fol
 
 ## Compile Contracts
 
+--8<-- 'text/smart-contracts/code-size.md'
+
 Polkadot Hub requires contracts to be compiled to [PolkaVM](/polkadot-protocol/smart-contracts-basics/polkavm-design){target=\_blank} bytecode. This is achieved using the [`revive`](https://github.com/paritytech/revive){target=\_blank} compiler. Install the [`@parity/revive`](https://github.com/paritytech/js-revive){target=\_blank} library as a development dependency:
 
 ```bash

--- a/llms.txt
+++ b/llms.txt
@@ -6313,10 +6313,7 @@ description: Learn how to create, compile, test, and deploy smart contracts on P
 </div>
 
 !!! note "Contracts Code Blob Size Disclaimer"
-    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
-
-    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
-    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
+    The maximum contract code blob size on Polkadot Hub networks is _100 kilobytes_, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
 
     For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.
 
@@ -6982,10 +6979,7 @@ description: Explore the smart contract development and deployment process on Po
     The Polkadot Remix IDE's contract compilation functionality is currently limited to Google Chrome. Alternative browsers are not recommended for this task.
 
 !!! note "Contracts Code Blob Size Disclaimer"
-    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
-
-    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
-    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
+    The maximum contract code blob size on Polkadot Hub networks is _100 kilobytes_, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
 
     For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.
 
@@ -7813,10 +7807,7 @@ main();
 ## Compile Contracts
 
 !!! note "Contracts Code Blob Size Disclaimer"
-    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
-
-    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
-    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
+    The maximum contract code blob size on Polkadot Hub networks is _100 kilobytes_, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
 
     For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.
 
@@ -8569,10 +8560,7 @@ contract Storage {
 ## Compile the Contract
 
 !!! note "Contracts Code Blob Size Disclaimer"
-    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
-
-    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
-    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
+    The maximum contract code blob size on Polkadot Hub networks is _100 kilobytes_, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
 
     For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.
 
@@ -9399,10 +9387,7 @@ main();
 ## Compile Contracts
 
 !!! note "Contracts Code Blob Size Disclaimer"
-    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
-
-    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
-    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
+    The maximum contract code blob size on Polkadot Hub networks is _100 kilobytes_, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
 
     For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.
 

--- a/llms.txt
+++ b/llms.txt
@@ -6312,6 +6312,14 @@ description: Learn how to create, compile, test, and deploy smart contracts on P
 
 </div>
 
+!!! note "Contracts Code Blob Size Disclaimer"
+    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
+
+    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
+    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
+
+    For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.
+
 ## Overview
 
 Hardhat is a robust development environment for Ethereum-compatible chains that makes smart contract development more efficient. This guide walks you through the essentials of using Hardhat to create, compile, test, and deploy smart contracts on Polkadot Hub.
@@ -6973,6 +6981,13 @@ description: Explore the smart contract development and deployment process on Po
 !!! warning
     The Polkadot Remix IDE's contract compilation functionality is currently limited to Google Chrome. Alternative browsers are not recommended for this task.
 
+!!! note "Contracts Code Blob Size Disclaimer"
+    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
+
+    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
+    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
+
+    For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.
 
 ## Overview
 
@@ -7797,6 +7812,14 @@ main();
 
 ## Compile Contracts
 
+!!! note "Contracts Code Blob Size Disclaimer"
+    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
+
+    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
+    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
+
+    For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.
+
 The `revive` compiler transforms Solidity smart contracts into [PolkaVM](/develop/smart-contracts/native-evm-contracts/#polkavm){target=\_blank} bytecode for deployment on Polkadot Hub. Revive's Ethereum RPC interface allows you to use familiar tools like Ethers.js and MetaMask to interact with contracts.
 
 ### Install the Revive Library
@@ -8544,6 +8567,14 @@ contract Storage {
 ```
 
 ## Compile the Contract
+
+!!! note "Contracts Code Blob Size Disclaimer"
+    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
+
+    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
+    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
+
+    For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.
 
 Create a new file at `src/compile.ts` for handling contract compilation:
 
@@ -9366,6 +9397,14 @@ main();
     ```
 
 ## Compile Contracts
+
+!!! note "Contracts Code Blob Size Disclaimer"
+    The maximum contract code blob size on Polkadot Hub networks is *100 kilobytes*, significantly larger than Ethereum’s EVM limit of 24 kilobytes. This difference stems from fundamental architectural distinctions between the two virtual machines:
+
+    - **PolkaVM**: Uses a RISC-V, register-based architecture, allowing for more efficient code compilation and larger contract sizes
+    - **EVM**: Uses a stack-based architecture with stricter size constraints due to gas optimization and network efficiency considerations
+
+    For detailed comparisons and migration guidelines, see the [EVM vs. PolkaVM](/polkadot-protocol/smart-contract-basics/evm-vs-polkavm/#current-memory-limits){target=\_blank} documentation page.
 
 Polkadot Hub requires contracts to be compiled to [PolkaVM](/polkadot-protocol/smart-contracts-basics/polkavm-design){target=\_blank} bytecode. This is achieved using the [`revive`](https://github.com/paritytech/revive){target=\_blank} compiler. Install the [`@parity/revive`](https://github.com/paritytech/js-revive){target=\_blank} library as a development dependency:
 


### PR DESCRIPTION
This PR adds some quick fixes before SC launch:
- Add a prominent note about the 100kb contract size limit in SC docs