### PR TITLE
[FIX] - correct casing in `interact-with-precompiles.md` page

### DIFF
--- a/develop/smart-contracts/precompiles/interact-with-precompiles.md
+++ b/develop/smart-contracts/precompiles/interact-with-precompiles.md
@@ -1,9 +1,9 @@
 ---
-title: Interact with Precompiles
+title: Interact With Precompiles
 description: Learn how to interact with Polkadot Hub’s precompiles from Solidity to access native, low-level functions like hashing, pairing, EC ops, etc.
 ---
 
-# Interact with Precompiles
+# Interact With Precompiles
 
 --8<-- 'text/smart-contracts/polkaVM-warning.md'
 

--- a/develop/smart-contracts/precompiles/xcm-precompile.md
+++ b/develop/smart-contracts/precompiles/xcm-precompile.md
@@ -1,5 +1,5 @@
 ---
-title: Interact with the XCM Precompile
+title: Interact With the XCM Precompile
 description: Learn how to use the XCM precompile to send cross-chain messages, execute XCM instructions, and estimate costs from your smart contracts.
 categories: Smart Contracts
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -12008,11 +12008,11 @@ Understanding and utilizing precompiles can unlock advanced functionality and pe
 Doc-Content: https://docs.polkadot.com/develop/smart-contracts/precompiles/interact-with-precompiles/
 --- BEGIN CONTENT ---
 ---
-title: Interact with Precompiles
+title: Interact With Precompiles
 description: Learn how to interact with Polkadot Hub’s precompiles from Solidity to access native, low-level functions like hashing, pairing, EC ops, etc.
 ---
 
-# Interact with Precompiles
+# Interact With Precompiles
 
 !!! smartcontract "PolkaVM Preview Release"
     PolkaVM smart contracts with Ethereum compatibility are in **early-stage development and may be unstable or incomplete**.
@@ -12470,7 +12470,7 @@ The examples provided in this guide demonstrate the basic patterns for interacti
 Doc-Content: https://docs.polkadot.com/develop/smart-contracts/precompiles/xcm-precompile/
 --- BEGIN CONTENT ---
 ---
-title: Interact with the XCM Precompile
+title: Interact With the XCM Precompile
 description: Learn how to use the XCM precompile to send cross-chain messages, execute XCM instructions, and estimate costs from your smart contracts.
 categories: Smart Contracts
 ---


### PR DESCRIPTION
This pull request standardizes the capitalization of titles across documentation files by changing "Interact with" to "Interact With" for consistency. The changes affect both standalone documentation files and embedded documentation content.

### Documentation Updates:

* [`develop/smart-contracts/precompiles/interact-with-precompiles.md`](diffhunk://#diff-141f15545cbb887efe1a1c61101e09b830028839513f6aa75364da4d33dce983L2-R6): Updated the title and header capitalization to "Interact With Precompiles" for consistency.
* [`develop/smart-contracts/precompiles/xcm-precompile.md`](diffhunk://#diff-27a1bda03ca6013b4f850170ad92cb8e9bd0dae0701b17af04abcfc50ddf0e2cL2-R2): Updated the title capitalization to "Interact With the XCM Precompile" for consistency.

### Embedded Documentation Updates:

* [`llms.txt`](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L12011-R12015): Updated the embedded documentation content for "Interact With Precompiles" to reflect the standardized capitalization.
* [`llms.txt`](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L12473-R12473): Updated the embedded documentation content for "Interact With the XCM Precompile" to reflect the standardized capitalization.