### PR TITLE
[Fix] - typo

### DIFF
--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -2,6 +2,7 @@ name: 'Check PR Labels'
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   check-docs-links:

--- a/llms.txt
+++ b/llms.txt
@@ -27180,7 +27180,7 @@ template: index-page.html
 
 Discover comprehensive tutorials that guide you through performing asset transfers between distinct consensus systems. These tutorials leverage [XCM (Cross-Consensus Messaging)](/develop/interoperability/intro-to-xcm/){target=\_blank} technology, that enables cross-chain communication and asset exchanges across different blockchain networks. Whether you're working within the same ecosystem or bridging multiple systems, XCM ensures secure, efficient, and interoperable solutions.
 
-By mastering XCM-based transfers, you'll unlock new possibilities for building cross-chain applications and expanding blockchain utility. Learn the methods, tools, and best practices for testibg XCM-powered transfers, ensuring your systems achieve robust interoperability.
+By mastering XCM-based transfers, you'll unlock new possibilities for building cross-chain applications and expanding blockchain utility. Learn the methods, tools, and best practices for testing XCM-powered transfers, ensuring your systems achieve robust interoperability.
 
 ## In This Section
 

--- a/tutorials/interoperability/xcm-transfers/index.md
+++ b/tutorials/interoperability/xcm-transfers/index.md
@@ -8,7 +8,7 @@ template: index-page.html
 
 Discover comprehensive tutorials that guide you through performing asset transfers between distinct consensus systems. These tutorials leverage [XCM (Cross-Consensus Messaging)](/develop/interoperability/intro-to-xcm/){target=\_blank} technology, that enables cross-chain communication and asset exchanges across different blockchain networks. Whether you're working within the same ecosystem or bridging multiple systems, XCM ensures secure, efficient, and interoperable solutions.
 
-By mastering XCM-based transfers, you'll unlock new possibilities for building cross-chain applications and expanding blockchain utility. Learn the methods, tools, and best practices for testibg XCM-powered transfers, ensuring your systems achieve robust interoperability.
+By mastering XCM-based transfers, you'll unlock new possibilities for building cross-chain applications and expanding blockchain utility. Learn the methods, tools, and best practices for testing XCM-powered transfers, ensuring your systems achieve robust interoperability.
 
 ## In This Section
 


### PR DESCRIPTION
This pull request includes minor typo corrections in documentation to improve clarity and professionalism.

* Typo Fixes:
  * Corrected "testibg" to "testing" in the `template: index-page.html` section of `llms.txt`.
  * Corrected "testibg" to "testing" in the `template: index-page.html` section of `tutorials/interoperability/xcm-transfers/index.md`.