### PR TITLE
[FIX] - Update hardhat guides to `hardhat-polkadot` 1.9.0

### DIFF
--- a/develop/smart-contracts/dev-environments/hardhat.md
+++ b/develop/smart-contracts/dev-environments/hardhat.md
@@ -289,7 +289,7 @@ npx hardhat run scripts/interact.js --network polkadotHubTestnet
 If you already have a Hardhat Polkadot project and want to upgrade to a newer version of the plugin, to avoid errors (for example, `Cannot find module 'run-container'`), you can clean your dependencies by running the following commands:
 
 ```bash
-rm -rf node_modules package-lock.json
+rm -rf node_modules
 ```
 
 After that, you can upgrade the plugin to the latest version by running the following commands:

--- a/develop/smart-contracts/dev-environments/hardhat.md
+++ b/develop/smart-contracts/dev-environments/hardhat.md
@@ -289,7 +289,7 @@ npx hardhat run scripts/interact.js --network polkadotHubTestnet
 If you already have a Hardhat Polkadot project and want to upgrade to a newer version of the plugin, to avoid errors (for example, `Cannot find module 'run-container'`), you can clean your dependencies by running the following commands:
 
 ```bash
-rm -rf node_modules
+rm -rf node_modules package-lock.json
 ```
 
 After that, you can upgrade the plugin to the latest version by running the following commands:

--- a/develop/smart-contracts/dev-environments/hardhat.md
+++ b/develop/smart-contracts/dev-environments/hardhat.md
@@ -284,6 +284,23 @@ Run your interaction script:
 npx hardhat run scripts/interact.js --network polkadotHubTestnet
 ```
 
+## Upgrading the Plugin
+
+If you already have a Hardhat Polkadot project and want to upgrade to a newer version of the plugin, to avoid errors (for example, `Cannot find module 'run-container'`), you can clean your dependencies by running the following commands:
+
+```bash
+rm -rf node_modules package-lock.json
+```
+
+After that, you can upgrade the plugin to the latest version by running the following commands:
+
+```bash
+npm install --save-dev @parity/hardhat-polkadot@latest
+npm install
+```
+
+Consider using [Node.js](https://nodejs.org/){target=\_blank} 22.18+ and [npm](https://www.npmjs.com/){target=\_blank} version 10.9.0+ to avoid issues with the plugin.
+
 ## Where to Go Next
 
 Hardhat provides a powerful environment for developing, testing, and deploying smart contracts on Polkadot Hub. Its plugin architecture allows seamless integration with PolkaVM through the `hardhat-resolc` and `hardhat-revive-node` plugins.

--- a/develop/smart-contracts/dev-environments/hardhat.md
+++ b/develop/smart-contracts/dev-environments/hardhat.md
@@ -51,7 +51,7 @@ Before getting started, ensure you have:
 3. To interact with Polkadot, Hardhat requires the following plugin to compile contracts to PolkaVM bytecode and to spawn a local node compatible with PolkaVM:
 
     ```bash
-    npm install --save-dev @parity/hardhat-polkadot@0.1.8
+    npm install --save-dev @parity/hardhat-polkadot@0.1.9
     ```
 
 4. Create a Hardhat project:
@@ -66,11 +66,9 @@ Before getting started, ensure you have:
     - **`test`** - contains your test files that validate contract functionality
     - **`ignition`** - deployment modules for safely deploying your contracts to various networks
 
-5. Add the following folders to the `.gitignore` file if they are not already there:
+5. Add the following folder to the `.gitignore` file if it is not already there:
 
     ```bash
