### PR TITLE
Include Ubuntu Rust setup commands

### DIFF
--- a/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
+++ b/tutorials/polkadot-sdk/parachains/zero-to-hero/set-up-a-template.md
@@ -33,12 +33,21 @@ Before getting started, ensure you have done the following:
 
 For this tutorial series, you need to use Rust `1.86`. Newer versions of the compiler may not work with this parachain template version.
 
-Run the following commands to set up the correct Rust version:
+### macOS
 
 ```bash
 rustup default 1.86
 rustup target add wasm32-unknown-unknown --toolchain 1.86-aarch64-apple-darwin
 rustup component add rust-src --toolchain 1.86-aarch64-apple-darwin
+```
+
+### Ubuntu
+
+```bash
+rustup toolchain install 1.86.0
+rustup default 1.86.0
+rustup target add wasm32-unknown-unknown --toolchain 1.86.0
+rustup component add rust-src --toolchain 1.86.0
 ```
 
 ## Utility Tools


### PR DESCRIPTION
This PR updates the "Set Up a Template" tutorial to improve clarity and accessibility for users on different operating systems. Specifically, the prerequisites section now includes separate instructions for both macOS and Ubuntu users, with clearly labeled code blocks for each. This ensures that Ubuntu users can easily follow the correct steps to install and configure the required Rust toolchain for the Polkadot SDK parachain template.
### Changes

- Added a dedicated "Ubuntu" subsection with the correct Rust installation commands.
- Retained and clarified the existing "macOS" instructions.

### Motivation
Previously, the tutorial only provided Rust setup instructions for macOS, which could cause confusion or setup issues for Ubuntu/Linux users. This update makes the documentation more inclusive and user-friendly for a broader audience.