### PR TITLE
[FIX] - Adding disclaimer for accounts

### DIFF
--- a/develop/smart-contracts/connect-to-kusama.md
+++ b/develop/smart-contracts/connect-to-kusama.md
@@ -16,6 +16,8 @@ For more information about how to connect to a Polkadot network, please check th
 !!! info "Production Environment"
     Kusama Hub offers a live environment for deploying smart contracts. Please note that the most recent version of Polkadot's Ethereum-compatible stack is available on the TestNet; however, you can also deploy it to the Kusama Hub for production use.
 
+!!! warning "Account Mapping"
+    If you are using a native Polkadot account (32-byte format) that was created with a Polkadot/Substrate keypair (Ed25519/Sr25519) rather than an Ethereum-compatible keypair (secp256k1), you'll need to map your account to enable Ethereum compatibility. See the [Account Mapping](/polkadot-protocol/smart-contract-basics/accounts#account-mapping-for-native-polkadot-accounts){target=\_blank} section for more details.
 
 ## Networks Details
 

--- a/develop/smart-contracts/connect-to-polkadot.md
+++ b/develop/smart-contracts/connect-to-polkadot.md
@@ -13,6 +13,9 @@ description: Explore how to connect to Polkadot Hub, configure your wallet, and 
 
 For more information about how to connect to Polkadot Hub, please check the [Wallets for Polkadot Hub](/develop/smart-contracts/wallets/){target=\_blank} guide.
 
+!!! warning "Account Mapping"
+    If you are using a native Polkadot account (32-byte format) that was created with a Polkadot/Substrate keypair (Ed25519/Sr25519) rather than an Ethereum-compatible keypair (secp256k1), you'll need to map your account to enable Ethereum compatibility. See the [Account Mapping](/polkadot-protocol/smart-contract-basics/accounts#account-mapping-for-native-polkadot-accounts){target=\_blank} section for more details.
+
 ## Networks Details
 
 Developers can leverage smart contracts across diverse networks, from TestNets to MainNet. This section outlines the network specifications and connection details for each environment.

--- a/llms.txt
+++ b/llms.txt
@@ -6887,6 +6887,8 @@ For more information about how to connect to a Polkadot network, please check th
 !!! info "Production Environment"
     Kusama Hub offers a live environment for deploying smart contracts. Please note that the most recent version of Polkadot's Ethereum-compatible stack is available on the TestNet; however, you can also deploy it to the Kusama Hub for production use.
 
+!!! warning "Account Mapping"
+    If you are using a native Polkadot account (32-byte format) that was created with a Polkadot/Substrate keypair (Ed25519/Sr25519) rather than an Ethereum-compatible keypair (secp256k1), you'll need to map your account to enable Ethereum compatibility. See the [Account Mapping](/polkadot-protocol/smart-contract-basics/accounts#account-mapping-for-native-polkadot-accounts){target=\_blank} section for more details.
 
 ## Networks Details
 
@@ -6975,6 +6977,9 @@ description: Explore how to connect to Polkadot Hub, configure your wallet, and 
 </div>
 
 For more information about how to connect to Polkadot Hub, please check the [Wallets for Polkadot Hub](/develop/smart-contracts/wallets/){target=\_blank} guide.
+
+!!! warning "Account Mapping"
+    If you are using a native Polkadot account (32-byte format) that was created with a Polkadot/Substrate keypair (Ed25519/Sr25519) rather than an Ethereum-compatible keypair (secp256k1), you'll need to map your account to enable Ethereum compatibility. See the [Account Mapping](/polkadot-protocol/smart-contract-basics/accounts#account-mapping-for-native-polkadot-accounts){target=\_blank} section for more details.
 
 ## Networks Details
 
@@ -25362,6 +25367,25 @@ The conversion from 32-byte Polkadot accounts to 20-byte Ethereum addresses is m
 The conversion process is implemented through the [`to_address`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.to_address){target=\_blank} function, which automatically detects the account type and applies the appropriate conversion method.
 
 **Stateful Mapping for Reversibility** : Since the conversion from 32-byte to 20-byte addresses is inherently lossy, the system provides an optional stateful mapping through the [`OriginalAccount`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/type.OriginalAccount.html){target=\_blank} storage. When a Polkadot account registers a mapping (via the [`map`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.map){target=\_blank} function), the system stores the original 32-byte account ID, enabling the [`to_account_id`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.to_account_id){target=\_blank} function to recover the exact original account rather than falling back to a default conversion.
+
+
+### Account Mapping for Native Polkadot Accounts
+
+If you have a native Polkadot account (32-byte format) that was created with a Polkadot/Substrate keypair (Ed25519/Sr25519) rather than an Ethereum-compatible keypair (secp256k1), you'll need to map your account to enable Ethereum compatibility.
+
+To map your account:
+
+1. Call the [`map_account`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/dispatchables/fn.map_account.html){target=\_blank} extrinsic of the [`pallet_revive`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/index.html){target=\_blank} pallet using your original Substrate account.
+2. This creates a stateful mapping that allows your 32-byte account to interact with the Ethereum-compatible smart contract system.
+
+Once mapped, you'll be able to:
+
+- Transfer funds between 20-byte format addresses.
+- Interact with smart contracts using Ethereum-compatible tools like MetaMask.
+- Maintain full reversibility to your original 32-byte account format.
+
+!!! warning "Mapping Requirement"
+    Without this mapping, native Polkadot accounts cannot transfer funds or interact with the Ethereum-compatible layer on the Hub.
 
 ## Account Registration
 

