### PR TITLE
Add badges and filter all badge URLs by push event

### DIFF
--- a/parachains/customize-runtime/add-existing-pallets.md
+++ b/parachains/customize-runtime/add-existing-pallets.md
@@ -8,7 +8,7 @@ categories: Parachains
 # Add an Existing Pallet to the Runtime
 
 <div class="status-badge" markdown>
-[![Add Existing Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml){target=\_blank}
+[![Add Existing Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml){target=\_blank}
 </div>
 
 ## Introduction
@@ -268,7 +268,7 @@ To interact with the pallet:
 You can now test the pallet's functionality by submitting transactions through the interface.
 
 <div class="status-badge" markdown>
-[![Add Existing Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml){target=\_blank}
+[![Add Existing Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml){target=\_blank}
 [:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/add-existing-pallets/tests/guide.test.ts){ .tests-button target=\_blank}
 </div>
 

--- a/parachains/customize-runtime/add-pallet-instances.md
+++ b/parachains/customize-runtime/add-pallet-instances.md
@@ -8,7 +8,7 @@ categories: Parachains
 # Add Multiple Pallet Instances
 
 <div class="status-badge" markdown>
-[![Add Pallet Instances](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml){target=\_blank}
+[![Add Pallet Instances](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml){target=\_blank}
 </div>
 
 ## Introduction
@@ -420,7 +420,7 @@ To test instance independence:
 You can now use both collective instances for different governance purposes in your parachain, such as technical decisions that require expertise and general governance decisions that require broader consensus.
 
 <div class="status-badge" markdown>
-[![Add Pallet Instances](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml){target=\_blank}
+[![Add Pallet Instances](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml){target=\_blank}
 [:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/add-pallet-instances/tests/guide.test.ts){ .tests-button target=\_blank}
 </div>
 

--- a/parachains/customize-runtime/pallet-development/benchmark-pallet.md
+++ b/parachains/customize-runtime/pallet-development/benchmark-pallet.md
@@ -7,7 +7,7 @@ categories: Parachains
 ## Introduction
 
 <div class="status-badge" markdown>
-[![Benchmark Pallet](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml){target=\_blank}
+[![Benchmark Pallet](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml){target=\_blank}
 </div>
 
 Benchmarking is the process of measuring the computational resources (execution time and storage) required by your pallet's extrinsics. Accurate [weight](https://paritytech.github.io/polkadot-sdk/master/frame_support/weights/index.html){target=\_blank} calculations are essential for ensuring your blockchain can process transactions efficiently while protecting against denial-of-service attacks.
@@ -450,7 +450,7 @@ Follow these steps to use the generated weights with your pallet:
 Congratulations, you've successfully benchmarked a pallet and updated your runtime to use the generated weight values.
 
 <div class="status-badge" markdown>
-[![Benchmark Pallet](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml){target=\_blank}
+[![Benchmark Pallet](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml){target=\_blank}
 [:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/tests/guide.test.ts){ .tests-button target=\_blank}
 </div>
 

--- a/parachains/customize-runtime/pallet-development/create-a-pallet.md
+++ b/parachains/customize-runtime/pallet-development/create-a-pallet.md
@@ -7,7 +7,7 @@ categories: Parachains
 # Create a Custom Pallet
 
 <div class="status-badge" markdown>
-[![Create a Custom Pallet](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-a-pallet.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-a-pallet.yml){target=\_blank}
+[![Create a Custom Pallet](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-a-pallet.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-a-pallet.yml){target=\_blank}
 </div>
 
 ## Introduction
@@ -411,7 +411,7 @@ You've successfully created and integrated a custom pallet into a Polkadot SDK-b
 These components form the foundation for developing sophisticated blockchain logic in Polkadot SDK-based chains.
 
 <div class="status-badge" markdown>
-[![Create a Custom Pallet](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-a-pallet.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-a-pallet.yml){target=\_blank}
+[![Create a Custom Pallet](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-a-pallet.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-a-pallet.yml){target=\_blank}
 [:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/tests/guide.test.ts){ .tests-button target=\_blank}
 </div>
 

--- a/parachains/customize-runtime/pallet-development/mock-runtime.md
+++ b/parachains/customize-runtime/pallet-development/mock-runtime.md
@@ -7,7 +7,7 @@ categories: Parachains
 # Mock Your Runtime
 
 <div class="status-badge" markdown>
-[![Mock Your Runtime](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml){target=\_blank}
+[![Mock Your Runtime](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml){target=\_blank}
 </div>
 
 ## Introduction
@@ -172,7 +172,7 @@ You've successfully created a mock runtime with a genesis configuration for your
 The mock runtime with a genesis configuration is essential for test-driven development, enabling you to verify logic under different initial conditions before integrating it into the actual parachain runtime.
 
 <div class="status-badge" markdown>
-[![Mock Your Runtime](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml){target=\_blank}
+[![Mock Your Runtime](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml){target=\_blank}
 [:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/tests/guide.test.ts){ .tests-button target=\_blank}
 </div>
 

--- a/parachains/customize-runtime/pallet-development/pallet-testing.md
+++ b/parachains/customize-runtime/pallet-development/pallet-testing.md
@@ -7,7 +7,7 @@ categories: Parachains
 # Unit Test Pallets
 
 <div class="status-badge" markdown>
-[![Unit Test Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml){target=\_blank}
+[![Unit Test Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml){target=\_blank}
 </div>
 
 ## Introduction
@@ -601,7 +601,7 @@ These tests demonstrate comprehensive coverage including basic operations, error
     ```
 
 <div class="status-badge" markdown>
-[![Unit Test Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml){target=\_blank}
+[![Unit Test Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml){target=\_blank}
 [:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/tests/guide.test.ts){ .tests-button target=\_blank}
 </div>
 

--- a/parachains/install-polkadot-sdk.md
+++ b/parachains/install-polkadot-sdk.md
@@ -7,7 +7,7 @@ categories: Basics, Tooling
 # Install Polkadot SDK
 
 <div class="status-badge" markdown>
-[![Install Polkadot SDK](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml){target=\_blank}
+[![Install Polkadot SDK](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml){target=\_blank}
 </div>
 
 This guide provides step-by-step instructions for installing the Polkadot SDK on macOS, Linux, and Windows. The installation process consists of two main parts:
@@ -406,7 +406,7 @@ You can now explore the various pallets and features included in the kitchensink
 To stop the node, press `Control-C` in the terminal.
 
 <div class="status-badge" markdown>
-[![Install Polkadot SDK](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml){target=\_blank}
+[![Install Polkadot SDK](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml){target=\_blank}
 [:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/install-polkadot-sdk/tests/guide.test.ts){ .tests-button target=\_blank}
 </div>
 

--- a/parachains/launch-a-parachain/set-up-the-parachain-template.md
+++ b/parachains/launch-a-parachain/set-up-the-parachain-template.md
@@ -8,7 +8,7 @@ categories: Basics, Parachains
 # Set Up the Polkadot SDK Parachain Template
 
 <div class="status-badge" markdown>
-[![Set Up Parachain Template](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml){target=\_blank}
+[![Set Up Parachain Template](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml){target=\_blank}
 </div>
 
 ## Introduction
@@ -215,7 +215,7 @@ To stop the local node:
 3. Verify that your terminal returns to the prompt in the `parachain-template` directory.
 
 <div class="status-badge" markdown>
-[![Set Up Parachain Template](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml){target=\_blank}
+[![Set Up Parachain Template](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml){target=\_blank}
 [:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/set-up-parachain-template/tests/guide.test.ts){ .tests-button target=\_blank}
 </div>
 

--- a/parachains/testing/fork-a-parachain.md
+++ b/parachains/testing/fork-a-parachain.md
@@ -7,7 +7,7 @@ categories: Parachains, Tooling
 # Fork a Parachain Using Chopsticks
 
 <div class="status-badge" markdown>
-[![Fork a Parachain](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml){target=\_blank}
+[![Fork a Parachain](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml){target=\_blank}
 </div>
 
 ## Introduction
@@ -194,7 +194,7 @@ These are the methods that can be invoked and their parameters:
         ```
 
 <div class="status-badge" markdown>
-[![Fork a Parachain](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml/badge.svg)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml){target=\_blank}
+[![Fork a Parachain](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml){target=\_blank}
 [:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/testing/fork-a-parachain/tests/guide.test.ts){ .tests-button target=\_blank}
 </div>
 

--- a/parachains/testing/run-a-parachain-network.md
+++ b/parachains/testing/run-a-parachain-network.md
@@ -6,6 +6,10 @@ categories: Parachains, Tooling
 
 # Run a Parachain Network Using Zombienet
 
+<div class="status-badge" markdown>
+[![Run a Parachain Network](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-run-a-parachain-network.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-run-a-parachain-network.yml){target=\_blank}
+</div>
+
 ## Introduction
 
 Zombienet is a robust testing framework designed for Polkadot SDK-based blockchain networks. It enables developers to efficiently deploy and test ephemeral blockchain environments on platforms like Kubernetes, Podman, and native setups. With its simple and versatile CLI, Zombienet provides an all-in-one solution for spawning networks, running tests, and validating performance.
@@ -810,6 +814,11 @@ You can use the `hrmp_channels` keyword to define further parameters for the XCM
         - **`recipient` ++"number"++**: Parachain ID of the recipient.
         - **`max_capacity` ++"number"++**: Maximum capacity of the HRMP channel.
         - **`max_message_size` ++"number"++**: Maximum message size allowed in the HRMP channel.
+
+<div class="status-badge" markdown>
+[![Run a Parachain Network](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-run-a-parachain-network.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-run-a-parachain-network.yml){target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/networks/run-a-parachain-network/tests/guide.test.ts){ .tests-button target=\_blank}
+</div>
 
 ## Where to Go Next
 


### PR DESCRIPTION
## Summary

- Add `?event=push` to all badge SVG URLs across 10 tutorial pages
- Add missing top and bottom badges to `run-a-parachain-network.md`
- Add status badges to the Fork a Parachain guide

The [`polkadot-docs-scheduled.yml`](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/.github/workflows/polkadot-docs-scheduled.yml) dispatcher triggers each tutorial's workflow weekly via `workflow_dispatch`. When upstream changes cause test failures, badges immediately show "failing" on docs.polkadot.com — even though the tutorial code hasn't changed.

`badge.svg?event=push` filters the badge to only consider push-triggered runs, making `workflow_dispatch` failures invisible to badges.

**Maintainers are still notified of every failure.** Every workflow has a `notify-docs-failure` job that automatically creates a GitHub issue when a test fails, regardless of event type. Nothing changes about how failures are detected or reported — only the badge display is filtered.

More signal, less noise: badges reflect the true state of the code, while scheduled test failures are routed to issues where maintainers can triage and fix them.

### Companion PR

- https://github.com/polkadot-developers/polkadot-cookbook/pull/139 (merged)