### PR TITLE
FIX warning note erc20

### DIFF
--- a/smart-contracts/precompiles/erc20.md
+++ b/smart-contracts/precompiles/erc20.md
@@ -35,6 +35,9 @@ interface IERC20 {
 }
 ```
 
+!!!warning "Metadata Functions Not Available"
+    The optional ERC20 metadata functions (`name()`, `symbol()`, `decimals()`) are **not implemented** in this precompile. These functions are only available through the Assets pallet's storage, not via the ERC20 interface.
+
 ## Query Functions
 
 ### Get Total Supply
@@ -196,9 +199,6 @@ uint256 amount = 250 * 10**10;
 bool success = token.transferFrom(owner, recipient, amount);
 require(success, "Transfer from failed");
 ```
-
-!!!note "Metadata Functions Not Available"
-    The optional ERC20 metadata functions (`name()`, `symbol()`, `decimals()`) are **not implemented** in this precompile. These functions are only available through the Assets pallet's storage, not via the ERC20 interface.
 
 For the complete implementation, refer to the [ERC20 precompile source code](https://github.com/paritytech/polkadot-sdk/blob/11be995be95ac1e25a5b2a6dd941006e7097bffc/substrate/frame/assets/precompiles/src/lib.rs){target=\_blank} in the Polkadot SDK.
 


### PR DESCRIPTION
## 📝 Description

This pull request updates the documentation for the ERC20 precompile to clarify the availability of metadata functions. The main change is the relocation and reformatting of a warning about the absence of `name()`, `symbol()`, and `decimals()` in the ERC20 interface.

Documentation clarification:

* Added a prominent warning near the top of `smart-contracts/precompiles/erc20.md` stating that the optional ERC20 metadata functions (`name()`, `symbol()`, `decimals()`) are not implemented in the precompile and are only accessible via the Assets pallet's storage.
* Removed the previous note about metadata functions from further down in the documentation to avoid redundancy and improve visibility.

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