--- a/llms.txt
+++ b/llms.txt
@@ -25373,10 +25373,7 @@ The conversion process is implemented through the [`to_address`](https://parityt
 
 If you have a native Polkadot account (32-byte format) that was created with a Polkadot/Substrate keypair (Ed25519/Sr25519) rather than an Ethereum-compatible keypair (secp256k1), you'll need to map your account to enable Ethereum compatibility.
 
-To map your account:
-
-1. Call the [`map_account`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/dispatchables/fn.map_account.html){target=\_blank} extrinsic of the [`pallet_revive`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/index.html){target=\_blank} pallet using your original Substrate account.
-2. This creates a stateful mapping that allows your 32-byte account to interact with the Ethereum-compatible smart contract system.
+To map your account, call the [`map_account`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/dispatchables/fn.map_account.html){target=\_blank} extrinsic of the [`pallet_revive`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/index.html){target=\_blank} pallet using your original Substrate account. This creates a stateful mapping that allows your 32-byte account to interact with the Ethereum-compatible smart contract system.
 
 Once mapped, you'll be able to:
 

--- a/polkadot-protocol/smart-contract-basics/accounts.md
+++ b/polkadot-protocol/smart-contract-basics/accounts.md
@@ -56,10 +56,7 @@ The conversion process is implemented through the [`to_address`](https://parityt
 
 If you have a native Polkadot account (32-byte format) that was created with a Polkadot/Substrate keypair (Ed25519/Sr25519) rather than an Ethereum-compatible keypair (secp256k1), you'll need to map your account to enable Ethereum compatibility.
 
-To map your account:
-
-1. Call the [`map_account`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/dispatchables/fn.map_account.html){target=\_blank} extrinsic of the [`pallet_revive`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/index.html){target=\_blank} pallet using your original Substrate account.
-2. This creates a stateful mapping that allows your 32-byte account to interact with the Ethereum-compatible smart contract system.
+To map your account, call the [`map_account`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/dispatchables/fn.map_account.html){target=\_blank} extrinsic of the [`pallet_revive`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/index.html){target=\_blank} pallet using your original Substrate account. This creates a stateful mapping that allows your 32-byte account to interact with the Ethereum-compatible smart contract system.
 
 Once mapped, you'll be able to:
 

--- a/polkadot-protocol/smart-contract-basics/accounts.md
+++ b/polkadot-protocol/smart-contract-basics/accounts.md
@@ -51,6 +51,25 @@ The conversion process is implemented through the [`to_address`](https://parityt
 
 **Stateful Mapping for Reversibility** : Since the conversion from 32-byte to 20-byte addresses is inherently lossy, the system provides an optional stateful mapping through the [`OriginalAccount`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/type.OriginalAccount.html){target=\_blank} storage. When a Polkadot account registers a mapping (via the [`map`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.map){target=\_blank} function), the system stores the original 32-byte account ID, enabling the [`to_account_id`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.to_account_id){target=\_blank} function to recover the exact original account rather than falling back to a default conversion.
 
+
+### Account Mapping for Native Polkadot Accounts
+
+If you have a native Polkadot account (32-byte format) that was created with a Polkadot/Substrate keypair (Ed25519/Sr25519) rather than an Ethereum-compatible keypair (secp256k1), you'll need to map your account to enable Ethereum compatibility.
+
+To map your account:
+
+1. Call the [`map_account`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/pallet/dispatchables/fn.map_account.html){target=\_blank} extrinsic of the [`pallet_revive`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/index.html){target=\_blank} pallet using your original Substrate account.
+2. This creates a stateful mapping that allows your 32-byte account to interact with the Ethereum-compatible smart contract system.
+
+Once mapped, you'll be able to:
+
+- Transfer funds between 20-byte format addresses.
+- Interact with smart contracts using Ethereum-compatible tools like MetaMask.
+- Maintain full reversibility to your original 32-byte account format.
+
+!!! warning "Mapping Requirement"
+    Without this mapping, native Polkadot accounts cannot transfer funds or interact with the Ethereum-compatible layer on the Hub.
+
 ## Account Registration
 
 The registration process is implemented through the [`map`](https://paritytech.github.io/polkadot-sdk/master/pallet_revive/trait.AddressMapper.html#tymethod.map){target=\_blank} function. This process involves:


### PR DESCRIPTION
Fixes https://github.com/polkadot-developers/polkadot-docs/issues/822
This pull request introduces documentation updates to explain the process of mapping native Polkadot accounts for Ethereum compatibility. The changes add warnings and detailed instructions across multiple files to guide users on enabling compatibility for accounts created with Polkadot/Substrate keypairs.

### Additions to Documentation on Account Mapping:

* **General Warnings on Account Mapping**:
  - Added warnings in `connect-to-kusama.md`, `connect-to-polkadot.md`, and `llms.txt` to inform users that native Polkadot accounts (32-byte format) must be mapped for Ethereum compatibility. Links to the detailed "Account Mapping" section are included. [[1]](diffhunk://#diff-150051690a6e5630e9981bc2e82d889814e12e66ceb828fc1620ff6b7804f12fR19-R20) [[2]](diffhunk://#diff-9c331e9d30ae9a2f2f2bedbb90ac5390a32277b0414ae729830f8ef8ce05d2c3R16-R18) [[3]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114R6890-R6891) [[4]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114R6981-R6983)

* **Detailed Account Mapping Instructions**:
  - Expanded the "Account Mapping for Native Polkadot Accounts" section in `accounts.md` and `llms.txt` to include step-by-step instructions for mapping accounts using the `map_account` extrinsic from the `pallet_revive` pallet. This includes information on transferring funds, interacting with smart contracts, and maintaining reversibility. [[1]](diffhunk://#diff-be7ea61fbb7ad6aa6c248ef03f5a653f662c65357b22661cd505dbe2d82e7ad3R54-R72) [[2]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114R25371-R25389)