### PR TITLE
Add guide for remote proxy implemention

### DIFF
--- a/.snippets/code/develop/toolkit/parachains/remote-proxies/remote-proxy-example.js
+++ b/.snippets/code/develop/toolkit/parachains/remote-proxies/remote-proxy-example.js
@@ -1,0 +1,81 @@
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
+// Account configuration - replace with your addresses
+const RECIPIENT_ACCOUNT = 'INSERT_RECIPIENT_ACCOUNT';
+const PROXIED_ACCOUNT = 'INSERT_PROXIED_ACCOUNT';
+
+async function executeRemoteProxyTransaction() {
+  try {
+    // Establish connections to both chains
+    console.log('Connecting to Kusama relay chain...');
+    const kusamaProvider = new WsProvider(
+      'wss://kusama.public.curie.radiumblock.co/ws',
+    );
+    const kusamaApi = await ApiPromise.create({ provider: kusamaProvider });
+
+    console.log('Connecting to Kusama Asset Hub...');
+    const assetHubProvider = new WsProvider(
+      'wss://kusama-asset-hub-rpc.polkadot.io',
+    );
+    const assetHubApi = await ApiPromise.create({ provider: assetHubProvider });
+
+    // Step 1: Generate storage key for proxy definition
+    const proxyStorageKey = kusamaApi.query.proxy.proxies.key(PROXIED_ACCOUNT);
+    console.log(`Proxy storage key: ${proxyStorageKey}`);
+
+    // Step 2: Identify latest recognized block
+    const blockToRootMapping = JSON.parse(
+      await assetHubApi.query.remoteProxyRelayChain.blockToRoot(),
+    );
+    const latestRecognizedBlock =
+      blockToRootMapping[blockToRootMapping.length - 1][0];
+    const blockHash = await kusamaApi.rpc.chain.getBlockHash(
+      latestRecognizedBlock,
+    );
+
+    console.log(`Generating proof for block ${latestRecognizedBlock}`);
+
+    // Step 3: Create storage proof
+    const storageProof = JSON.parse(
+      await kusamaApi.rpc.state.getReadProof([proxyStorageKey], blockHash),
+    );
+
+    // Step 4: Define target transaction
+    const targetTransaction = assetHubApi.tx.balances.transferAll(
+      RECIPIENT_ACCOUNT,
+      false,
+    );
+
+    // Step 5: Construct remote proxy call
+    const remoteProxyCall = assetHubApi.tx.remoteProxyRelayChain.remoteProxy(
+      PROXIED_ACCOUNT,
+      null, // Proxy type filter (null accepts any compatible type)
+      targetTransaction.method,
+      {
+        RelayChain: {
+          proof: storageProof.proof,
+          block: latestRecognizedBlock,
+        },
+      },
+    );
+
+    console.log('\n✅ Remote proxy transaction constructed successfully!');
+    console.log('\n📋 Next steps:');
+    console.log('1. Copy the URL below');
+    console.log('2. Open in Polkadot.js Apps');
+    console.log('3. Submit the transaction within 1 minute');
+    console.log('\n🔗 Polkadot.js Apps URL:');
+    console.log(
+      `https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama-asset-hub-rpc.polkadot.io#/extrinsics/decode/${remoteProxyCall.method.toHex()}`,
+    );
+
+    // Cleanup connections
+    await kusamaApi.disconnect();
+    await assetHubApi.disconnect();
+  } catch (error) {
+    console.error('❌ Remote proxy execution failed:', error.message);
+  }
+}
+
+// Execute the remote proxy workflow
+executeRemoteProxyTransaction();

--- a/develop/toolkit/parachains/.nav.yml
+++ b/develop/toolkit/parachains/.nav.yml
@@ -6,5 +6,6 @@ nav:
   - fork-chains
   - e2e-testing
   - 'Light Clients': light-clients.md
+  - 'Remote Proxies': remote-proxies.md
   - 'RPC Calls': rpc-calls.md
   - 'Polkadot Omni Node': polkadot-omni-node.md

