### PR TITLE
[FIX] -updating uniswap repo

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -32813,7 +32813,7 @@ Let's start by cloning the Uniswap V2 project:
 1. Clone the Uniswap V2 repository:
 
     ```
-    git clone https://github.com/papermoonio/uniswap-V2-polkadot.git
+    git clone https://github.com/polkadot-developers/polkavm-hardhat-examples.git -b v0.0.3
     cd uniswap-V2-polkadot
     ```
 

--- a/tutorials/smart-contracts/demo-aplications/deploying-uniswap-v2.md
+++ b/tutorials/smart-contracts/demo-aplications/deploying-uniswap-v2.md
@@ -28,7 +28,7 @@ Let's start by cloning the Uniswap V2 project:
 1. Clone the Uniswap V2 repository:
 
     ```
-    git clone https://github.com/papermoonio/uniswap-V2-polkadot.git
+    git clone https://github.com/polkadot-developers/polkavm-hardhat-examples.git -b v0.0.3
     cd uniswap-V2-polkadot
     ```
 


### PR DESCRIPTION
This PR updates the uniswap v2 tutorial location from papermoon organization to polkadot developers organization.

This should hold off until https://github.com/polkadot-developers/polkavm-hardhat-examples/pull/5 is merged