### PR TITLE
Add status badges for ERC-20 Hardhat deployment documentation

### DIFF
--- a/smart-contracts/cookbook/smart-contracts/deploy-erc20/erc20-hardhat.md
+++ b/smart-contracts/cookbook/smart-contracts/deploy-erc20/erc20-hardhat.md
@@ -8,6 +8,10 @@ tools: Hardhat
 
 # Deploy an ERC-20 Using Hardhat
 
+<div class="status-badge" markdown>
+[![Deploy ERC-20 Hardhat](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-erc20-hardhat.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-erc20-hardhat.yml){target=\_blank}
+</div>
+
 ## Introduction
 
 [ERC-20](https://eips.ethereum.org/EIPS/eip-20){target=\_blank} tokens are fungible tokens commonly used for creating cryptocurrencies, governance tokens, and staking mechanisms. Polkadot Hub enables easy deployment of ERC-20 tokens via Ethereum-compatible smart contracts and tools.
@@ -105,6 +109,11 @@ You are now ready to deploy the contract to your chosen network. This example de
     --8<-- 'code/smart-contracts/cookbook/smart-contracts/deploy-erc20/erc20-hardhat/deploy-output.html'
 
 Congratulations! You've successfully deployed an ERC-20 token contract to Polkadot Hub TestNet using Hardhat. Consider the following resources to build upon your progress.
+
+<div class="status-badge" markdown>
+[![Deploy ERC-20 Hardhat](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-erc20-hardhat.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-erc20-hardhat.yml){target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/smart-contracts/erc20-hardhat/tests/recipe.test.ts){ .tests-button target=\_blank}
+</div>
 
 ## Where to Go Next
 


### PR DESCRIPTION
## 📝 Description

- Introduced status badges at the beginning and end of the erc20-hardhat.md file to indicate CI workflow status and link to test resources.
- Enhanced visibility of deployment success and testing resources for users.

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
