### PR TITLE
Add references to using Rust for PVM

### DIFF
--- a/smart-contracts/for-eth-devs/dual-vm-stack.md
+++ b/smart-contracts/for-eth-devs/dual-vm-stack.md
@@ -57,6 +57,8 @@ This proxy-based approach eliminates the need for node binary modifications, mai
 
 For advanced use cases requiring maximum performance, Polkadot Hub also supports the [PVM (Polkadot Virtual Machine)](https://github.com/paritytech/polkavm){target=\_blank} backend. PVM uses a RISC-V-based architecture that can provide performance optimizations for computationally intensive workloads. Solidity contracts can be compiled to PVM bytecode using the `resolc` compiler.
 
+Rust is also well-suited for PVM. Tooling is still limited, so consider using LLMs and coding agents to supplement development.
+
 Most developers should start with REVM for its simplicity and full Ethereum compatibility. PVM is available for projects with specific performance requirements.
 
 ## Where To Go Next

--- a/smart-contracts/get-started.md
+++ b/smart-contracts/get-started.md
@@ -27,6 +27,7 @@ Set up local environments and CI-friendly workflows to iterate quickly and valid
 | [Run a Local Dev Node](/smart-contracts/dev-environments/local-dev-node/) | Polkadot SDK node | Spin up a local node for iterative development |
 |   [Use Remix for Development](/smart-contracts/dev-environments/remix/)   |       Remix       |         Connect Remix to Polkadot Hub          |
 | [Use Hardhat for Development](/smart-contracts/dev-environments/hardhat/) |      Hardhat      |     Project scaffolding and configuration      |
+| [Rust for PVM](/smart-contracts/for-eth-devs/dual-vm-stack/#alternative-pvm-backend) | LLMs, coding agents | Write PVM contracts in Rust; use AI assistants while tooling matures |
 
 
 ## Ethereum Developer Resources

--- a/smart-contracts/overview.md
+++ b/smart-contracts/overview.md
@@ -28,7 +28,7 @@ Deploy existing Ethereum contracts with zero modifications while maintaining ful
 Choose between two execution backends:
 
 - **REVM**: Run unmodified Ethereum contracts with full EVM/Ethereum compatibility.
-- **PVM**: Compile to optimized RISC-V bytecode for enhanced performance and lower fees while keeping Ethereum-compatibility.
+- **PVM**: Compile to optimized RISC-V bytecode for enhanced performance and lower fees while keeping Ethereum-compatibility. You can write PVM contracts in Solidity (via `resolc`) or Rust—for Rust, tooling is maturing; use LLMs and coding agents to assist development.
 
 Both backends share the same RPC interface and tooling support, allowing seamless transitions. In addition, smart contracts can interact with Polkadot native services via [precompile contracts](/smart-contracts/precompiles/){target=\_blank}.
 


### PR DESCRIPTION
Solves https://github.com/polkadot-developers/polkadot-docs/issues/1479

## 📝 Description

This pull request updates documentation to clarify support for writing PVM contracts in Rust and suggests using LLMs and coding agents to supplement development while Rust tooling matures. It also adds Rust/PVM options to developer guides and improves guidance for Ethereum developers transitioning to Polkadot Hub.

Enhancements to PVM contract development guidance:

* [`smart-contracts/overview.md`](diffhunk://#diff-55fb5b56aba979607765a3b84d45f4da87ac3b2db3adb8d6d6683bf72fb4e88bL31-R31): Clarified that PVM contracts can be written in both Solidity (using `resolc`) and Rust, and recommended LLMs and coding agents for Rust development due to limited tooling.
* [`smart-contracts/for-eth-devs/dual-vm-stack.md`](diffhunk://#diff-4ca10dc6c3b50ddd33a6672f7d0dbe876e02fd00b948a8129e274899cb1ceca2R60-R61): Added a note highlighting Rust suitability for PVM and suggesting AI-assisted development while Rust tooling is limited.
* [`smart-contracts/get-started.md`](diffhunk://#diff-fc5d640a93df51fb2874c5d406ff93065fa9db9370e0e451ade6a9c47c3c6facR30): Added an entry to the developer workflow table for writing PVM contracts in Rust, with guidance on using LLMs and coding agents.

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