--- a/develop/toolkit/parachains/remote-proxies.md
+++ b/develop/toolkit/parachains/remote-proxies.md
@@ -1,0 +1,178 @@
+---
+title: Remote Proxies
+description: Remote proxies enable cross-chain proxy functionality within the Polkadot ecosystem, allowing proxy accounts defined on one chain to execute transactions on different chains through cryptographic storage proofs.
+---
+
+
+# Remote Proxies
+
+!!!warning "Kusama Implementation Only"
+    Remote proxies are currently only available on Kusama and its parachains (such as Kusama Asset Hub). This feature is not yet deployed on Polkadot MainNet. The examples and implementations described in this guide are specific to the Kusama ecosystem.
+
+## Introduction
+
+Remote proxies enable cross-chain proxy functionality within the Polkadot ecosystem, allowing proxy accounts defined on one chain to execute transactions on different chains through cryptographic storage proofs. This extends the traditional [proxy system](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank} beyond single-chain boundaries.
+
+This guide covers:
+
+- Understanding remote proxy mechanics and architecture
+- Implementation workflow and timing constraints  
+- Practical examples using Polkadot.js
+- Advanced use cases and security considerations
+
+Remote proxies are particularly valuable for maintaining unified security models across multiple parachains while avoiding the complexity of managing separate proxy setups on each chain.
+
+!!!note "Traditional vs Remote Proxies"
+    Traditional proxies work within a single chain, where both the proxy and proxied accounts exist on the same blockchain. Remote proxies extend this concept across chains, using cryptographic proofs to verify proxy relationships without requiring account replication.
+
+## Remote Proxy Architecture
+
+Remote proxies operate through a trust and verification model using storage proofs. The target chain verifies the existence of proxy relationships on the source chain without requiring direct replication of proxy data.
+
+```mermaid
+flowchart LR
+RC([Relay Chain])-- Proxy Definition -->AH([Asset Hub])
+RC -- Storage Proof --> AH
+AH -- Verify Proof --> TX([Execute Transaction])
+AH -- Trust Relationship --> RC
+```
+
+In this architecture, Asset Hub trusts proxy definitions from the Relay Chain. When a remote proxy transaction is initiated, Asset Hub verifies the storage proof against its stored block roots from the Relay Chain, ensuring the proxy relationship is authentic and current.
+
+The verification process utilizes [Merkle proofs](/polkadot-protocol/glossary/#trie-patricia-merkle-tree){target=\_blank} to confirm proxy permissions exist on the source chain at a specific block height.
+
+!!!note "What makes remote proxies secure?"
+    Remote proxies maintain security through cryptographic storage proofs that cannot be forged. The target chain verifies these proofs against trusted block roots, ensuring proxy relationships are authentic without requiring blind trust in external nodes.
+
+## Implementation Workflow
+
+Remote proxy execution follows a time-constrained workflow requiring coordination between multiple chains. The remote proxy workflow consists of several critical steps that must be completed within a narrow time window.
+
+1. **Block Synchronization** - Query the target chain for recognized source chain blocks
+2. **Storage Proof Creation** - Generate cryptographic proof of proxy relationship  
+3. **Transaction Construction** - Build the wrapped transaction with proof data
+4. **Execution** - Submit the transaction before proof expiration
+
+Remote proxies operate under strict timing limitations.
+
+- **Proof Validity**: Storage proofs expire after approximately **1 minute**
+- **Block Recognition**: Target chains maintain only recent source chain block roots
+- **Execution Window**: Transactions must be submitted immediately after proof generation
+
+These constraints exist to prevent replay attacks and ensure proof freshness while maintaining system security.
+
+| Constraint Type | Duration | Purpose |
+| :-------------: | :------: | :-----: |
+| Proof Validity | ~1 minute | Prevent replay attacks |
+| Block Storage | ~10 minutes | Balance security and usability |
+| Execution Window | Immediate | Ensure proof freshness |
+
+## Practical Implementation
+
+### Prerequisites
+
+Before implementing remote proxies, ensure you have:
+
+- Active proxy relationship on the source chain (Kusama)
+- Access to both source and target chain RPC endpoints
+- Compatible proxy types between chains
+- Node.js environment for script execution
+
+### Installation and Setup
+
+```bash
+# Install required dependencies
+yarn add @polkadot/api
+
+# Create your implementation script
+touch remote-proxy-example.js
+```
+
+### Complete Implementation Example
+
+```javascript
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
+// Account configuration - replace with your addresses
+const RECIPIENT_ACCOUNT = '5EjdajLJp5CKhGVaWV21wiyGxUw42rhCqGN32LuVH4wrqXTN';
+const PROXIED_ACCOUNT = 'D9o7gYB92kXgr1UTjYWLDwXK5BeJdxR2irjwaoDEhJnNCfp';
+
+async function executeRemoteProxyTransaction() {
+  try {
+    // Establish connections to both chains
+    console.log('Connecting to Kusama relay chain...');
+    const kusamaProvider = new WsProvider('wss://kusama.public.curie.radiumblock.co/ws');
+    const kusamaApi = await ApiPromise.create({ provider: kusamaProvider });
+
+    console.log('Connecting to Kusama Asset Hub...');
+    const assetHubProvider = new WsProvider('wss://kusama-asset-hub-rpc.polkadot.io');
+    const assetHubApi = await ApiPromise.create({ provider: assetHubProvider });
+
+    // Step 1: Generate storage key for proxy definition
+    const proxyStorageKey = kusamaApi.query.proxy.proxies.key(PROXIED_ACCOUNT);
+    console.log(`Proxy storage key: ${proxyStorageKey}`);
+
+    // Step 2: Identify latest recognized block
+    const blockToRootMapping = JSON.parse(
+      await assetHubApi.query.remoteProxyRelayChain.blockToRoot()
+    );
+    const latestRecognizedBlock = blockToRootMapping[blockToRootMapping.length - 1][0];
+    const blockHash = await kusamaApi.rpc.chain.getBlockHash(latestRecognizedBlock);
+    
+    console.log(`Generating proof for block ${latestRecognizedBlock}`);
+
+    // Step 3: Create storage proof
+    const storageProof = JSON.parse(
+      await kusamaApi.rpc.state.getReadProof([proxyStorageKey], blockHash)
+    );
+
+    // Step 4: Define target transaction
+    const targetTransaction = assetHubApi.tx.balances.transferAll(RECIPIENT_ACCOUNT, false);
+
+    // Step 5: Construct remote proxy call
+    const remoteProxyCall = assetHubApi.tx.remoteProxyRelayChain.remoteProxy(
+      PROXIED_ACCOUNT,
+      null, // Proxy type filter (null accepts any compatible type)
+      targetTransaction.method,
+      { 
+        RelayChain: { 
+          proof: storageProof.proof, 
+          block: latestRecognizedBlock 
+        }
+      }
+    );
+
+    console.log('\n✅ Remote proxy transaction constructed successfully!');
+    console.log('\n📋 Next steps:');
+    console.log('1. Copy the URL below');
+    console.log('2. Open in Polkadot.js Apps');
+    console.log('3. Submit the transaction within 1 minute');
+    console.log('\n🔗 Polkadot.js Apps URL:');
+    console.log(`https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama-asset-hub-rpc.polkadot.io#/extrinsics/decode/${remoteProxyCall.method.toHex()}`);
+
+    // Cleanup connections
+    await kusamaApi.disconnect();
+    await assetHubApi.disconnect();
+
+  } catch (error) {
+    console.error('❌ Remote proxy execution failed:', error.message);
+  }
+}
+
+// Execute the remote proxy workflow
+executeRemoteProxyTransaction();
+```
+
+The code snippet above is a complete implementation example of a remote proxy transaction. It demonstrates how to:
+
+- **Storage Key Generation**: The `proxyStorageKey` identifies where proxy relationship data is stored on Kusama. This key is used to create a proof that the relationship exists.
+- **Block Synchronization**: Asset Hub maintains a mapping of recent Kusama block numbers to their storage roots. This enables proof verification without requiring full blockchain synchronization.
+- **Proof Creation**: The `getReadProof` RPC call generates a cryptographic proof that specific data exists in Kusama's state at a given block height.
+- **Transaction Wrapping**: The target transaction is wrapped within a `remoteProxy` call that includes both the proof data and the block anchor.
+
+## Resources
+
+- [Traditional Proxies Guide](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank}
+- [Polkadot.js API Documentation](https://polkadot.js.org/docs/){target=\_blank}
+- [Kusama Asset Hub Information](https://wiki.polkadot.com/docs/learn-assets){target=\_blank}
+- [Cross-Chain Message Passing (XCM)](/polkadot-protocol/xcm){target=\_blank}

--- a/develop/toolkit/parachains/remote-proxies.md
+++ b/develop/toolkit/parachains/remote-proxies.md
@@ -10,14 +10,14 @@ description: Remote proxies enable cross-chain proxy functionality within the Po
 
 ## Introduction
 
-Remote proxies enable cross-chain proxy functionality within the Polkadot ecosystem, allowing proxy accounts defined on one chain to execute transactions on different chains through cryptographic storage proofs. This extends the traditional [proxy system](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank} beyond single-chain boundaries.
+Remote proxies enable cross-chain proxy functionality within the Polkadot ecosystem, allowing proxy accounts defined on one chain to execute transactions on different chains through cryptographic storage proofs. This functionality extends the traditional [proxy system](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank} beyond single-chain boundaries.
 
 This guide covers:
 
-- Understanding remote proxy mechanics and architecture
-- Implementation workflow and timing constraints  
-- Practical examples using Polkadot.js
-- Advanced use cases and security considerations
+- Understanding remote proxy mechanics and architecture.
+- Implementation workflow and timing constraints.
+- Practical examples using Polkadot.js.
+- Advanced use cases and security considerations.
 
 Remote proxies are particularly valuable for maintaining unified security models across multiple parachains while avoiding the complexity of managing separate proxy setups on each chain.
 
@@ -47,16 +47,16 @@ The verification process utilizes [Merkle proofs](/polkadot-protocol/glossary/#t
 
 Remote proxy execution follows a time-constrained workflow requiring coordination between multiple chains. The remote proxy workflow consists of several critical steps that must be completed within a narrow time window.
 
-1. **Block Synchronization** - Query the target chain for recognized source chain blocks
-2. **Storage Proof Creation** - Generate cryptographic proof of proxy relationship  
-3. **Transaction Construction** - Build the wrapped transaction with proof data
-4. **Execution** - Submit the transaction before proof expiration
+1. **Block Synchronization**: Query the target chain for recognized source chain blocks.
+2. **Storage Proof Creation**: Generate cryptographic proof of proxy relationship. 
+3. **Transaction Construction**: Build the wrapped transaction with proof data.
+4. **Execution**: Submit the transaction before proof expiration.
 
 Remote proxies operate under strict timing limitations.
 
-- **Proof Validity**: Storage proofs expire after approximately **1 minute**
-- **Block Recognition**: Target chains maintain only recent source chain block roots
-- **Execution Window**: Transactions must be submitted immediately after proof generation
+- **Proof Validity**: Storage proofs expire after approximately **1 minute**.
+- **Block Recognition**: Target chains maintain only recent source chain block roots.
+- **Execution Window**: Transactions must be submitted immediately after proof generation.
 
 These constraints exist to prevent replay attacks and ensure proof freshness while maintaining system security.
 
@@ -72,10 +72,10 @@ These constraints exist to prevent replay attacks and ensure proof freshness whi
 
 Before implementing remote proxies, ensure you have:
 
-- Active proxy relationship on the source chain (Kusama)
-- Access to both source and target chain RPC endpoints
-- Compatible proxy types between chains
-- Node.js environment for script execution
+- Active proxy relationship on the source chain (Kusama).
+- Access to both source and target chain RPC endpoints.
+- Compatible proxy types between chains.
+- Node.js environment for script execution.
 
 ### Installation and Setup
 
@@ -99,12 +99,12 @@ Here is a complete implementation example of a remote proxy transaction:
 --8<-- "code/develop/toolkit/parachains/remote-proxies/remote-proxy-example.js"
 ```
 
