### PR TITLE
Update .nav.yml

### DIFF
--- a/develop/toolkit/interoperability/.nav.yml
+++ b/develop/toolkit/interoperability/.nav.yml
@@ -2,5 +2,4 @@ title: Interoperability
 nav:
   - index.md
   - 'XCM Tools': xcm-tools.md
-  - asset-transfer-api
   - paraspell-xcm-sdk


### PR DESCRIPTION
We've got a warning in the build logs:

```
WARNING -  awesome-nav: The nav item 'asset-transfer-api' doesn't match any files or directories [develop/toolkit/interoperability/.nav.yml]
```

So this just removes the `asset-transfer-api` entry in the `.nav.yml` file since that directory doesn't exist.