### PR TITLE
[FIX] - remove specific version of hardhat

### DIFF
--- a/develop/smart-contracts/dev-environments/hardhat.md
+++ b/develop/smart-contracts/dev-environments/hardhat.md
@@ -51,7 +51,7 @@ Before getting started, ensure you have:
 3. To interact with Polkadot, Hardhat requires the following plugin to compile contracts to PolkaVM bytecode and to spawn a local node compatible with PolkaVM:
 
     ```bash
-    npm install --save-dev @parity/hardhat-polkadot@0.1.5
+    npm install --save-dev @parity/hardhat-polkadot
     ```
 
 4. Create a Hardhat project:


### PR DESCRIPTION
When you install hardhat using `npm install --save-dev @parity/hardhat-polkadot@0.1.5` you get an error when running `npx hardhat-polkadot init`.

<img width="1033" height="785" alt="image" src="https://github.com/user-attachments/assets/515494e5-6a8b-42bb-86eb-592bde7418a5" />
