### PR TITLE
Add Ethereum RPC adapter documentation for Polkadot Hub

### DIFF
--- a/node-infrastructure/run-a-node/polkadot-hub-rpc.md
+++ b/node-infrastructure/run-a-node/polkadot-hub-rpc.md
@@ -564,7 +564,7 @@ Your node setup provides two distinct API interfaces:
 
 ### Verify the Ethereum RPC Adapter
 
-To verify the Ethereum RPC adapter is working correctly, you can test standard Ethereum JSON-RPC methods like `eth_chainId`, `eth_blockNumber`, and `eth_getBlockByNumber`. For a complete list of supported methods and example queries, see the [JSON-RPC APIs](/develop/smart-contracts/dev-tools/json-rpc-apis/){target=\_blank} reference.
+To verify the Ethereum RPC adapter is working correctly, you can test standard Ethereum JSON-RPC methods like `eth_chainId`, `eth_blockNumber`, and `eth_getBlockByNumber`. For a complete list of supported methods and example queries, see the [JSON-RPC APIs](/smart-contracts/for-eth-devs/json-rpc-apis/){target=\_blank} reference.
 
 ### Manage the Ethereum RPC Adapter
 


### PR DESCRIPTION
Closes https://github.com/polkadot-developers/polkadot-docs/issues/1390

## Summary

- Adds comprehensive documentation for running the pallet-revive eth-rpc adapter alongside a Polkadot Hub RPC node
- Enables users to set up Ethereum JSON-RPC compatibility for seamless integration with Web3 tools (MetaMask, Hardhat, Ethers.js)
- Includes both Docker and systemd deployment options

## Changes

**New "Ethereum RPC Compatibility" section covering:**
- Prerequisites (fully synchronized node required)
- Docker deployment using the `paritypr/eth-rpc` image
- systemd service configuration for production deployments
- Configuration parameters reference table
- API endpoints overview (Substrate RPC vs Ethereum RPC)
- Verification commands for testing the endpoint
- Management commands for the adapter

**Updated existing sections:**
- Introduction now mentions Ethereum RPC capability
- Hardware requirements include port 8545
- Conclusion reflects the optional Ethereum RPC feature