### PR TITLE
Adding pr label checker

### DIFF
--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -7,4 +7,4 @@ jobs:
   check-docs-links:
     uses: papermoonio/workflows/.github/workflows/pr-blocked-label.yml@main
     with: 
-      blocking_labels: "B2 - Blocked"
+      blocking_labels: "B1 - Ready to Merge"

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -1,0 +1,13 @@
+name: 'PR Docs Link Check'
+
+on:
+  pull_request:
+
+jobs:
+  check-docs-links:
+    uses: papermoonio/workflows/.github/workflows/pr-blocked-label.yml@main
+    with:
+      mkdocs_repo: papermoonio/polkadot-mkdocs
+      docs_repo: polkadot-developers/polkadot-docs
+      docs_checkout: polkadot-docs
+      url: https://docs.polkadot.com

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -6,8 +6,5 @@ on:
 jobs:
   check-docs-links:
     uses: papermoonio/workflows/.github/workflows/pr-blocked-label.yml@main
-    with:
-      mkdocs_repo: papermoonio/polkadot-mkdocs
-      docs_repo: polkadot-developers/polkadot-docs
-      docs_checkout: polkadot-docs
-      url: https://docs.polkadot.com
+    with: 
+      blocking_labels: "B2 - Blocked"

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -7,4 +7,4 @@ jobs:
   check-docs-links:
     uses: papermoonio/workflows/.github/workflows/pr-blocked-label.yml@main
     with: 
-      blocking_labels: "B1 - Ready to Merge"
+      whitelist_labels: "B1 - Ready to Merge"

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -1,4 +1,4 @@
-name: 'PR Docs Link Check'
+name: 'Check PR Labels'
 
 on:
   pull_request:


### PR DESCRIPTION
This PR goes with https://github.com/papermoonio/workflows/pull/5

This pull request adds a new GitHub Actions workflow to ensure proper labeling of pull requests. The workflow leverages a reusable workflow to check for documentation-related labels.

### Workflow addition:

* [`.github/workflows/check-pr-labels.yml`](diffhunk://#diff-246a758f4f4b88200b9c146ac52277a7f5f8da296a9ad88b6be7b079a174b1c7R1-R13): Introduced a new workflow named "Check PR Labels" that uses the reusable `pr-blocked-label.yml` workflow to validate PR labels related to documentation. It includes parameters for repositories and URLs for documentation checks.