-Ensure to replace the `RECIPIENT_ACCOUNT` and `PROXIED_ACCOUNT` with your own accounts. For a concrete example, check out the [Sending a remote proxy transaction via Polkadot-JS](https://blog.kchr.de/polkadot/guides/remote-proxies-for-the-braves/#sending-a-remote-proxy-transaction-via-polkadot-js){target=\_blank} section in the Remote Proxies article.
+Ensure to replace the `RECIPIENT_ACCOUNT` and `PROXIED_ACCOUNT` with your accounts. For a concrete example, check out the [Sending a remote proxy transaction via Polkadot-JS](https://blog.kchr.de/polkadot/guides/remote-proxies-for-the-braves/#sending-a-remote-proxy-transaction-via-polkadot-js){target=\_blank} section in the Remote Proxies article.
 
 The code snippet above is a complete implementation example of a remote proxy transaction. It demonstrates how to:
 
 - **Storage Key Generation**: The `proxyStorageKey` identifies where proxy relationship data is stored on Kusama. This key is used to create a proof that the relationship exists.
-- **Block Synchronization**: Asset Hub maintains a mapping of recent Kusama block numbers to their storage roots. This enables proof verification without requiring full blockchain synchronization.
+- **Block Synchronization**: Asset Hub maintains a mapping of recent Kusama block numbers to their storage roots to enable proof verification without requiring full blockchain synchronization.
 - **Proof Creation**: The `getReadProof` RPC call generates a cryptographic proof that specific data exists in Kusama's state at a given block height.
 - **Transaction Wrapping**: The target transaction is wrapped within a `remoteProxy` call that includes both the proof data and the block anchor.
 

--- a/develop/toolkit/parachains/remote-proxies.md
+++ b/develop/toolkit/parachains/remote-proxies.md
@@ -3,7 +3,6 @@ title: Remote Proxies
 description: Remote proxies enable cross-chain proxy functionality within the Polkadot ecosystem, allowing proxy accounts defined on one chain to execute transactions on different chains through cryptographic storage proofs.
 ---
 
-
 # Remote Proxies
 
 !!!warning "Kusama Implementation Only"
@@ -80,88 +79,27 @@ Before implementing remote proxies, ensure you have:
 
 ### Installation and Setup
 
-```bash
-# Install required dependencies
-yarn add @polkadot/api
+To implement remote proxies, you need to install the [`@polkadot/api`](/develop/toolkit/api-libraries/polkadot-js-api/){target=\_blank} package and create a script to execute the remote proxy transaction:
 
-# Create your implementation script
+```bash
+pnpm add @polkadot/api
+```
+
+Create your implementation script:
+
+```bash
 touch remote-proxy-example.js
 ```
 
-### Complete Implementation Example
+### Implementation Example
 
-```javascript
-import { ApiPromise, WsProvider } from '@polkadot/api';
+Here is a complete implementation example of a remote proxy transaction:
 
-// Account configuration - replace with your addresses
-const RECIPIENT_ACCOUNT = '5EjdajLJp5CKhGVaWV21wiyGxUw42rhCqGN32LuVH4wrqXTN';
-const PROXIED_ACCOUNT = 'D9o7gYB92kXgr1UTjYWLDwXK5BeJdxR2irjwaoDEhJnNCfp';
-
-async function executeRemoteProxyTransaction() {
-  try {
-    // Establish connections to both chains
-    console.log('Connecting to Kusama relay chain...');
-    const kusamaProvider = new WsProvider('wss://kusama.public.curie.radiumblock.co/ws');
-    const kusamaApi = await ApiPromise.create({ provider: kusamaProvider });
-
-    console.log('Connecting to Kusama Asset Hub...');
-    const assetHubProvider = new WsProvider('wss://kusama-asset-hub-rpc.polkadot.io');
-    const assetHubApi = await ApiPromise.create({ provider: assetHubProvider });
-
-    // Step 1: Generate storage key for proxy definition
-    const proxyStorageKey = kusamaApi.query.proxy.proxies.key(PROXIED_ACCOUNT);
-    console.log(`Proxy storage key: ${proxyStorageKey}`);
-
-    // Step 2: Identify latest recognized block
-    const blockToRootMapping = JSON.parse(
-      await assetHubApi.query.remoteProxyRelayChain.blockToRoot()
-    );
-    const latestRecognizedBlock = blockToRootMapping[blockToRootMapping.length - 1][0];
-    const blockHash = await kusamaApi.rpc.chain.getBlockHash(latestRecognizedBlock);
-    
-    console.log(`Generating proof for block ${latestRecognizedBlock}`);
-
-    // Step 3: Create storage proof
-    const storageProof = JSON.parse(
-      await kusamaApi.rpc.state.getReadProof([proxyStorageKey], blockHash)
-    );
-
-    // Step 4: Define target transaction
-    const targetTransaction = assetHubApi.tx.balances.transferAll(RECIPIENT_ACCOUNT, false);
-
-    // Step 5: Construct remote proxy call
-    const remoteProxyCall = assetHubApi.tx.remoteProxyRelayChain.remoteProxy(
-      PROXIED_ACCOUNT,
-      null, // Proxy type filter (null accepts any compatible type)
-      targetTransaction.method,
-      { 
-        RelayChain: { 
-          proof: storageProof.proof, 
-          block: latestRecognizedBlock 
-        }
-      }
-    );
-
-    console.log('\n✅ Remote proxy transaction constructed successfully!');
-    console.log('\n📋 Next steps:');
-    console.log('1. Copy the URL below');
-    console.log('2. Open in Polkadot.js Apps');
-    console.log('3. Submit the transaction within 1 minute');
-    console.log('\n🔗 Polkadot.js Apps URL:');
-    console.log(`https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama-asset-hub-rpc.polkadot.io#/extrinsics/decode/${remoteProxyCall.method.toHex()}`);
-
-    // Cleanup connections
-    await kusamaApi.disconnect();
-    await assetHubApi.disconnect();
-
-  } catch (error) {
-    console.error('❌ Remote proxy execution failed:', error.message);
-  }
-}
-
-// Execute the remote proxy workflow
-executeRemoteProxyTransaction();
+```javascript title="remote-proxy-example.js"
+--8<-- "code/develop/toolkit/parachains/remote-proxies/remote-proxy-example.js"
 ```
+
+Ensure to replace the `RECIPIENT_ACCOUNT` and `PROXIED_ACCOUNT` with your own accounts. For a concrete example, check out the [Sending a remote proxy transaction via Polkadot-JS](https://blog.kchr.de/polkadot/guides/remote-proxies-for-the-braves/#sending-a-remote-proxy-transaction-via-polkadot-js){target=\_blank} section in the Remote Proxies article.
 
 The code snippet above is a complete implementation example of a remote proxy transaction. It demonstrates how to:
 
@@ -172,7 +110,7 @@ The code snippet above is a complete implementation example of a remote proxy tr
 
 ## Resources
 
-- [Traditional Proxies Guide](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank}
-- [Polkadot.js API Documentation](https://polkadot.js.org/docs/){target=\_blank}
-- [Kusama Asset Hub Information](https://wiki.polkadot.com/docs/learn-assets){target=\_blank}
-- [Cross-Chain Message Passing (XCM)](/polkadot-protocol/xcm){target=\_blank}
+- **[Remote Proxies for Braves](https://blog.kchr.de/polkadot/guides/remote-proxies-for-the-braves){target=\_blank}**
+- **[Ecosystem Proxy](https://blog.kchr.de/ecosystem-proxy/){target=\_blank}**
+- **[RFC: Pure Proxy Replication](https://github.com/polkadot-fellows/RFCs/pull/111){target=\_blank}**
+- **[Learn Proxies](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank}**

--- a/llms.txt
+++ b/llms.txt
@@ -17101,7 +17101,6 @@ title: Remote Proxies
 description: Remote proxies enable cross-chain proxy functionality within the Polkadot ecosystem, allowing proxy accounts defined on one chain to execute transactions on different chains through cryptographic storage proofs.
 ---
 
-
 # Remote Proxies
 
 !!!warning "Kusama Implementation Only"
@@ -17178,32 +17177,42 @@ Before implementing remote proxies, ensure you have:
 
 ### Installation and Setup
 
-```bash
-# Install required dependencies
-yarn add @polkadot/api
+To implement remote proxies, you need to install the [`@polkadot/api`](/develop/toolkit/api-libraries/polkadot-js-api/){target=\_blank} package and create a script to execute the remote proxy transaction:
 
-# Create your implementation script
+```bash
+pnpm add @polkadot/api
+```
+
+Create your implementation script:
+
+```bash
 touch remote-proxy-example.js
 ```
 
-### Complete Implementation Example
+### Implementation Example
 
-```javascript
+Here is a complete implementation example of a remote proxy transaction:
+
+```javascript title="remote-proxy-example.js"
 import { ApiPromise, WsProvider } from '@polkadot/api';
 
 // Account configuration - replace with your addresses
-const RECIPIENT_ACCOUNT = '5EjdajLJp5CKhGVaWV21wiyGxUw42rhCqGN32LuVH4wrqXTN';
-const PROXIED_ACCOUNT = 'D9o7gYB92kXgr1UTjYWLDwXK5BeJdxR2irjwaoDEhJnNCfp';
+const RECIPIENT_ACCOUNT = 'INSERT_RECIPIENT_ACCOUNT';
+const PROXIED_ACCOUNT = 'INSERT_PROXIED_ACCOUNT';
 
 async function executeRemoteProxyTransaction() {
   try {
     // Establish connections to both chains
     console.log('Connecting to Kusama relay chain...');
-    const kusamaProvider = new WsProvider('wss://kusama.public.curie.radiumblock.co/ws');
+    const kusamaProvider = new WsProvider(
+      'wss://kusama.public.curie.radiumblock.co/ws',
+    );
     const kusamaApi = await ApiPromise.create({ provider: kusamaProvider });
 
     console.log('Connecting to Kusama Asset Hub...');
-    const assetHubProvider = new WsProvider('wss://kusama-asset-hub-rpc.polkadot.io');
+    const assetHubProvider = new WsProvider(
+      'wss://kusama-asset-hub-rpc.polkadot.io',
+    );
     const assetHubApi = await ApiPromise.create({ provider: assetHubProvider });
 
     // Step 1: Generate storage key for proxy definition
@@ -17212,32 +17221,38 @@ async function executeRemoteProxyTransaction() {
 
     // Step 2: Identify latest recognized block
     const blockToRootMapping = JSON.parse(
-      await assetHubApi.query.remoteProxyRelayChain.blockToRoot()
+      await assetHubApi.query.remoteProxyRelayChain.blockToRoot(),
     );
-    const latestRecognizedBlock = blockToRootMapping[blockToRootMapping.length - 1][0];
-    const blockHash = await kusamaApi.rpc.chain.getBlockHash(latestRecognizedBlock);
-    
+    const latestRecognizedBlock =
+      blockToRootMapping[blockToRootMapping.length - 1][0];
+    const blockHash = await kusamaApi.rpc.chain.getBlockHash(
+      latestRecognizedBlock,
+    );
+
     console.log(`Generating proof for block ${latestRecognizedBlock}`);
 
     // Step 3: Create storage proof
     const storageProof = JSON.parse(
-      await kusamaApi.rpc.state.getReadProof([proxyStorageKey], blockHash)
+      await kusamaApi.rpc.state.getReadProof([proxyStorageKey], blockHash),
     );
 
     // Step 4: Define target transaction
-    const targetTransaction = assetHubApi.tx.balances.transferAll(RECIPIENT_ACCOUNT, false);
+    const targetTransaction = assetHubApi.tx.balances.transferAll(
+      RECIPIENT_ACCOUNT,
+      false,
+    );
 
     // Step 5: Construct remote proxy call
     const remoteProxyCall = assetHubApi.tx.remoteProxyRelayChain.remoteProxy(
       PROXIED_ACCOUNT,
       null, // Proxy type filter (null accepts any compatible type)
       targetTransaction.method,
-      { 
-        RelayChain: { 
-          proof: storageProof.proof, 
-          block: latestRecognizedBlock 
-        }
-      }
+      {
+        RelayChain: {
+          proof: storageProof.proof,
+          block: latestRecognizedBlock,
+        },
+      },
     );
 
     console.log('\n✅ Remote proxy transaction constructed successfully!');
@@ -17246,12 +17261,13 @@ async function executeRemoteProxyTransaction() {
     console.log('2. Open in Polkadot.js Apps');
     console.log('3. Submit the transaction within 1 minute');
     console.log('\n🔗 Polkadot.js Apps URL:');
-    console.log(`https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama-asset-hub-rpc.polkadot.io#/extrinsics/decode/${remoteProxyCall.method.toHex()}`);
+    console.log(
+      `https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama-asset-hub-rpc.polkadot.io#/extrinsics/decode/${remoteProxyCall.method.toHex()}`,
+    );
 
     // Cleanup connections
     await kusamaApi.disconnect();
     await assetHubApi.disconnect();
-
   } catch (error) {
     console.error('❌ Remote proxy execution failed:', error.message);
   }
@@ -17260,6 +17276,8 @@ async function executeRemoteProxyTransaction() {
 // Execute the remote proxy workflow
 executeRemoteProxyTransaction();
 ```
+
+Ensure to replace the `RECIPIENT_ACCOUNT` and `PROXIED_ACCOUNT` with your own accounts. For a concrete example, check out the [Sending a remote proxy transaction via Polkadot-JS](https://blog.kchr.de/polkadot/guides/remote-proxies-for-the-braves/#sending-a-remote-proxy-transaction-via-polkadot-js){target=\_blank} section in the Remote Proxies article.
 
 The code snippet above is a complete implementation example of a remote proxy transaction. It demonstrates how to:
 
@@ -17270,10 +17288,10 @@ The code snippet above is a complete implementation example of a remote proxy tr
 
 ## Resources
 
-- [Traditional Proxies Guide](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank}
-- [Polkadot.js API Documentation](https://polkadot.js.org/docs/){target=\_blank}
-- [Kusama Asset Hub Information](https://wiki.polkadot.com/docs/learn-assets){target=\_blank}
-- [Cross-Chain Message Passing (XCM)](/polkadot-protocol/xcm){target=\_blank}
+- **[Remote Proxies for Braves](https://blog.kchr.de/polkadot/guides/remote-proxies-for-the-braves){target=\_blank}**
+- **[Ecosystem Proxy](https://blog.kchr.de/ecosystem-proxy/){target=\_blank}**
+- **[RFC: Pure Proxy Replication](https://github.com/polkadot-fellows/RFCs/pull/111){target=\_blank}**
+- **[Learn Proxies](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank}**
 --- END CONTENT ---
 
 Doc-Content: https://docs.polkadot.com/develop/toolkit/parachains/rpc-calls/

--- a/llms.txt
+++ b/llms.txt
@@ -87,6 +87,7 @@ Doc-Page: https://docs.polkadot.com/develop/toolkit/parachains/light-clients/
 Doc-Page: https://docs.polkadot.com/develop/toolkit/parachains/polkadot-omni-node/
 Doc-Page: https://docs.polkadot.com/develop/toolkit/parachains/quickstart/
 Doc-Page: https://docs.polkadot.com/develop/toolkit/parachains/quickstart/pop-cli/
+Doc-Page: https://docs.polkadot.com/develop/toolkit/parachains/remote-proxies/
 Doc-Page: https://docs.polkadot.com/develop/toolkit/parachains/rpc-calls/
 Doc-Page: https://docs.polkadot.com/develop/toolkit/parachains/spawn-chains/
 Doc-Page: https://docs.polkadot.com/develop/toolkit/parachains/spawn-chains/zombienet/get-started/
@@ -610,7 +611,8 @@ The [`XcmRouter`](https://paritytech.github.io/polkadot-sdk/master/pallet_xcm/pa
 For instance, the Kusama network employs the [`ChildParachainRouter`](https://paritytech.github.io/polkadot-sdk/master/polkadot_runtime_common/xcm_sender/struct.ChildParachainRouter.html){target=\_blank}, which restricts routing to [Downward Message Passing (DMP)](https://wiki.polkadot.network/learn/learn-xcm-transport/#dmp-downward-message-passing){target=\_blank} from the relay chain to parachains, ensuring secure and controlled communication.
 
 ```rust
-// Only one router so far - use DMP to communicate with child parachains.
+pub type XcmRouter = WithUniqueTopic<(
+	// Only one router so far - use DMP to communicate with child parachains.
 	ChildParachainRouter<Runtime, XcmPallet, PriceForChildParachainDelivery>,
 )>;
 ```
@@ -17090,6 +17092,188 @@ You can also interact with your local network using Pop CLI's `pop call chain` c
 For a comprehensive guide to all Pop CLI features and advanced usage, see the official [Pop CLI](https://learn.onpop.io/appchains) documentation. 
 !!! tip
     Pop CLI also offers powerful solutions for smart contract developers. If you're interested in that path, check out the [Pop CLI Smart Contracts](https://learn.onpop.io/contracts) documentation.
+--- END CONTENT ---
+
+Doc-Content: https://docs.polkadot.com/develop/toolkit/parachains/remote-proxies/
+--- BEGIN CONTENT ---
+---
+title: Remote Proxies
+description: Remote proxies enable cross-chain proxy functionality within the Polkadot ecosystem, allowing proxy accounts defined on one chain to execute transactions on different chains through cryptographic storage proofs.
+---
+
+
+# Remote Proxies
+
+!!!warning "Kusama Implementation Only"
+    Remote proxies are currently only available on Kusama and its parachains (such as Kusama Asset Hub). This feature is not yet deployed on Polkadot MainNet. The examples and implementations described in this guide are specific to the Kusama ecosystem.
+
+## Introduction
+
+Remote proxies enable cross-chain proxy functionality within the Polkadot ecosystem, allowing proxy accounts defined on one chain to execute transactions on different chains through cryptographic storage proofs. This extends the traditional [proxy system](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank} beyond single-chain boundaries.
+
+This guide covers:
+
+- Understanding remote proxy mechanics and architecture
+- Implementation workflow and timing constraints  
+- Practical examples using Polkadot.js
+- Advanced use cases and security considerations
+
+Remote proxies are particularly valuable for maintaining unified security models across multiple parachains while avoiding the complexity of managing separate proxy setups on each chain.
+
+!!!note "Traditional vs Remote Proxies"
+    Traditional proxies work within a single chain, where both the proxy and proxied accounts exist on the same blockchain. Remote proxies extend this concept across chains, using cryptographic proofs to verify proxy relationships without requiring account replication.
+
+## Remote Proxy Architecture
+
+Remote proxies operate through a trust and verification model using storage proofs. The target chain verifies the existence of proxy relationships on the source chain without requiring direct replication of proxy data.
+
+```mermaid
+flowchart LR
+RC([Relay Chain])-- Proxy Definition -->AH([Asset Hub])
+RC -- Storage Proof --> AH
+AH -- Verify Proof --> TX([Execute Transaction])
+AH -- Trust Relationship --> RC
+```
+
+In this architecture, Asset Hub trusts proxy definitions from the Relay Chain. When a remote proxy transaction is initiated, Asset Hub verifies the storage proof against its stored block roots from the Relay Chain, ensuring the proxy relationship is authentic and current.
+
+The verification process utilizes [Merkle proofs](/polkadot-protocol/glossary/#trie-patricia-merkle-tree){target=\_blank} to confirm proxy permissions exist on the source chain at a specific block height.
+
+!!!note "What makes remote proxies secure?"
+    Remote proxies maintain security through cryptographic storage proofs that cannot be forged. The target chain verifies these proofs against trusted block roots, ensuring proxy relationships are authentic without requiring blind trust in external nodes.
+
+## Implementation Workflow
+
+Remote proxy execution follows a time-constrained workflow requiring coordination between multiple chains. The remote proxy workflow consists of several critical steps that must be completed within a narrow time window.
+
+1. **Block Synchronization** - Query the target chain for recognized source chain blocks
+2. **Storage Proof Creation** - Generate cryptographic proof of proxy relationship  
+3. **Transaction Construction** - Build the wrapped transaction with proof data
+4. **Execution** - Submit the transaction before proof expiration
+
+Remote proxies operate under strict timing limitations.
+
+- **Proof Validity**: Storage proofs expire after approximately **1 minute**
+- **Block Recognition**: Target chains maintain only recent source chain block roots
+- **Execution Window**: Transactions must be submitted immediately after proof generation
+
+These constraints exist to prevent replay attacks and ensure proof freshness while maintaining system security.
+
+| Constraint Type | Duration | Purpose |
+| :-------------: | :------: | :-----: |
+| Proof Validity | ~1 minute | Prevent replay attacks |
+| Block Storage | ~10 minutes | Balance security and usability |
+| Execution Window | Immediate | Ensure proof freshness |
+
+## Practical Implementation
+
+### Prerequisites
+
+Before implementing remote proxies, ensure you have:
+
+- Active proxy relationship on the source chain (Kusama)
+- Access to both source and target chain RPC endpoints
+- Compatible proxy types between chains
+- Node.js environment for script execution
+
+### Installation and Setup
+
+```bash
+# Install required dependencies
+yarn add @polkadot/api
+
+# Create your implementation script
+touch remote-proxy-example.js
+```
+
+### Complete Implementation Example
+
+```javascript
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
+// Account configuration - replace with your addresses
+const RECIPIENT_ACCOUNT = '5EjdajLJp5CKhGVaWV21wiyGxUw42rhCqGN32LuVH4wrqXTN';
+const PROXIED_ACCOUNT = 'D9o7gYB92kXgr1UTjYWLDwXK5BeJdxR2irjwaoDEhJnNCfp';
+
+async function executeRemoteProxyTransaction() {
+  try {
+    // Establish connections to both chains
+    console.log('Connecting to Kusama relay chain...');
+    const kusamaProvider = new WsProvider('wss://kusama.public.curie.radiumblock.co/ws');
+    const kusamaApi = await ApiPromise.create({ provider: kusamaProvider });
+
+    console.log('Connecting to Kusama Asset Hub...');
+    const assetHubProvider = new WsProvider('wss://kusama-asset-hub-rpc.polkadot.io');
+    const assetHubApi = await ApiPromise.create({ provider: assetHubProvider });
+
+    // Step 1: Generate storage key for proxy definition
+    const proxyStorageKey = kusamaApi.query.proxy.proxies.key(PROXIED_ACCOUNT);
+    console.log(`Proxy storage key: ${proxyStorageKey}`);
+
+    // Step 2: Identify latest recognized block
+    const blockToRootMapping = JSON.parse(
+      await assetHubApi.query.remoteProxyRelayChain.blockToRoot()
+    );
+    const latestRecognizedBlock = blockToRootMapping[blockToRootMapping.length - 1][0];
+    const blockHash = await kusamaApi.rpc.chain.getBlockHash(latestRecognizedBlock);
+    
+    console.log(`Generating proof for block ${latestRecognizedBlock}`);
+
+    // Step 3: Create storage proof
+    const storageProof = JSON.parse(
+      await kusamaApi.rpc.state.getReadProof([proxyStorageKey], blockHash)
+    );
+
+    // Step 4: Define target transaction
+    const targetTransaction = assetHubApi.tx.balances.transferAll(RECIPIENT_ACCOUNT, false);
+
+    // Step 5: Construct remote proxy call
+    const remoteProxyCall = assetHubApi.tx.remoteProxyRelayChain.remoteProxy(
+      PROXIED_ACCOUNT,
+      null, // Proxy type filter (null accepts any compatible type)
+      targetTransaction.method,
+      { 
+        RelayChain: { 
+          proof: storageProof.proof, 
+          block: latestRecognizedBlock 
+        }
+      }
+    );
+
+    console.log('\n✅ Remote proxy transaction constructed successfully!');
+    console.log('\n📋 Next steps:');
+    console.log('1. Copy the URL below');
+    console.log('2. Open in Polkadot.js Apps');
+    console.log('3. Submit the transaction within 1 minute');
+    console.log('\n🔗 Polkadot.js Apps URL:');
+    console.log(`https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama-asset-hub-rpc.polkadot.io#/extrinsics/decode/${remoteProxyCall.method.toHex()}`);
+
+    // Cleanup connections
+    await kusamaApi.disconnect();
+    await assetHubApi.disconnect();
+
+  } catch (error) {
+    console.error('❌ Remote proxy execution failed:', error.message);
+  }
+}
+
+// Execute the remote proxy workflow
+executeRemoteProxyTransaction();
+```
+
+The code snippet above is a complete implementation example of a remote proxy transaction. It demonstrates how to:
+
+- **Storage Key Generation**: The `proxyStorageKey` identifies where proxy relationship data is stored on Kusama. This key is used to create a proof that the relationship exists.
+- **Block Synchronization**: Asset Hub maintains a mapping of recent Kusama block numbers to their storage roots. This enables proof verification without requiring full blockchain synchronization.
+- **Proof Creation**: The `getReadProof` RPC call generates a cryptographic proof that specific data exists in Kusama's state at a given block height.
+- **Transaction Wrapping**: The target transaction is wrapped within a `remoteProxy` call that includes both the proof data and the block anchor.
+
+## Resources
+
+- [Traditional Proxies Guide](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank}
+- [Polkadot.js API Documentation](https://polkadot.js.org/docs/){target=\_blank}
+- [Kusama Asset Hub Information](https://wiki.polkadot.com/docs/learn-assets){target=\_blank}
+- [Cross-Chain Message Passing (XCM)](/polkadot-protocol/xcm){target=\_blank}
 --- END CONTENT ---
 
 Doc-Content: https://docs.polkadot.com/develop/toolkit/parachains/rpc-calls/

--- a/llms.txt
+++ b/llms.txt
@@ -17108,14 +17108,14 @@ description: Remote proxies enable cross-chain proxy functionality within the Po
 
 ## Introduction
 
-Remote proxies enable cross-chain proxy functionality within the Polkadot ecosystem, allowing proxy accounts defined on one chain to execute transactions on different chains through cryptographic storage proofs. This extends the traditional [proxy system](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank} beyond single-chain boundaries.
+Remote proxies enable cross-chain proxy functionality within the Polkadot ecosystem, allowing proxy accounts defined on one chain to execute transactions on different chains through cryptographic storage proofs. This functionality extends the traditional [proxy system](https://wiki.polkadot.com/learn/learn-proxies/){target=\_blank} beyond single-chain boundaries.
 
 This guide covers:
 
-- Understanding remote proxy mechanics and architecture
-- Implementation workflow and timing constraints  
-- Practical examples using Polkadot.js
-- Advanced use cases and security considerations
+- Understanding remote proxy mechanics and architecture.
+- Implementation workflow and timing constraints.
+- Practical examples using Polkadot.js.
+- Advanced use cases and security considerations.
 
 Remote proxies are particularly valuable for maintaining unified security models across multiple parachains while avoiding the complexity of managing separate proxy setups on each chain.
 
@@ -17145,16 +17145,16 @@ The verification process utilizes [Merkle proofs](/polkadot-protocol/glossary/#t
 
 Remote proxy execution follows a time-constrained workflow requiring coordination between multiple chains. The remote proxy workflow consists of several critical steps that must be completed within a narrow time window.
 
-1. **Block Synchronization** - Query the target chain for recognized source chain blocks
-2. **Storage Proof Creation** - Generate cryptographic proof of proxy relationship  
-3. **Transaction Construction** - Build the wrapped transaction with proof data
-4. **Execution** - Submit the transaction before proof expiration
+1. **Block Synchronization**: Query the target chain for recognized source chain blocks.
+2. **Storage Proof Creation**: Generate cryptographic proof of proxy relationship. 
+3. **Transaction Construction**: Build the wrapped transaction with proof data.
+4. **Execution**: Submit the transaction before proof expiration.
 
 Remote proxies operate under strict timing limitations.
 
-- **Proof Validity**: Storage proofs expire after approximately **1 minute**
-- **Block Recognition**: Target chains maintain only recent source chain block roots
-- **Execution Window**: Transactions must be submitted immediately after proof generation
+- **Proof Validity**: Storage proofs expire after approximately **1 minute**.
+- **Block Recognition**: Target chains maintain only recent source chain block roots.
+- **Execution Window**: Transactions must be submitted immediately after proof generation.
 
 These constraints exist to prevent replay attacks and ensure proof freshness while maintaining system security.
 
@@ -17170,10 +17170,10 @@ These constraints exist to prevent replay attacks and ensure proof freshness whi
 
 Before implementing remote proxies, ensure you have:
 
-- Active proxy relationship on the source chain (Kusama)
-- Access to both source and target chain RPC endpoints
-- Compatible proxy types between chains
-- Node.js environment for script execution
+- Active proxy relationship on the source chain (Kusama).
+- Access to both source and target chain RPC endpoints.
+- Compatible proxy types between chains.
+- Node.js environment for script execution.
 
 ### Installation and Setup
 
@@ -17277,12 +17277,12 @@ async function executeRemoteProxyTransaction() {
 executeRemoteProxyTransaction();
 ```
 
-Ensure to replace the `RECIPIENT_ACCOUNT` and `PROXIED_ACCOUNT` with your own accounts. For a concrete example, check out the [Sending a remote proxy transaction via Polkadot-JS](https://blog.kchr.de/polkadot/guides/remote-proxies-for-the-braves/#sending-a-remote-proxy-transaction-via-polkadot-js){target=\_blank} section in the Remote Proxies article.
+Ensure to replace the `RECIPIENT_ACCOUNT` and `PROXIED_ACCOUNT` with your accounts. For a concrete example, check out the [Sending a remote proxy transaction via Polkadot-JS](https://blog.kchr.de/polkadot/guides/remote-proxies-for-the-braves/#sending-a-remote-proxy-transaction-via-polkadot-js){target=\_blank} section in the Remote Proxies article.
 
 The code snippet above is a complete implementation example of a remote proxy transaction. It demonstrates how to:
 
 - **Storage Key Generation**: The `proxyStorageKey` identifies where proxy relationship data is stored on Kusama. This key is used to create a proof that the relationship exists.
-- **Block Synchronization**: Asset Hub maintains a mapping of recent Kusama block numbers to their storage roots. This enables proof verification without requiring full blockchain synchronization.
+- **Block Synchronization**: Asset Hub maintains a mapping of recent Kusama block numbers to their storage roots to enable proof verification without requiring full blockchain synchronization.
 - **Proof Creation**: The `getReadProof` RPC call generates a cryptographic proof that specific data exists in Kusama's state at a given block height.
 - **Transaction Wrapping**: The target transaction is wrapped within a `remoteProxy` call that includes both the proof data and the block anchor.
 


### PR DESCRIPTION
Resolves https://github.com/polkadot-developers/polkadot-docs/issues/610

This pull request introduces a new feature for implementing remote proxies in the Polkadot ecosystem, specifically for the Kusama network and its parachains. It includes a detailed guide, an example implementation script, and updates to the documentation navigation to reflect the new feature.

### Remote Proxy Implementation:

* **Example Script**: Added a complete implementation of a remote proxy transaction in `remote-proxy-example.js`. This script demonstrates how to connect to the Kusama relay chain and Asset Hub, generate cryptographic storage proofs, and construct a remote proxy transaction.
* **Documentation Guide**: Created a comprehensive guide in `remote-proxies.md` explaining the architecture, workflow, and practical implementation of remote proxies. It includes timing constraints, security considerations, and a step-by-step example using the Polkadot.js API.

### Documentation Updates:

* **Navigation Update**: Added a new entry for "Remote Proxies" in the `.nav.yml` file to make the new guide accessible from the documentation sidebar.
* **Linked Documentation**: Updated `llms.txt` to include references to the new "Remote Proxies" documentation page, ensuring it is discoverable in related contexts. [[1]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114R90) [[2]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114R17097-R17296)

These changes provide developers with the tools and guidance needed to leverage remote proxies for cross-chain transactions within the Kusama ecosystem.