### PR TITLE
Add technical reference to navigation

### DIFF
--- a/.nav.yml
+++ b/.nav.yml
@@ -5,3 +5,4 @@ nav:
   - 'Chain Interactions': chain-interactions
   # 'Get Support': get-support
   - 'Nodes and Validators': nodes-and-validators
+  - 'Technical Reference': reference


### PR DESCRIPTION
## 📝 Description

This PR enables navigation functionality for the technical reference section.

How it works:

- `Technical Reference` is added to root-level `.nav.yml` file so that we can rely on default mkdocs behavior to render the left navigation when on a page in that section AND so that it shows up in navigation on smaller screens.
- In the mkdocs repo, there is configuration to ignore it and never show it in the top navigation

Goes with: https://github.com/papermoonio/polkadot-mkdocs/pull/177