### PR TITLE
Document gasCost tracing differences for CALL-like opcodes

### DIFF
--- a/smart-contracts/for-eth-devs/json-rpc-apis.md
+++ b/smart-contracts/for-eth-devs/json-rpc-apis.md
@@ -801,8 +801,8 @@ Ensure to replace the `INSERT_TRANSACTION_HASH` with the proper value.
 !!!note "Differences from Ethereum (Geth)"
     When using the default struct logger (opcode tracer), there is a difference in how `gasCost` is calculated for CALL-like opcodes (`CALL`, `DELEGATECALL`, `STATICCALL`, `CREATE`, `CREATE2`):
 
-    - **Geth behavior**: the `gasCost` includes the opcode's intrinsic cost plus all gas forwarded to child calls.
-    - **Polkadot Hub behavior**: the `gasCost` includes only the opcode's intrinsic cost, excluding forwarded gas. The intrinsic cost covers:
+    - **Geth behavior**: The `gasCost` includes the opcode's intrinsic cost plus all gas forwarded to child calls.
+    - **Polkadot Hub behavior**: The `gasCost` includes only the opcode's intrinsic cost, excluding forwarded gas. The intrinsic cost covers:
         - Base cost of the CALL opcode.
         - Post-call costs (for example, copying return data back to the caller's memory).
 


### PR DESCRIPTION
## 📝 Description

Adds a note under `debug_traceTransaction` documenting how `gasCost` calculation for CALL-like opcodes differs between Geth and Polkadot Hub
This behavior was introduced in [paritytech/polkadot-sdk#10928](https://github.com/paritytech/polkadot-sdk/pull/10928).

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [x] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [x] Changes tested  
- [x] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
