### PR TITLE
Fix pallet instance types in add-pallet-instances guide

### DIFF
--- a/parachains/customize-runtime/add-pallet-instances.md
+++ b/parachains/customize-runtime/add-pallet-instances.md
@@ -415,6 +415,11 @@ To test instance independence:
 
 You can now use both collective instances for different governance purposes in your parachain, such as technical decisions that require expertise and general governance decisions that require broader consensus.
 
+!!! note "Automated verification"
+    This tutorial is verified by automated tests. View the [test source](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/add-pallet-instances/tests/guide.test.ts){target=\_blank} for implementation details.
+
+    [![Add Pallet Instances](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml){target=\_blank}
+
 ## Where to Go Next
 
 <div class="grid cards" markdown>


### PR DESCRIPTION
## Summary

Updates the "Add Multiple Pallet Instances" guide to use the correct instance types for polkadot-sdk-parachain-template v0.0.4.

## Related PR

- polkadot-developers/polkadot-cookbook#71 - Adds automated test verification for this guide

## Changes

The guide previously used `pallet_collective::Instance1` which was valid in older SDK versions. The polkadot-sdk-parachain-template v0.0.4 (which uses polkadot-sdk 2503.0.1) provides instance types via `frame_support::instances` instead.

- Update instance imports to use `frame_support::instances::{Instance1, Instance2}`
- Update Config trait implementations to use `Instance1`/`Instance2` directly
- Update runtime construct examples to use `Instance1`/`Instance2`

## Test plan

- [x] Tested the guide with polkadot-sdk-parachain-template v0.0.4
- [x] Added `pallet-collective` with two instances using the updated instructions
- [x] Successfully built the runtime with `cargo build --release`
- [x] Generated a chain spec and verified the node starts and produces blocks