### PR TITLE
Add account converter

### DIFF
--- a/smart-contracts/for-eth-devs/accounts.md
+++ b/smart-contracts/for-eth-devs/accounts.md
@@ -16,7 +16,7 @@ categories: Basics, Polkadot Protocol
 
 ---
 
-<iframe src="https://polkadot-developers.github.io/account-converter/" width="100%" height="670" frameborder="0" class="converter"></iframe>
+<iframe src="https://polkadot-developers.github.io/account-converter/" width="100%" height="670" class="converter" style="border: 0;"></iframe>
 
 ## Introduction
 


### PR DESCRIPTION
## 📝 Description

This pull request updates the Ethereum-to-Polkadot address conversion documentation by embedding the address converter tool directly in the page instead of linking to an external site. This improves usability by allowing users to convert addresses without leaving the documentation.

- Documentation usability improvement:
  * Replaced the external link to the EVM to SS58 address converter with an embedded `<iframe>` pointing to the converter tool, making it accessible directly within the documentation (`smart-contracts/for-eth-devs/accounts.md`).

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
