### PR TITLE
[FIX] - Accounts page, polkadot to eth section

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -24600,11 +24600,18 @@ The [`AccountId32Mapper`](https://paritytech.github.io/polkadot-sdk/master/palle
 
 ### Polkadot to Ethereum Mapping
 
-The conversion from 32-byte to 20-byte addresses is handled through a stateful mapping system implemented in the [`AddressMapper`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html){target=\_blank} trait. The core functionality includes:
+The conversion from 32-byte Polkadot accounts to 20-byte Ethereum addresses is more complex than the reverse direction due to the lossy nature of the conversion. The [`AccountId32Mapper`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/struct.AccountId32Mapper.html){target=\_blank} handles this through two distinct approaches:
 
-- Address conversion in both directions
-- Account registration and management
-- Mapping status verification
+- **For Ethereum-derived accounts** - The system uses the [`is_eth_derived`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/fn.is_eth_derived.html){target=\_blank} function to detect accounts that were originally Ethereum addresses (identified by the `0xEE` suffix pattern). For these accounts, the conversion simply strips the last 12 bytes to recover the original 20-byte Ethereum address.
+
+- **For native Polkadot accounts** - Since these accounts use the full 32-byte space and weren't derived from Ethereum addresses, direct truncation would lose information. Instead, the system:
+    1. Hashes the entire 32-byte account using Keccak-256
+    2. Takes the last 20 bytes of the hash to create the Ethereum address
+    3. This ensures a deterministic mapping while avoiding simple truncation
+
+The conversion process is implemented through the [`to_address`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.to_address){target=\_blank} function, which automatically detects the account type and applies the appropriate conversion method.
+
+**Stateful Mapping for Reversibility** - Since the conversion from 32-byte to 20-byte addresses is inherently lossy, the system provides an optional stateful mapping through the [`OriginalAccount`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/type.OriginalAccount.html){target=\_blank} storage. When a Polkadot account registers a mapping (via the [`map`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.map){target=\_blank} function), the system stores the original 32-byte account ID, enabling the [`to_account_id`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.to_account_id){target=\_blank} function to recover the exact original account rather than falling back to a default conversion.
 
 ## Account Registration
 

--- a/polkadot-protocol/smart-contract-basics/accounts.md
+++ b/polkadot-protocol/smart-contract-basics/accounts.md
@@ -38,11 +38,18 @@ The [`AccountId32Mapper`](https://paritytech.github.io/polkadot-sdk/master/palle
 
 ### Polkadot to Ethereum Mapping
 
-The conversion from 32-byte to 20-byte addresses is handled through a stateful mapping system implemented in the [`AddressMapper`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html){target=\_blank} trait. The core functionality includes:
+The conversion from 32-byte Polkadot accounts to 20-byte Ethereum addresses is more complex than the reverse direction due to the lossy nature of the conversion. The [`AccountId32Mapper`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/struct.AccountId32Mapper.html){target=\_blank} handles this through two distinct approaches:
 
-- Address conversion in both directions
-- Account registration and management
-- Mapping status verification
+- **For Ethereum-derived accounts** - The system uses the [`is_eth_derived`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/fn.is_eth_derived.html){target=\_blank} function to detect accounts that were originally Ethereum addresses (identified by the `0xEE` suffix pattern). For these accounts, the conversion simply strips the last 12 bytes to recover the original 20-byte Ethereum address.
+
+- **For native Polkadot accounts** - Since these accounts use the full 32-byte space and weren't derived from Ethereum addresses, direct truncation would lose information. Instead, the system:
+    1. Hashes the entire 32-byte account using Keccak-256
+    2. Takes the last 20 bytes of the hash to create the Ethereum address
+    3. This ensures a deterministic mapping while avoiding simple truncation
+
+The conversion process is implemented through the [`to_address`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.to_address){target=\_blank} function, which automatically detects the account type and applies the appropriate conversion method.
+
+**Stateful Mapping for Reversibility** - Since the conversion from 32-byte to 20-byte addresses is inherently lossy, the system provides an optional stateful mapping through the [`OriginalAccount`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/type.OriginalAccount.html){target=\_blank} storage. When a Polkadot account registers a mapping (via the [`map`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.map){target=\_blank} function), the system stores the original 32-byte account ID, enabling the [`to_account_id`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.to_account_id){target=\_blank} function to recover the exact original account rather than falling back to a default conversion.
 
 ## Account Registration
 


### PR DESCRIPTION
This pull request updates documentation related to the `AccountId32Mapper` for Polkadot-to-Ethereum address conversion. The changes clarify the mapping process and introduce details about handling lossy conversions and stateful mappings.

### Updates to Polkadot-to-Ethereum Mapping Documentation:

* **Enhanced Explanation of Conversion Logic**: Added detailed descriptions of the two approaches for converting Polkadot accounts to Ethereum addresses:
  - For Ethereum-derived accounts, the system detects and strips the last 12 bytes to recover the original 20-byte Ethereum address. (`llms.txt` - [[1]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L24603-R24614) `accounts.md` - [[2]](diffhunk://#diff-be7ea61fbb7ad6aa6c248ef03f5a653f662c65357b22661cd505dbe2d82e7ad3L41-R52)
  - For native Polkadot accounts, the system hashes the 32-byte account using Keccak-256 and extracts the last 20 bytes for deterministic mapping. (`llms.txt` - [[1]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L24603-R24614) `accounts.md` - [[2]](diffhunk://#diff-be7ea61fbb7ad6aa6c248ef03f5a653f662c65357b22661cd505dbe2d82e7ad3L41-R52)

* **Stateful Mapping for Reversibility**: Documented the optional stateful mapping mechanism that allows recovery of original 32-byte Polkadot accounts via the `OriginalAccount` storage and `map` function. (`llms.txt` - [[1]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L24603-R24614) `accounts.md` - [[2]](diffhunk://#diff-be7ea61fbb7ad6aa6c248ef03f5a653f662c65357b22661cd505dbe2d82e7ad3L41-R52)

These updates improve clarity and provide a more comprehensive understanding of the address conversion process.