### PR TITLE
[Add] - connect to kusama page

### DIFF
--- a/develop/smart-contracts/.pages
+++ b/develop/smart-contracts/.pages
@@ -3,6 +3,7 @@ nav:
   - index.md
   - 'Overview': overview.md
   - 'Connect to Polkadot': connect-to-polkadot.md
+  - 'Connect to Kusama': connect-to-kusama.md
   - 'Wallets': wallets.md
   - 'Local Development Node': local-development-node.md
   - dev-environments

--- a/develop/smart-contracts/connect-to-kusama.md
+++ b/develop/smart-contracts/connect-to-kusama.md
@@ -11,7 +11,7 @@ description: Explore how to connect to Kusama Hub for developing and testing sma
     <a href="#" class="md-button connectMetaMask" value="kusamaHub">Connect to Kusama Hub</a>
 </div>
 
-For more information about how to connect to a Polkadot Network, please check the [Wallets](/develop/smart-contracts/wallets/){target=\_blank} guide.
+For more information about how to connect to a Polkadot network, please check the [Wallets](/develop/smart-contracts/wallets/){target=\_blank} guide.
 
 !!! info "Production Environment"
     Kusama Hub offers a live environment for deploying smart contracts. Please note that the most recent version of Polkadot's Ethereum-compatible stack is available on the TestNet; however, you can also deploy it to the Kusama Hub for production use.
@@ -56,9 +56,9 @@ Developers can leverage smart contracts on Kusama Hub for live production deploy
 
 While the compatibility with regular EVM codebases is still being maximized, some recommendations include:
     
-- **Leverage Hardhat** to compile, deploy, and interact with your contract.
+- **Leverage [Hardhat](/develop/smart-contracts/dev-environments/hardhat){target=\_blank}** to compile, deploy, and interact with your contract.
 - **Use MetaMask** to interact with your dApp (note that using MetaMask can sometimes lead to `Invalid transaction` errors - this is actively being worked on and will be fixed soon).
-- **Avoid REMIX** for deployment as MetaMask enforces a 48kb size limit when using the [REMIX IDE](/develop/smart-contracts/dev-environments/remix){target=\_blank}, which is why [Hardhat Polkadot](/develop/smart-contracts/dev-environments/hardhat){target=\_blank} is recommended for deployment.
+- **Avoid Remix** for deployment as MetaMask enforces a 48kb size limit when using the [Remix IDE](/develop/smart-contracts/dev-environments/remix){target=\_blank}, which is why Hardhat Polkadot is recommended for deployment.
 
 Kusama Hub is a live environment. Ensure your contracts are thoroughly tested before deployment, as transactions on Kusama Hub involve real KSM tokens and **cannot be reversed**.
 