-    echo '/artifacts-pvm' >> .gitignore
-    echo '/cache-pvm' >> .gitignore
     echo '/ignition/deployments/' >> .gitignore
     ```
 
@@ -162,6 +160,9 @@ Configure a local node setup by adding the node binary path along with the ETH-R
 ```
 
 Replace `INSERT_PATH_TO_SUBSTRATE_NODE` and `INSERT_PATH_TO_ETH_RPC_ADAPTER` with the actual paths to your compiled binaries. The `dev: true` flag configures both the node and adapter for development mode. To obtain these binaries, check the [Installation](/develop/smart-contracts/local-development-node#install-the-substrate-node-and-eth-rpc-adapter){target=\_blank} section on the Local Development Node page.
+
+!!! warning
+    If you're using the default `hardhat.config.js` created by the `hardhat-polkadot` plugin, it includes a `forking` section pointing to the Polkadot Hub TestNet. When you run `npx hardhat node`, Hardhat will start a fork of that network. To use your local node instead, comment out the `forking` section; otherwise, `npx hardhat node` will continue to use the forked network even if a local node is defined in the configuration.
 
 Once configured, start your chosen testing environment with:
 

--- a/llms.txt
+++ b/llms.txt
@@ -8301,7 +8301,7 @@ npx hardhat run scripts/interact.js --network polkadotHubTestnet
 If you already have a Hardhat Polkadot project and want to upgrade to a newer version of the plugin, to avoid errors (for example, `Cannot find module 'run-container'`), you can clean your dependencies by running the following commands:
 
 ```bash
-rm -rf node_modules package-lock.json
+rm -rf node_modules
 ```
 
 After that, you can upgrade the plugin to the latest version by running the following commands:

--- a/llms.txt
+++ b/llms.txt
@@ -8301,7 +8301,7 @@ npx hardhat run scripts/interact.js --network polkadotHubTestnet
 If you already have a Hardhat Polkadot project and want to upgrade to a newer version of the plugin, to avoid errors (for example, `Cannot find module 'run-container'`), you can clean your dependencies by running the following commands:
 
 ```bash
-rm -rf node_modules
+rm -rf node_modules package-lock.json
 ```
 
 After that, you can upgrade the plugin to the latest version by running the following commands:

--- a/llms.txt
+++ b/llms.txt
@@ -8296,6 +8296,23 @@ Run your interaction script:
 npx hardhat run scripts/interact.js --network polkadotHubTestnet
 ```
 
+## Upgrading the Plugin
+
+If you already have a Hardhat Polkadot project and want to upgrade to a newer version of the plugin, to avoid errors (for example, `Cannot find module 'run-container'`), you can clean your dependencies by running the following commands:
+
+```bash
+rm -rf node_modules package-lock.json
+```
+
+After that, you can upgrade the plugin to the latest version by running the following commands:
+
+```bash
+npm install --save-dev @parity/hardhat-polkadot@latest
+npm install
+```
+
+Consider using [Node.js](https://nodejs.org/){target=\_blank} 22.18+ and [npm](https://www.npmjs.com/){target=\_blank} version 10.9.0+ to avoid issues with the plugin.
+
 ## Where to Go Next
 
 Hardhat provides a powerful environment for developing, testing, and deploying smart contracts on Polkadot Hub. Its plugin architecture allows seamless integration with PolkaVM through the `hardhat-resolc` and `hardhat-revive-node` plugins.

--- a/llms.txt
+++ b/llms.txt
@@ -7956,7 +7956,7 @@ Before getting started, ensure you have:
 3. To interact with Polkadot, Hardhat requires the following plugin to compile contracts to PolkaVM bytecode and to spawn a local node compatible with PolkaVM:
 
     ```bash
-    npm install --save-dev @parity/hardhat-polkadot@0.1.8
+    npm install --save-dev @parity/hardhat-polkadot@0.1.9
     ```
 
 4. Create a Hardhat project:
@@ -7971,11 +7971,9 @@ Before getting started, ensure you have:
     - **`test`** - contains your test files that validate contract functionality
     - **`ignition`** - deployment modules for safely deploying your contracts to various networks
 
-5. Add the following folders to the `.gitignore` file if they are not already there:
+5. Add the following folder to the `.gitignore` file if it is not already there:
 
     ```bash
-    echo '/artifacts-pvm' >> .gitignore
-    echo '/cache-pvm' >> .gitignore
     echo '/ignition/deployments/' >> .gitignore
     ```
 
@@ -8109,6 +8107,9 @@ module.exports = {
 ```
 
 Replace `INSERT_PATH_TO_SUBSTRATE_NODE` and `INSERT_PATH_TO_ETH_RPC_ADAPTER` with the actual paths to your compiled binaries. The `dev: true` flag configures both the node and adapter for development mode. To obtain these binaries, check the [Installation](/develop/smart-contracts/local-development-node#install-the-substrate-node-and-eth-rpc-adapter){target=\_blank} section on the Local Development Node page.
+
+!!! warning
+    If you're using the default `hardhat.config.js` created by the `hardhat-polkadot` plugin, it includes a `forking` section pointing to the Polkadot Hub TestNet. When you run `npx hardhat node`, Hardhat will start a fork of that network. To use your local node instead, comment out the `forking` section; otherwise, `npx hardhat node` will continue to use the forked network even if a local node is defined in the configuration.
 
 Once configured, start your chosen testing environment with:
 
@@ -40141,7 +40142,7 @@ Let's start by setting up Hardhat for your Storage contract project:
 3. Install `hardhat-polkadot` and all required plugins:
 
     ```bash
-    npm install --save-dev @parity/hardhat-polkadot solc@0.8.28
+    npm install --save-dev @parity/hardhat-polkadot@0.1.9 solc@0.8.28
     ```
 
     For dependencies compatibility, ensure to install the `@nomicfoundation/hardhat-toolbox` dependency with the `--force` flag:
@@ -40171,7 +40172,6 @@ const { vars } = require("hardhat/config");
 module.exports = {
   solidity: "0.8.28",
   resolc: {
-    version: "1.5.2",
     compilerSource: "npm",
   },
   networks: {
@@ -40590,7 +40590,7 @@ Congratulations! You've successfully set up a Hardhat development environment, w
 To get started with a working example right away, you can clone the repository and navigate to the project directory:
 
 ```bash
-git clone https://github.com/polkadot-developers/polkavm-hardhat-examples.git -b v0.0.7
+git clone https://github.com/polkadot-developers/polkavm-hardhat-examples.git -b v0.0.8
 cd polkavm-hardhat-examples/storage-hardhat
 ```
 --- END CONTENT ---

--- a/tutorials/smart-contracts/launch-your-first-project/test-and-deploy-with-hardhat.md
+++ b/tutorials/smart-contracts/launch-your-first-project/test-and-deploy-with-hardhat.md
@@ -41,7 +41,7 @@ Let's start by setting up Hardhat for your Storage contract project:
 3. Install `hardhat-polkadot` and all required plugins:
 
     ```bash
-    npm install --save-dev @parity/hardhat-polkadot solc@0.8.28
+    npm install --save-dev @parity/hardhat-polkadot@0.1.9 solc@0.8.28
     ```
 
     For dependencies compatibility, ensure to install the `@nomicfoundation/hardhat-toolbox` dependency with the `--force` flag:
@@ -61,7 +61,7 @@ Let's start by setting up Hardhat for your Storage contract project:
 6. Configure Hardhat by updating the `hardhat.config.js` file:
 
     ```javascript title="hardhat.config.js"
-    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.7/storage-hardhat/hardhat.config.js'
+    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.8/storage-hardhat/hardhat.config.js'
     ```
 
     Ensure that `INSERT_PATH_TO_SUBSTRATE_NODE` and `INSERT_PATH_TO_ETH_RPC_ADAPTER` are replaced with the proper paths to the compiled binaries. 
@@ -91,7 +91,7 @@ Let's start by setting up Hardhat for your Storage contract project:
 1. Create a new folder called `contracts` and create a `Storage.sol` file. Add the contract code from the previous tutorial:
 
     ```solidity title="Storage.sol"
-    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.7/storage-hardhat/contracts/Storage.sol'
+    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.8/storage-hardhat/contracts/Storage.sol'
     ```
 
 2. Compile the contract:
@@ -113,9 +113,9 @@ Testing is a critical part of smart contract development. Hardhat makes it easy 
 1. Create a folder for testing called `test`. Inside that directory, create a file named `Storage.js` and add the following code:
 
     ```javascript title="Storage.js" 
-    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.7/storage-hardhat/test/Storage.js:0:19'
+    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.8/storage-hardhat/test/Storage.js:0:19'
         // Add your logic here
-    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.7/storage-hardhat/test/Storage.js:48:49'
+    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.8/storage-hardhat/test/Storage.js:48:49'
     ```
 
     The `beforeEach` hook ensures stateless contract execution by redeploying a fresh instance of the Storage contract before each test case. This approach guarantees that each test starts with a clean and independent contract state by using `ethers.getSigners()` to obtain test accounts and `ethers.getContractFactory('Storage').deploy()` to create a new contract instance.
@@ -125,7 +125,7 @@ Testing is a critical part of smart contract development. Hardhat makes it easy 
     a. **Initial state verification** - ensures that the contract starts with a default value of zero, which is a fundamental expectation for the `Storage.sol` contract
 
     ```javascript title="Storage.js"
-    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.7/storage-hardhat/test/Storage.js:20:22'
+    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.8/storage-hardhat/test/Storage.js:20:22'
     ```
 
     Explanation:
@@ -137,7 +137,7 @@ Testing is a critical part of smart contract development. Hardhat makes it easy 
     b. **Value storage test** - validate the core functionality of storing and retrieving a value in the contract
 
     ```javascript title="Storage.js"
-    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.7/storage-hardhat/test/Storage.js:24:30'
+    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.8/storage-hardhat/test/Storage.js:24:30'
     ```
 
     Explanation:
@@ -149,7 +149,7 @@ Testing is a critical part of smart contract development. Hardhat makes it easy 
     c. **Event emission verification** - confirm that the contract emits the correct event when storing a value, which is crucial for off-chain tracking
 
     ```javascript title="Storage.js"
-    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.7/storage-hardhat/test/Storage.js:32:38'
+    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.8/storage-hardhat/test/Storage.js:32:38'
     ```
 
     Explanation:
@@ -161,7 +161,7 @@ Testing is a critical part of smart contract development. Hardhat makes it easy 
     d. **Sequential value storage test** - check the contract's ability to store multiple values sequentially and maintain the most recent value
 
     ```javascript title="Storage.js"
-    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.7/storage-hardhat/test/Storage.js:40:47'
+    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.8/storage-hardhat/test/Storage.js:40:47'
     ```
 
     Explanation:
@@ -174,7 +174,7 @@ Testing is a critical part of smart contract development. Hardhat makes it easy 
 
     ???--- code "View complete script"
         ```javascript title="Storage.js"
-        --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.7/storage-hardhat/test/Storage.js'
+        --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.8/storage-hardhat/test/Storage.js'
         ```
 
 2. Run the tests:
@@ -194,7 +194,7 @@ Testing is a critical part of smart contract development. Hardhat makes it easy 
 1. Create a new folder called`ignition/modules`. Add a new file named `StorageModule.js` with the following logic:
 
     ```javascript title="StorageModule.js"
-    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.7/storage-hardhat/ignition/modules/StorageModule.js'
+    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.8/storage-hardhat/ignition/modules/StorageModule.js'
     ```
 
 2. Deploy to the local network:
@@ -234,7 +234,7 @@ To interact with your deployed contract:
 1. Create a new folder named `scripts` and add the `interact.js` with the following content:
 
     ```javascript title="interact.js"
-    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.7/storage-hardhat/scripts/interact.js'
+    --8<-- 'https://raw.githubusercontent.com/polkadot-developers/polkavm-hardhat-examples/refs/tags/v0.0.8/storage-hardhat/scripts/interact.js'
     ```
 
     Ensure that `INSERT_DEPLOYED_CONTRACT_ADDRESS` is replaced with the value obtained in the previous step.
@@ -256,6 +256,6 @@ Congratulations! You've successfully set up a Hardhat development environment, w
 To get started with a working example right away, you can clone the repository and navigate to the project directory:
 
 ```bash
-git clone https://github.com/polkadot-developers/polkavm-hardhat-examples.git -b v0.0.7
+git clone https://github.com/polkadot-developers/polkavm-hardhat-examples.git -b v0.0.8
 cd polkavm-hardhat-examples/storage-hardhat
 ```


### PR DESCRIPTION
Note: this PR does not include the new Docker feature due to issues with 0.1.9. Once hardhat-polkadot 0.1.10 is released, we will add documentation for that feature.

This pull request updates the Hardhat development environment documentation and related tutorial files to use the latest `@parity/hardhat-polkadot` plugin version and the latest example code from the `polkavm-hardhat-examples` repository. It also clarifies `.gitignore` instructions and adds a warning about the default network forking behavior in Hardhat.

Dependency and example updates:

* Updated all installation instructions and code references to use `@parity/hardhat-polkadot@0.1.9` instead of `0.1.8` and updated repository/example links and code snippets to use `v0.0.8` instead of `v0.0.7`. [[1]](diffhunk://#diff-b4bcef9dce452b44004a772adf5859c1c5de0cabb87ef8ab62cc188f055df245L54-R54) [[2]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L7959-R7959) [[3]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L40144-R40145) [[4]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L44-R44) [[5]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L64-R64) [[6]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L94-R94) [[7]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L116-R118) [[8]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L128-R128) [[9]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L140-R140) [[10]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L152-R152) [[11]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L164-R164) [[12]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L177-R177) [[13]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L197-R197) [[14]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L237-R237) [[15]](diffhunk://#diff-c13ee7d4ce7595b5e2d0f84bb6ab5585cb23c9b9e9e7973f8f8e64419263a4a6L259-R259) [[16]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L40593-R40593)

Documentation improvements:

* Added a warning about the default `forking` configuration in `hardhat.config.js`, explaining how it affects local node usage and how to switch to a local node. [[1]](diffhunk://#diff-b4bcef9dce452b44004a772adf5859c1c5de0cabb87ef8ab62cc188f055df245R164-R166) [[2]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114R8111-R8113)

Project setup instructions:

* Clarified `.gitignore` instructions to only require ignoring the `/ignition/deployments/` folder, removing references to `/artifacts-pvm` and `/cache-pvm`. [[1]](diffhunk://#diff-b4bcef9dce452b44004a772adf5859c1c5de0cabb87ef8ab62cc188f055df245L69-L73) [[2]](diffhunk://#diff-f43a9e2f7da89777ca234fc2f236252b27a44652586c9514b243e81bf1b19114L7974-L7978)

Other minor changes:

* Removed the unused `resolc.version` field from the sample Hardhat config.