### PR TITLE
[FIX] - update deploy-to-testnet.md to note deprecation of `para_id` in chain specs

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -32500,6 +32500,15 @@ To define your chain specification:
 
     You should now see your chain specification containing SCALE-encoded hex values versus plain text.
 
+
+!!!note "Deprecation of `para_id` in Chain Specs"
+
+    The `para_id` field in JSON chain specifications, added through the [`chain-spec-builder`](https://paritytech.github.io/polkadot-sdk/master/staging_chain_spec_builder/index.html){target=\_blank} command, is currently used by nodes for configuration purposes. However, beginning with Polkadot SDK release `stable2509`, the `para_id` field will no longer be required in chain specifications. Instead, runtimes need to be updated to implement the [`cumulus_primitives_core::GetParachainInfo`](https://paritytech.github.io/polkadot-sdk/master/cumulus_primitives_core/trait.GetParachainInfo.html){target=\_blank} trait to successfully operate with nodes using chain specs that omit the `para_id` field.
+
+    With the upcoming `stable2512` release, the `para_id` field will be completely removed from chain specifications in favor of the new runtime API. New nodes will be unable to start with chain specs containing the `para_id` field unless the runtime implements the `GetParachainInfo` trait. Ensure your runtime is updated to maintain compatibility with future node versions.
+
+    For guidance on performing runtime upgrades to implement this new trait, refer to the [runtime upgrade tutorial](/tutorials/polkadot-sdk/parachains/zero-to-hero/runtime-upgrade/){target=\_blank}.
+
 ## Export Required Files
 
 To prepare the parachain collator to be registered on Paseo, follow these steps:

--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/deploy-to-testnet.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/deploy-to-testnet.md
@@ -148,6 +148,15 @@ To define your chain specification:
 
     You should now see your chain specification containing SCALE-encoded hex values versus plain text.
 
+
+!!!note "Deprecation of `para_id` in Chain Specs"
+
+    The `para_id` field in JSON chain specifications, added through the [`chain-spec-builder`](https://paritytech.github.io/polkadot-sdk/master/staging_chain_spec_builder/index.html){target=\_blank} command, is currently used by nodes for configuration purposes. However, beginning with Polkadot SDK release `stable2509`, the `para_id` field will no longer be required in chain specifications. Instead, runtimes need to be updated to implement the [`cumulus_primitives_core::GetParachainInfo`](https://paritytech.github.io/polkadot-sdk/master/cumulus_primitives_core/trait.GetParachainInfo.html){target=\_blank} trait to successfully operate with nodes using chain specs that omit the `para_id` field.
+
+    With the upcoming `stable2512` release, the `para_id` field will be completely removed from chain specifications in favor of the new runtime API. New nodes will be unable to start with chain specs containing the `para_id` field unless the runtime implements the `GetParachainInfo` trait. Ensure your runtime is updated to maintain compatibility with future node versions.
+
+    For guidance on performing runtime upgrades to implement this new trait, refer to the [runtime upgrade tutorial](/tutorials/polkadot-sdk/parachains/zero-to-hero/runtime-upgrade/){target=\_blank}.
+
 ## Export Required Files
 
 To prepare the parachain collator to be registered on Paseo, follow these steps:


### PR DESCRIPTION
This pull request updates documentation to reflect the deprecation of the `para_id` field in Polkadot SDK chain specifications. It introduces guidance for transitioning to the new runtime API using the `GetParachainInfo` trait.

**_DISCLAIMER_**: This PR uses the following url: `tutorials/polkadot-sdk/parachains/zero-to-hero/runtime-upgrade` which is introduced by https://github.com/polkadot-developers/polkadot-docs/pull/760

### Updates to documentation on `para_id` deprecation:

* [`llms.txt`](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114R32503-R32511): Added a note explaining the upcoming removal of the `para_id` field in chain specifications starting with Polkadot SDK release `stable2512`. It provides details on updating runtimes to implement the `cumulus_primitives_core::GetParachainInfo` trait and links to a runtime upgrade tutorial for further guidance.

* [`tutorials/polkadot-sdk/parachains/zero-to-hero/deploy-to-testnet.md`](diffhunk://#diff-88f2a1f27938d6ca15e0ed4f799602dceaac83cf9f6aeb54b14f1e1077167bcdR151-R159): Included the same note about the deprecation of the `para_id` field, emphasizing the need for runtime updates and compatibility with future node versions.

Fixes #689 