--- a/develop/smart-contracts/connect-to-kusama.md
+++ b/develop/smart-contracts/connect-to-kusama.md
@@ -1,0 +1,87 @@
+---
+title: Connect to Kusama
+description: Explore how to connect to Kusama Hub for developing and testing smart contracts in a live environment with real monetary value.
+---
+
+# Connect to Kusama
+
+--8<-- 'text/smart-contracts/polkaVM-warning.md'
+
+<div class="button-wrapper">
+    <a href="#" class="md-button connectMetaMask" value="kusamaHub">Connect to Kusama Hub</a>
+</div>
+
+For more information about how to connect to a Polkadot Network, please check the [Wallets](/develop/smart-contracts/wallets/){target=\_blank} guide.
+
+!!! info "Production Environment"
+    Kusama Hub offers a live environment for deploying smart contracts. Please note that the most recent version of Polkadot's Ethereum-compatible stack is available on the TestNet; however, you can also deploy it to the Kusama Hub for production use.
+
+
+## Networks Details
+
+Developers can leverage smart contracts on Kusama Hub for live production deployments. This section outlines the network specifications and connection details.
+
+=== "Kusama Hub"
+
+    Network name
+    ```text
+    Kusama Hub
+    ```
+    ---
+    Currency symbol
+    ```text
+    KSM
+    ```
+    ---
+    
+    Chain ID
+    ```text
+    420420418
+    ```
+    ---
+    
+    RPC URL
+    ```text
+    https://kusama-asset-hub-eth-rpc.polkadot.io
+    ```
+    ---
+    
+    Block explorer URL
+    ```text
+    https://blockscout-kusama-asset-hub.parity-chains-scw.parity.io/
+    ```
+    ---
+
+## Important Deployment Considerations
+
+While the compatibility with regular EVM codebases is still being maximized, some recommendations:
+    
+- **Use Hardhat** to compile, deploy, and interact with your contract.
+- **Use MetaMask** to interact with your dApp (note that using MetaMask can sometimes lead to `Invalid transaction` errors - this is actively being worked on and will be fixed soon).
+- **Avoid REMIX for deployment** - MetaMask enforces a 48kb size limit when using the [REMIX IDE](/develop/smart-contracts/dev-environments/remix){target=\_blank}, which is why [Hardhat Polkadot](/develop/smart-contracts/dev-environments/hardhat){target=\_blank} is recommended for deployment.
+
+Kusama Hub is a live environment. Ensure your contracts are thoroughly tested before deployment, as transactions on Kusama Hub involve real KSM tokens and cannot be reversed.
+
+## Where to Go Next
+
+For your next steps, explore the various smart contract guides demonstrating how to use and integrate different tools and development environments into your workflow.
+
+<div class="grid cards" markdown>
+
+-   <span class="badge guide">Guide</span> **Deploy your first contract with Hardhat**
+    
+    ---
+    
+    Explore the recommended smart contract development and deployment process on Kusama Hub using Hardhat.
+    
+    [:octicons-arrow-right-24: Build with HardHat](/develop/smart-contracts/dev-environments/hardhat/)
+
+-   <span class="badge guide">Guide</span> **Interact with the blockchain with viem**
+    
+    ---
+    
+    Use viem for interacting with Ethereum-compatible chains, to deploy and interact with smart contracts on Kusama Hub.
+    
+    [:octicons-arrow-right-24: Build with viem](/develop/smart-contracts/libraries/viem/)
+
+</div>

--- a/develop/smart-contracts/connect-to-kusama.md
+++ b/develop/smart-contracts/connect-to-kusama.md
@@ -54,13 +54,13 @@ Developers can leverage smart contracts on Kusama Hub for live production deploy
 
 ## Important Deployment Considerations
 
-While the compatibility with regular EVM codebases is still being maximized, some recommendations:
+While the compatibility with regular EVM codebases is still being maximized, some recommendations include:
     
-- **Use Hardhat** to compile, deploy, and interact with your contract.
+- **Leverage Hardhat** to compile, deploy, and interact with your contract.
 - **Use MetaMask** to interact with your dApp (note that using MetaMask can sometimes lead to `Invalid transaction` errors - this is actively being worked on and will be fixed soon).
-- **Avoid REMIX for deployment** - MetaMask enforces a 48kb size limit when using the [REMIX IDE](/develop/smart-contracts/dev-environments/remix){target=\_blank}, which is why [Hardhat Polkadot](/develop/smart-contracts/dev-environments/hardhat){target=\_blank} is recommended for deployment.
+- **Avoid REMIX** for deployment as MetaMask enforces a 48kb size limit when using the [REMIX IDE](/develop/smart-contracts/dev-environments/remix){target=\_blank}, which is why [Hardhat Polkadot](/develop/smart-contracts/dev-environments/hardhat){target=\_blank} is recommended for deployment.
 
-Kusama Hub is a live environment. Ensure your contracts are thoroughly tested before deployment, as transactions on Kusama Hub involve real KSM tokens and cannot be reversed.
+Kusama Hub is a live environment. Ensure your contracts are thoroughly tested before deployment, as transactions on Kusama Hub involve real KSM tokens and **cannot be reversed**.
 
 ## Where to Go Next
 
