### PR TITLE
Update dependencies

### DIFF
--- a/develop/toolkit/interoperability/asset-transfer-api/reference.md
+++ b/develop/toolkit/interoperability/asset-transfer-api/reference.md
@@ -32,7 +32,7 @@ description: Explore the Asset Transfer API Reference for comprehensive details 
 
 Holds open an API connection to a specified chain within the `ApiPromise` to help construct transactions for assets and estimate fees.
 
-For a more in-depth explanation of the Asset Transfer API class structure, check the [source code](https://github.com/paritytech/asset-transfer-api/blob/{{dependencies.repositories.asset_transfer_api.version}}/src/AssetTransferApi.ts#L123){target=\_blank}.
+For a more in-depth explanation of the Asset Transfer API class structure, check the [source code](https://github.com/paritytech/asset-transfer-api/blob/{{dependencies.repositories.asset_transfer_api.version}}/src/AssetTransferApi.ts#L128){target=\_blank}.
 
 ### Methods
 
@@ -43,7 +43,7 @@ Generates an XCM transaction for transferring assets between chains. It simplifi
 After obtaining the transaction, you must handle the signing and submission process separately.
 
 ```ts
---8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/AssetTransferApi.ts:186:192'
+--8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/AssetTransferApi.ts:191:197'
 ```
 
 ??? interface "Request parameters"
@@ -102,7 +102,7 @@ Creates a local XCM transaction to retrieve trapped assets. This function can be
 
 
 ```ts
---8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/AssetTransferApi.ts:370:375'
+--8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/AssetTransferApi.ts:383:388'
 ```
 
 ??? interface "Request parameters"
@@ -153,7 +153,7 @@ Creates a local XCM transaction to retrieve trapped assets. This function can be
 Decodes the hex of an extrinsic into a string readable format.
 
 ```ts
---8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/AssetTransferApi.ts:536:536'
+--8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/AssetTransferApi.ts:558:558'
 ```
 
 ??? interface "Request parameters"
@@ -171,7 +171,7 @@ Decodes the hex of an extrinsic into a string readable format.
     ??? child "Type `Format`"
 
         ```ts
-        --8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/types.ts:132:132'
+        --8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/types.ts:130:130'
         ```
 
 ??? interface "Response parameters"
@@ -197,7 +197,7 @@ Decodes the hex of an extrinsic into a string readable format.
 Fetch estimated fee information for an extrinsic.
 
 ```ts
---8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/AssetTransferApi.ts:446:449'
+--8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/AssetTransferApi.ts:468:471'
 ```
 
 ??? interface "Request parameters"
@@ -209,7 +209,7 @@ Fetch estimated fee information for an extrinsic.
     ??? child "Type `ConstructedFormat<T>`"
 
         ```ts
-        --8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/types.ts:137:143'
+        --8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/types.ts:135:141'
         ```
 
         The `ConstructedFormat` type is a conditional type that returns a specific type based on the value of the TxResult `format` field.
@@ -227,7 +227,7 @@ Fetch estimated fee information for an extrinsic.
     ??? child "Type `Format`"
 
         ```ts
-        --8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/types.ts:132:132'
+        --8<-- 'https://raw.githubusercontent.com/paritytech/asset-transfer-api/refs/tags/{{dependencies.repositories.asset_transfer_api.version}}/src/types.ts:130:130'
         ```
 
 ??? interface "Response parameters"

--- a/variables.yml
+++ b/variables.yml
@@ -63,7 +63,7 @@ dependencies:
       version: 16.1.2
     polkadot_api:
       name: polkadot-api
-      version: 1.13.1
+      version: 1.14.1
     hardhat_resolc: 
       name: '@hardhat-resolc'
       version: 0.0.7  

--- a/variables.yml
+++ b/variables.yml
@@ -60,7 +60,7 @@ dependencies:
       version: 5.12.0
     polkadot_js_api:
       name: '@polkadot/api'
-      version: 16.2.1
+      version: 16.2.2
     polkadot_api:
       name: polkadot-api
       version: 1.14.1

--- a/variables.yml
+++ b/variables.yml
@@ -60,7 +60,7 @@ dependencies:
       version: 5.12.0
     polkadot_js_api:
       name: '@polkadot/api'
-      version: 16.1.2
+      version: 16.2.1
     polkadot_api:
       name: polkadot-api
       version: 1.14.1

--- a/variables.yml
+++ b/variables.yml
@@ -53,8 +53,8 @@ dependencies:
       version: 1.1.1
     asset_transfer_api:
       name: '@substrate/asset-transfer-api'
-      version: 0.7.2
-      polkadot_js_api_version: v16.0.1 # Check changelog for pjs version bumps
+      version: 1.0.0
+      polkadot_js_api_version: v16.2.2 # Check changelog for pjs version bumps
     moonwall:
       name: '@moonwall/cli'
       version: 5.12.0

--- a/variables.yml
+++ b/variables.yml
@@ -3,7 +3,7 @@ dependencies:
   repositories:
     zombienet:
       repository_url: https://github.com/paritytech/zombienet
-      version: v1.3.128
+      version: v1.3.130
       architecture: macos-arm64
     asset_transfer_api:
       repository_url: https://github.com/paritytech/asset-transfer-api

--- a/variables.yml
+++ b/variables.yml
@@ -7,7 +7,7 @@ dependencies:
       architecture: macos-arm64
     asset_transfer_api:
       repository_url: https://github.com/paritytech/asset-transfer-api
-      version: v0.7.2
+      version: v1.0.0
     polkadot_sdk_solochain_template:
       repository_url: https://github.com/paritytech/polkadot-sdk-solochain-template
       version: v0.0.2

--- a/variables.yml
+++ b/variables.yml
@@ -22,7 +22,7 @@ dependencies:
       docker_image_version: stable2412
     open_zeppelin_contracts:
       repository_url: https://github.com/OpenZeppelin/openzeppelin-contracts
-      version: v5.0.0
+      version: v5.3.0
     polkadot_sdk_contracts_node:
       repository_url: https://github.com/paritytech/polkadot-sdk
       version: polkadot-stable2503-6

--- a/variables.yml
+++ b/variables.yml
@@ -50,7 +50,7 @@ dependencies:
   javascript_packages:
     chopsticks:
       name: '@acala-network/chopsticks'
-      version: 1.0.6
+      version: 1.1.1
     asset_transfer_api:
       name: '@substrate/asset-transfer-api'
       version: 0.7.2

--- a/variables.yml
+++ b/variables.yml
@@ -3,7 +3,7 @@ dependencies:
   repositories:
     zombienet:
       repository_url: https://github.com/paritytech/zombienet
-      version: v1.3.130
+      version: v1.3.133
       architecture: macos-arm64
     asset_transfer_api:
       repository_url: https://github.com/paritytech/asset-transfer-api


### PR DESCRIPTION
This pull request updates the `Asset Transfer API` documentation to reflect changes in the codebase and upgrades several dependencies in the `variables.yml` file. The most important changes include updating references in the documentation to match the latest version of the `Asset Transfer API` and bumping dependency versions across multiple repositories and JavaScript packages.

### Documentation Updates for `Asset Transfer API`:
* Updated source code links in `develop/toolkit/interoperability/asset-transfer-api/reference.md` to reflect changes in line numbers due to the new `Asset Transfer API` version. These updates ensure the documentation points to the correct sections of the codebase. [[1]](diffhunk://#diff-ea00480a130d6c8a85b1e9fd10ed76caa7e51133e7b0b6855b0c1beeaf95b8b5L35-R35) [[2]](diffhunk://#diff-ea00480a130d6c8a85b1e9fd10ed76caa7e51133e7b0b6855b0c1beeaf95b8b5L46-R46) [[3]](diffhunk://#diff-ea00480a130d6c8a85b1e9fd10ed76caa7e51133e7b0b6855b0c1beeaf95b8b5L105-R105) [[4]](diffhunk://#diff-ea00480a130d6c8a85b1e9fd10ed76caa7e51133e7b0b6855b0c1beeaf95b8b5L156-R156) [[5]](diffhunk://#diff-ea00480a130d6c8a85b1e9fd10ed76caa7e51133e7b0b6855b0c1beeaf95b8b5L174-R174) [[6]](diffhunk://#diff-ea00480a130d6c8a85b1e9fd10ed76caa7e51133e7b0b6855b0c1beeaf95b8b5L200-R200) [[7]](diffhunk://#diff-ea00480a130d6c8a85b1e9fd10ed76caa7e51133e7b0b6855b0c1beeaf95b8b5L212-R212) [[8]](diffhunk://#diff-ea00480a130d6c8a85b1e9fd10ed76caa7e51133e7b0b6855b0c1beeaf95b8b5L230-R230)

### Dependency Updates:
* Bumped the version of the `Asset Transfer API` from `v0.7.2` to `v1.0.0` in `variables.yml`. This reflects the major update to the API. [[1]](diffhunk://#diff-6026bd27cefffc01295edd8430f545994aaecdc2bb96af0f0b18f7fa0b00a8c5L6-R10) [[2]](diffhunk://#diff-6026bd27cefffc01295edd8430f545994aaecdc2bb96af0f0b18f7fa0b00a8c5L53-R66)
* Updated other dependencies in `variables.yml`:
  - `zombienet` from `v1.3.128` to `v1.3.133`.
  - `open_zeppelin_contracts` from `v5.0.0` to `v5.3.0`.
  - JavaScript packages such as `@acala-network/chopsticks`, `@polkadot/api`, and `polkadot-api` to their latest versions for compatibility and feature enhancements.