### PR TITLE
Point to Wiki for offenses table

### DIFF
--- a/infrastructure/staking-mechanics/offenses-and-slashes.md
+++ b/infrastructure/staking-mechanics/offenses-and-slashes.md
@@ -166,4 +166,4 @@ Some minor offenses, such as spamming, are only punished by networking reputatio
 
 ### Penalties by Offense
 
-Refer to the Polkadot Wiki's [offences page](https://wiki.polkadot.com/learn/learn-offenses/){target=\_blank} for a summary of penalties for specific offenses.
+Refer to the Polkadot Wiki's [offenses page](https://wiki.polkadot.com/learn/learn-offenses/){target=\_blank} for a summary of penalties for specific offenses.

--- a/llms.txt
+++ b/llms.txt
@@ -21483,7 +21483,7 @@ Some minor offenses, such as spamming, are only punished by networking reputatio
 
 ### Penalties by Offense
 
-Refer to the Polkadot Wiki's [offences page](https://wiki.polkadot.com/learn/learn-offenses/){target=\_blank} for a summary of penalties for specific offenses.
+Refer to the Polkadot Wiki's [offenses page](https://wiki.polkadot.com/learn/learn-offenses/){target=\_blank} for a summary of penalties for specific offenses.
 --- END CONTENT ---
 
 Doc-Content: https://docs.polkadot.com/infrastructure/staking-mechanics/rewards-payout/


### PR DESCRIPTION
Resolves https://github.com/polkadot-developers/polkadot-docs/pull/855

Removed the detailed table summarizing penalties for specific offenses and replaced it with a link to the Polkadot Wiki's [offenses page](https://wiki.polkadot.com/learn/learn-offenses/) for one source of truth and up-to-date information.