@@ -76,11 +76,11 @@ For your next steps, explore the various smart contract guides demonstrating how
     
     [:octicons-arrow-right-24: Build with HardHat](/develop/smart-contracts/dev-environments/hardhat/)
 
--   <span class="badge guide">Guide</span> **Interact with the blockchain with viem**
+-   <span class="badge guide">Guide</span> **Interact with the blockchain using viem**
     
     ---
     
-    Use viem for interacting with Ethereum-compatible chains, to deploy and interact with smart contracts on Kusama Hub.
+    Use viem for interacting with Ethereum-compatible chains to deploy and interact with smart contracts on Kusama Hub.
     
     [:octicons-arrow-right-24: Build with viem](/develop/smart-contracts/libraries/viem/)
 

--- a/js/connect-to-metamask.js
+++ b/js/connect-to-metamask.js
@@ -12,6 +12,18 @@ const supportedNetworks = {
       decimals: 18,
     },
   },
+  kusamaHub: {
+    name: 'Kusama Hub',
+    chainId: '0x190f1b42', //Hex value of "420420418"
+    chainName: 'Kusama Hub TestNet',
+    rpcUrls: ['https://kusama-asset-hub-eth-rpc.polkadot.io'],
+    blockExplorerUrls: ['https://blockscout-kusama-asset-hub.parity-chains-scw.parity.io/'],
+    nativeCurrency: {
+      name: 'Kusama Token',
+      symbol: 'KSM',
+      decimals: 18,
+    },
+  }
 };
 
 /*

--- a/llms.txt
+++ b/llms.txt
@@ -6876,7 +6876,7 @@ description: Explore how to connect to Kusama Hub for developing and testing sma
     <a href="#" class="md-button connectMetaMask" value="kusamaHub">Connect to Kusama Hub</a>
 </div>
 
-For more information about how to connect to a Polkadot Network, please check the [Wallets](/develop/smart-contracts/wallets/){target=\_blank} guide.
+For more information about how to connect to a Polkadot network, please check the [Wallets](/develop/smart-contracts/wallets/){target=\_blank} guide.
 
 !!! info "Production Environment"
     Kusama Hub offers a live environment for deploying smart contracts. Please note that the most recent version of Polkadot's Ethereum-compatible stack is available on the TestNet; however, you can also deploy it to the Kusama Hub for production use.
@@ -6921,9 +6921,9 @@ Developers can leverage smart contracts on Kusama Hub for live production deploy
 
 While the compatibility with regular EVM codebases is still being maximized, some recommendations include:
     
-- **Leverage Hardhat** to compile, deploy, and interact with your contract.
+- **Leverage [Hardhat](/develop/smart-contracts/dev-environments/hardhat){target=\_blank}** to compile, deploy, and interact with your contract.
 - **Use MetaMask** to interact with your dApp (note that using MetaMask can sometimes lead to `Invalid transaction` errors - this is actively being worked on and will be fixed soon).
-- **Avoid REMIX** for deployment as MetaMask enforces a 48kb size limit when using the [REMIX IDE](/develop/smart-contracts/dev-environments/remix){target=\_blank}, which is why [Hardhat Polkadot](/develop/smart-contracts/dev-environments/hardhat){target=\_blank} is recommended for deployment.
+- **Avoid Remix** for deployment as MetaMask enforces a 48kb size limit when using the [Remix IDE](/develop/smart-contracts/dev-environments/remix){target=\_blank}, which is why Hardhat Polkadot is recommended for deployment.
 
 Kusama Hub is a live environment. Ensure your contracts are thoroughly tested before deployment, as transactions on Kusama Hub involve real KSM tokens and **cannot be reversed**.
 

--- a/llms.txt
+++ b/llms.txt
@@ -38,6 +38,7 @@ Doc-Page: https://docs.polkadot.com/develop/parachains/testing/
 Doc-Page: https://docs.polkadot.com/develop/parachains/testing/mock-runtime/
 Doc-Page: https://docs.polkadot.com/develop/parachains/testing/pallet-testing/
 Doc-Page: https://docs.polkadot.com/develop/smart-contracts/block-explorers/
+Doc-Page: https://docs.polkadot.com/develop/smart-contracts/connect-to-kusama/
 Doc-Page: https://docs.polkadot.com/develop/smart-contracts/connect-to-polkadot/
 Doc-Page: https://docs.polkadot.com/develop/smart-contracts/dev-environments/foundry/
 Doc-Page: https://docs.polkadot.com/develop/smart-contracts/dev-environments/hardhat/
@@ -6857,6 +6858,98 @@ Routescan delivers multi-chain explorer capabilities with specialized support fo
 - [Westend Hub Routescan](https://420420421.testnet.routescan.io/){target=\_blank}
 
 ![](/images/develop/smart-contracts/block-explorers/block-explorers-3.webp) -->
+--- END CONTENT ---
+
+Doc-Content: https://docs.polkadot.com/develop/smart-contracts/connect-to-kusama/
+--- BEGIN CONTENT ---
+---
+title: Connect to Kusama
+description: Explore how to connect to Kusama Hub for developing and testing smart contracts in a live environment with real monetary value.
+---
+
+# Connect to Kusama
+
+!!! smartcontract "PolkaVM Preview Release"
+    PolkaVM smart contracts with Ethereum compatibility are in **early-stage development and may be unstable or incomplete**.
+
+<div class="button-wrapper">
+    <a href="#" class="md-button connectMetaMask" value="kusamaHub">Connect to Kusama Hub</a>
+</div>
+
+For more information about how to connect to a Polkadot Network, please check the [Wallets](/develop/smart-contracts/wallets/){target=\_blank} guide.
+
+!!! info "Production Environment"
+    Kusama Hub offers a live environment for deploying smart contracts. Please note that the most recent version of Polkadot's Ethereum-compatible stack is available on the TestNet; however, you can also deploy it to the Kusama Hub for production use.
+
+
+## Networks Details
+
+Developers can leverage smart contracts on Kusama Hub for live production deployments. This section outlines the network specifications and connection details.
+
+=== "Kusama Hub"
+
+    Network name
+    ```text
+    Kusama Hub
+    ```
+    ---
+    Currency symbol
+    ```text
+    KSM
+    ```
+    ---
+    
+    Chain ID
+    ```text
+    420420418
+    ```
+    ---
+    
+    RPC URL
+    ```text
+    https://kusama-asset-hub-eth-rpc.polkadot.io
+    ```
+    ---
+    
+    Block explorer URL
+    ```text
+    https://blockscout-kusama-asset-hub.parity-chains-scw.parity.io/
+    ```
+    ---
+
+## Important Deployment Considerations
+
+While the compatibility with regular EVM codebases is still being maximized, some recommendations:
+    
+- **Use Hardhat** to compile, deploy, and interact with your contract.
+- **Use MetaMask** to interact with your dApp (note that using MetaMask can sometimes lead to `Invalid transaction` errors - this is actively being worked on and will be fixed soon).
+- **Avoid REMIX for deployment** - MetaMask enforces a 48kb size limit when using the [REMIX IDE](/develop/smart-contracts/dev-environments/remix){target=\_blank}, which is why [Hardhat Polkadot](/develop/smart-contracts/dev-environments/hardhat){target=\_blank} is recommended for deployment.
+
+Kusama Hub is a live environment. Ensure your contracts are thoroughly tested before deployment, as transactions on Kusama Hub involve real KSM tokens and cannot be reversed.
+
+## Where to Go Next
+
+For your next steps, explore the various smart contract guides demonstrating how to use and integrate different tools and development environments into your workflow.
+
+<div class="grid cards" markdown>
+
+-   <span class="badge guide">Guide</span> **Deploy your first contract with Hardhat**
+    
+    ---
+    
+    Explore the recommended smart contract development and deployment process on Kusama Hub using Hardhat.
+    
+    [:octicons-arrow-right-24: Build with HardHat](/develop/smart-contracts/dev-environments/hardhat/)
+
+-   <span class="badge guide">Guide</span> **Interact with the blockchain with viem**
+    
+    ---
+    
+    Use viem for interacting with Ethereum-compatible chains, to deploy and interact with smart contracts on Kusama Hub.
+    
+    [:octicons-arrow-right-24: Build with viem](/develop/smart-contracts/libraries/viem/)
+
+</div>
 --- END CONTENT ---
 
 Doc-Content: https://docs.polkadot.com/develop/smart-contracts/connect-to-polkadot/

--- a/llms.txt
+++ b/llms.txt
@@ -6919,13 +6919,13 @@ Developers can leverage smart contracts on Kusama Hub for live production deploy
 
 ## Important Deployment Considerations
 
-While the compatibility with regular EVM codebases is still being maximized, some recommendations:
+While the compatibility with regular EVM codebases is still being maximized, some recommendations include:
     
-- **Use Hardhat** to compile, deploy, and interact with your contract.
+- **Leverage Hardhat** to compile, deploy, and interact with your contract.
 - **Use MetaMask** to interact with your dApp (note that using MetaMask can sometimes lead to `Invalid transaction` errors - this is actively being worked on and will be fixed soon).
-- **Avoid REMIX for deployment** - MetaMask enforces a 48kb size limit when using the [REMIX IDE](/develop/smart-contracts/dev-environments/remix){target=\_blank}, which is why [Hardhat Polkadot](/develop/smart-contracts/dev-environments/hardhat){target=\_blank} is recommended for deployment.
+- **Avoid REMIX** for deployment as MetaMask enforces a 48kb size limit when using the [REMIX IDE](/develop/smart-contracts/dev-environments/remix){target=\_blank}, which is why [Hardhat Polkadot](/develop/smart-contracts/dev-environments/hardhat){target=\_blank} is recommended for deployment.
 
-Kusama Hub is a live environment. Ensure your contracts are thoroughly tested before deployment, as transactions on Kusama Hub involve real KSM tokens and cannot be reversed.
+Kusama Hub is a live environment. Ensure your contracts are thoroughly tested before deployment, as transactions on Kusama Hub involve real KSM tokens and **cannot be reversed**.
 
 ## Where to Go Next
 
@@ -6941,11 +6941,11 @@ For your next steps, explore the various smart contract guides demonstrating how
     
     [:octicons-arrow-right-24: Build with HardHat](/develop/smart-contracts/dev-environments/hardhat/)
 
--   <span class="badge guide">Guide</span> **Interact with the blockchain with viem**
+-   <span class="badge guide">Guide</span> **Interact with the blockchain using viem**
     
     ---
     
-    Use viem for interacting with Ethereum-compatible chains, to deploy and interact with smart contracts on Kusama Hub.
+    Use viem for interacting with Ethereum-compatible chains to deploy and interact with smart contracts on Kusama Hub.
     
     [:octicons-arrow-right-24: Build with viem](/develop/smart-contracts/libraries/viem/)
 


### PR DESCRIPTION
This pull request introduces support for connecting to Kusama Hub, a live production environment for deploying smart contracts. It includes updates to documentation, code, and configuration files to integrate Kusama Hub into the developer workflow.

### Documentation Updates:
* Added a new page, `connect-to-kusama.md`, detailing how to connect to Kusama Hub, including network specifications, deployment considerations, and next steps for developers. [[1]](diffhunk://#diff-150051690a6e5630e9981bc2e82d889814e12e66ceb828fc1620ff6b7804f12fR1-R87) [[2]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114R6863-R6954)
* Updated the navigation in `develop/smart-contracts/.pages` to include the new "Connect to Kusama" section.
* Added references to the new documentation page in `llms.txt`.

### Code Updates:
* Enhanced `js/connect-to-metamask.js` to include Kusama Hub in the `supportedNetworks` object, specifying its chain ID, RPC URL, block explorer URL, and native currency details.