### PR TITLE
add AI chatbot policy to docs

### DIFF
--- a/ai-chatbot-policy.md
+++ b/ai-chatbot-policy.md
@@ -1,0 +1,12 @@
+---
+title: AI Chatbot Policy
+description: This AI chatbot policy outlines the terms, conditions, and guidelines you agree to when accessing or using the AI chatbot provided through this Website.
+hide:
+- toc
+- feedback
+- navigation
+---
+
+# AI Chatbot Policy
+
+--8<-- 'https://raw.githubusercontent.com/w3f/polkadot-wiki/refs/heads/master/docs/policies/chatbot-terms.md:5'


### PR DESCRIPTION
Add the AI Chatbot policy to the docs.

This goes with Mkdocs PR, which adds a link to this page to the footer: https://github.com/papermoonio/polkadot-mkdocs/pull/116