### PR TITLE
Reorder APIs on the sidebar

### DIFF
--- a/develop/toolkit/api-libraries/.nav.yml
+++ b/develop/toolkit/api-libraries/.nav.yml
@@ -1,8 +1,8 @@
 title: API Libraries
 nav:
   - index.md
-  - ':simple-typescript: Dedot': dedot.md
   - ':simple-typescript: Polkadot-API': papi.md
+  - ':simple-typescript: Dedot': dedot.md
   - ':simple-javascript: Polkadot.js API': polkadot-js-api.md
   - ':simple-dart: Polkadart': polkadart.md
   - ':simple-python: Python Substrate Interface': py-substrate-interface.md


### PR DESCRIPTION
## 📝 Description

Since it is not in alphabetical order anyway, as far as I know "Polkadart" should be before "Polkadot-API"

Dart, comes before TypeScript, Python comes before TypeScript, and so on, but it seems the only "error" is that Dedot is listed first. Not that I really care but some people really do, it seems.

If you don't mind us making this change @sinzii ? I really appreciate all your hard work.

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [x] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## 🤖 AI-Ready Docs

If content changed, [regenerate AI files](../CONTRIBUTING.md#making-changes):
- [ ] ✅ I ran `python3 scripts/generate_llms.py`  
- [x] ⚡ Docs team will regenerate (check "Allow edits from maintainers")  

## ✅ Checklist

- [x] Changes tested  
- [x] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed