### PR TITLE
Migrate to wasm32v1-none

### DIFF
--- a/infrastructure/running-a-node/setup-full-node.md
+++ b/infrastructure/running-a-node/setup-full-node.md
@@ -111,8 +111,8 @@ This section will walk you through installing and building the Polkadot binary f
     rustup default stable
     rustup update
     rustup update nightly
-    rustup target add wasm32-unknown-unknown --toolchain nightly
-    rustup target add wasm32-unknown-unknown --toolchain stable-x86_64-unknown-linux-gnu
+    rustup target add wasm32v1-none --toolchain nightly
+    rustup target add wasm32v1-none --toolchain stable-aarch64-apple-darwin
     rustup component add rust-src --toolchain stable-x86_64-unknown-linux-gnu
     ```
 


### PR DESCRIPTION
Per warnings when building any kind node we get those, should we migrate the instructions from `wasm32-unknown-unknown` to `wasm32v1-none` ? I can confirm it does compile after that doing that and the warnings go away, just wondering if this could generate any issues or not.

```bash
warning: `frame-benchmarking-cli` (lib) generated 4 warnings
warning: yet-another-parachain-runtime@0.6.0: You are building WASM runtime using `wasm32-unknown-unknown` target, although Rust >= 1.84 supports `wasm32v1-none` target!
warning: yet-another-parachain-runtime@0.6.0: You can install it with `rustup target add wasm32v1-none --toolchain stable-aarch64-apple-darwin` if you're using `rustup`.
warning: yet-another-parachain-runtime@0.6.0: After installing `wasm32v1-none` target, you must rebuild WASM runtime from scratch, use `cargo clean` before building.
warning: penpal-runtime@0.14.0: You are building WASM runtime using `wasm32-unknown-unknown` target, although Rust >= 1.84 supports `wasm32v1-none` target!
warning: penpal-runtime@0.14.0: You can install it with `rustup target add wasm32v1-none --toolchain stable-aarch64-apple-darwin` if you're using `rustup`.
warning: penpal-runtime@0.14.0: After installing `wasm32v1-none` target, you must rebuild WASM runtime from scratch, use `cargo clean` before building.
warning: asset-hub-rococo-runtime@0.11.0: You are building WASM runtime using `wasm32-unknown-unknown` target, although Rust >= 1.84 supports `wasm32v1-none` target!
warning: asset-hub-rococo-runtime@0.11.0: You can install it with `rustup target add wasm32v1-none --toolchain stable-aarch64-apple-darwin` if you're using `rustup`.
warning: asset-hub-rococo-runtime@0.11.0: After installing `wasm32v1-none` target, you must rebuild WASM runtime from scratch, use `cargo clean` before building.
warning: bridge-hub-westend-runtime@0.3.0: You are building WASM runtime using `wasm32-unknown-unknown` target, although Rust >= 1.84 supports `wasm32v1-none` target!
warning: bridge-hub-westend-runtime@0.3.0: You can install it with `rustup target add wasm32v1-none --toolchain stable-aarch64-apple-darwin` if you're using `rustup`.
warning: bridge-hub-westend-runtime@0.3.0: After installing `wasm32v1-none` target, you must rebuild WASM runtime from scratch, use `cargo clean` before building.
warning: coretime-rococo-runtime@0.1.0: You are building WASM runtime using `wasm32-unknown-unknown` target, although Rust >= 1.84 supports `wasm32v1-none` target!
warning: coretime-rococo-runtime@0.1.0: You can install it with `rustup target add wasm32v1-none --toolchain stable-aarch64-apple-darwin` if you're using `rustup`.
warning: coretime-rococo-runtime@0.1.0: After installing `wasm32v1-none` target, you must rebuild WASM runtime from scratch, use `cargo clean` before building.
warning: coretime-rococo-runtime@0.1.0: You are building WASM runtime using `wasm32-unknown-unknown` target, although Rust >= 1.84 supports `wasm32v1-none` target!
warning: coretime-rococo-runtime@0.1.0: You can install it with `rustup target add wasm32v1-none --toolchain stable-aarch64-apple-darwin` if you're using `rustup`.
warning: coretime-rococo-runtime@0.1.0: After installing `wasm32v1-none` target, you must rebuild WASM runtime from scratch, use `cargo clean` before building.
```

## 🔍 Review Preference

Choose one:
- [x] ✅ I have time to handle formatting/style feedback myself 
- [x] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## 🤖 AI-Ready Docs

If content changed, [regenerate AI files](../CONTRIBUTING.md#making-changes):
- [ ] ✅ I ran `python3 scripts/generate_llms.py`  
- [x] ⚡ Docs team will regenerate (check "Allow edits from maintainers")  

## ✅ Checklist

- [x] Changes tested  
- [x] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed