### PR TITLE
Taylor/fix-toc-scroll

### DIFF
--- a/js/fix-toc-scroll.js
+++ b/js/fix-toc-scroll.js
@@ -1,6 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
   const SCROLL_OFFSET = 70; // Adjust based on your header height
-  const TOC_SELECTOR_LEFT = '.md-nav__link'; // Left nav links
   const TOC_SELECTOR_RIGHT = '.md-nav--right .md-nav__link'; // Right nav links (update selector as needed)
 
   // Smooth scroll with offset


### PR DESCRIPTION
This script improves the table of contents (TOC) behavior for MkDocs-based documentation sites. It ensures that both the left and right navigation TOCs highlight the correct heading as the user scrolls or clicks anchor links.

Related to [Polkadot Mkdocs #126](https://github.com/papermoonio/polkadot-mkdocs/pull/126)