### PR TITLE
Taylor/update url checker

### DIFF
--- a/.github/workflows/check-url-changes.yml
+++ b/.github/workflows/check-url-changes.yml
@@ -19,9 +19,11 @@ jobs:
 
       - name: Identify deleted and renamed files
         run: |
-          BASE_REF=origin/${{ github.event.pull_request.base.ref }}
+          BASE_BRANCH=${{ github.event.pull_request.base.ref }}
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          BASE_REF="origin/${BASE_BRANCH}"
 
+          git fetch origin "${BASE_BRANCH}" --depth=1
 
           DELETED_FILES=$(git diff --name-status "$BASE_REF" "$HEAD_SHA" | grep '^D.*\.md$' | cut -f2- || true)
           RENAMED_FILES=$(git diff --name-status "$BASE_REF" "$HEAD_SHA" | grep '^R.*\.md$' | awk '{print $2 " -> " $3}' || true)


### PR DESCRIPTION
This workflow compares the PR branch against master and looks only for Markdown files that were deleted or renamed/moved. If it finds any, it posts a warning comment on the pull request so reviewers know these changes could break documentation URLs. If no files are deleted or renamed, the workflow runs silently and does not comment.