### PR TITLE
Add quick address conversion TLDR for Ethereum and Polkadot

### DIFF
--- a/smart-contracts/for-eth-devs/accounts.md
+++ b/smart-contracts/for-eth-devs/accounts.md
@@ -9,7 +9,7 @@ categories: Basics, Polkadot Protocol
 !!! tip "Address Conversion Summary"
     Polkadot Hub automatically converts addresses between Ethereum (20-byte) and Polkadot (32-byte) formats:
 
-    - **Ethereum → Polkadot**: Adds twelve `0xEE` bytes to the end (reversible)
+    - **Ethereum to Polkadot**: The system adds twelve `0xEE` bytes to the end of the address, which is a reversible operation.
     - **Polkadot to Ethereum**: The system strips trailing `0xEE` bytes if present; otherwise, it hashes the account to derive a 20-byte address.
 
     Use the [EVM to SS58 address converter](https://ggwpez.github.io/evm-to-ss58){target=\_blank} to convert addresses.


### PR DESCRIPTION
## 📝 Description

This pull request adds a helpful summary section to the top of the `smart-contracts/for-eth-devs/accounts.md` documentation. The section provides a quick explanation of how Polkadot Hub handles address conversion between Ethereum and Polkadot formats, along with a link to a conversion tool and an important note about account mapping for native Polkadot accounts.

Documentation improvements:

* Added a "TL;DR - Quick Address Conversion" tip to explain automatic conversion between Ethereum (20-byte) and Polkadot (32-byte) addresses, including a summary of the conversion logic and a link to an online converter tool.
* Included a warning that native Polkadot accounts must call `map_account` before interacting with smart contracts via Ethereum tools, with a reference to further documentation.

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
