### PR TITLE
Update Penalties by Offenses

### DIFF
--- a/infrastructure/staking-mechanics/offenses-and-slashes.md
+++ b/infrastructure/staking-mechanics/offenses-and-slashes.md
@@ -157,7 +157,7 @@ The disabling mechanism is triggered when validators commit serious infractions,
 
 Off-chain disabling is always a lower priority than on-chain disabling. Off-chain disabling prioritizes disabling first backers and then approval checkers.
 
-The material in this guide reflects the changes introduced in Stage 2. For more details, see the [State of Disabling issue](https://github.com/paritytech/polkadot-sdk/issues/4359){target=\_blank} on GitHub.
+The material in this guide reflects the changes introduced in Stage 4. For more details, see the [State of Disabling issue](https://github.com/paritytech/polkadot-sdk/issues/4359){target=\_blank} on GitHub.
 
 
 ### Reputation Changes
@@ -170,9 +170,9 @@ Below, you can find a summary of penalties for specific offenses:
 
 |               Offense                | [Slash (%)](#slashing) | [On-Chain Disabling](#disabling) | [Off-Chain Disabling](#disabling) | [Reputational Changes](#reputation-changes) |
 |:------------------------------------:|:----------------------:|:--------------------------------------:|:------------------------------------:|:-------------------------------------------:|
-|           Backing Invalid            |          100%          |                  Yes                   |         Yes (High Priority)          |                     No                      |
-|           ForInvalid Vote            |           -            |                   No                   |          Yes (Mid Priority)          |                     No                      |
-|          AgainstValid Vote           |           -            |                   No                   |          Yes (Low Priority)          |                     No                      |
-| GRANDPA / BABE / BEEFY Equivocations |       0.01-100%        |                  Yes                   |                  No                  |                     No                      |
+|           Backing Invalid            |          100%          |                  Yes (High Priority)   |         Yes (High Priority)          |                     No                      |
+|           ForInvalid Vote            |           2%           |                  Yes (Mid Priority)    |          Yes (Mid Priority)          |                     No                      |
+|          AgainstValid Vote           |           0%           |                  Yes (Low Priority)    |          Yes (Low Priority)          |                     No                      |
+| GRANDPA / BABE / BEEFY Equivocations |       0.01-100%        |                  Yes (Varying Priority)|                  No                  |                     No                      |
 |    Seconded + Valid Equivocation     |           -            |                   No                   |                  No                  |                     No                      |
 |     Double Seconded Equivocation     |           -            |                   No                   |                  No                  |                     Yes                     |

--- a/llms.txt
+++ b/llms.txt
@@ -21055,7 +21055,7 @@ The disabling mechanism is triggered when validators commit serious infractions,
 
 Off-chain disabling is always a lower priority than on-chain disabling. Off-chain disabling prioritizes disabling first backers and then approval checkers.
 
-The material in this guide reflects the changes introduced in Stage 2. For more details, see the [State of Disabling issue](https://github.com/paritytech/polkadot-sdk/issues/4359){target=\_blank} on GitHub.
+The material in this guide reflects the changes introduced in Stage 4. For more details, see the [State of Disabling issue](https://github.com/paritytech/polkadot-sdk/issues/4359){target=\_blank} on GitHub.
 
 
 ### Reputation Changes
@@ -21068,10 +21068,10 @@ Below, you can find a summary of penalties for specific offenses:
 
 |               Offense                | [Slash (%)](#slashing) | [On-Chain Disabling](#disabling) | [Off-Chain Disabling](#disabling) | [Reputational Changes](#reputation-changes) |
 |:------------------------------------:|:----------------------:|:--------------------------------------:|:------------------------------------:|:-------------------------------------------:|
-|           Backing Invalid            |          100%          |                  Yes                   |         Yes (High Priority)          |                     No                      |
-|           ForInvalid Vote            |           -            |                   No                   |          Yes (Mid Priority)          |                     No                      |
-|          AgainstValid Vote           |           -            |                   No                   |          Yes (Low Priority)          |                     No                      |
-| GRANDPA / BABE / BEEFY Equivocations |       0.01-100%        |                  Yes                   |                  No                  |                     No                      |
+|           Backing Invalid            |          100%          |                  Yes (High Priority)   |         Yes (High Priority)          |                     No                      |
+|           ForInvalid Vote            |           2%           |                  Yes (Mid Priority)    |          Yes (Mid Priority)          |                     No                      |
+|          AgainstValid Vote           |           0%           |                  Yes (Low Priority)    |          Yes (Low Priority)          |                     No                      |
+| GRANDPA / BABE / BEEFY Equivocations |       0.01-100%        |                  Yes (Varying Priority)|                  No                  |                     No                      |
 |    Seconded + Valid Equivocation     |           -            |                   No                   |                  No                  |                     No                      |
 |     Double Seconded Equivocation     |           -            |                   No                   |                  No                  |                     Yes                     |
 --- END CONTENT ---


### PR DESCRIPTION
Resolves https://github.com/polkadot-developers/polkadot-docs/issues/789

This pull request updates documentation in two files, `infrastructure/staking-mechanics/offenses-and-slashes.md` and `llms.txt`, to reflect changes in the staking mechanics and penalties for validator infractions. The updates primarily focus on aligning the material with Stage 4 changes and refining the details of penalties and priorities.

### Updates to Staking Mechanics Documentation:

* **Stage Update:**
  - Updated references from Stage 2 to Stage 4 to reflect the latest changes in the disabling mechanism. (`infrastructure/staking-mechanics/offenses-and-slashes.md` - [[1]](diffhunk://#diff-642b3f70d3fe4003f798bf0afa641762a92ede84316dceb387f6208cc89623d7L160-R160) `llms.txt` - [[2]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L21058-R21058)

* **Penalty Table Adjustments:**
  - Revised the penalty table to include updated slashing percentages and priorities for various offenses:
    - `ForInvalid Vote`: Added a 2% slash and introduced "Yes (Mid Priority)" for on-chain disabling.
    - `AgainstValid Vote`: Added a 0% slash and introduced "Yes (Low Priority)" for on-chain disabling.
    - Clarified that `GRANDPA / BABE / BEEFY Equivocations` have varying priorities for on-chain disabling. (`infrastructure/staking-mechanics/offenses-and-slashes.md` - [[1]](diffhunk://#diff-642b3f70d3fe4003f798bf0afa641762a92ede84316dceb387f6208cc89623d7L173-R176) `llms.txt` - [[2]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L21071-R21074)