### PR TITLE
fix: update broken subxt docs.rs links

### DIFF
--- a/reference/tools/subxt.md
+++ b/reference/tools/subxt.md
@@ -78,14 +78,14 @@ Use the `#[subxt::subxt]` macro to generate a type-safe Rust interface from the 
 
 Once subxt interfaces are generated, you can interact with your node in the following ways. You can use the links below to view the related subxt documentation:
 
-- **[Transactions](https://docs.rs/subxt/latest/subxt/book/usage/transactions/index.html){target=\_blank}**: Builds and submits transactions, monitors their inclusion in blocks, and retrieves associated events.
-- **[Storage](https://docs.rs/subxt/latest/subxt/book/usage/storage/index.html){target=\_blank}**: Enables querying of node storage data.
-- **[Events](https://docs.rs/subxt/latest/subxt/book/usage/events/index.html){target=\_blank}**: Retrieves events emitted from recent blocks.
-- **[Constants](https://docs.rs/subxt/latest/subxt/book/usage/constants/index.html){target=\_blank}**: Accesses constant values stored in nodes that remain unchanged across a specific runtime version.
-- **[Blocks](https://docs.rs/subxt/latest/subxt/book/usage/blocks/index.html){target=\_blank}**: Loads recent blocks or subscribes to new/finalized blocks, allowing examination of extrinsics, events, and storage at those blocks.
-- **[Runtime APIs](https://docs.rs/subxt/latest/subxt/book/usage/runtime_apis/index.html){target=\_blank}**: Makes calls into pallet runtime APIs to fetch data.
-- **[Custom values](https://docs.rs/subxt/latest/subxt/book/usage/custom_values/index.html){target=\_blank}**: Accesses "custom values" contained within metadata.
-- **[Raw RPC calls](https://docs.rs/subxt/latest/subxt/book/usage/rpc/index.html){target=\_blank}**: Facilitates raw RPC requests to compatible nodes.
+- **[Transactions](https://docs.rs/subxt/latest/subxt/transactions/index.html){target=\_blank}**: Builds and submits transactions, monitors their inclusion in blocks, and retrieves associated events.
+- **[Storage](https://docs.rs/subxt/latest/subxt/storage/index.html){target=\_blank}**: Enables querying of node storage data.
+- **[Events](https://docs.rs/subxt/latest/subxt/events/index.html){target=\_blank}**: Retrieves events emitted from recent blocks.
+- **[Constants](https://docs.rs/subxt/latest/subxt/constants/index.html){target=\_blank}**: Accesses constant values stored in nodes that remain unchanged across a specific runtime version.
+- **[Extrinsics](https://docs.rs/subxt/latest/subxt/extrinsics/index.html){target=\_blank}**: Loads recent blocks or subscribes to new/finalized blocks, allowing examination of extrinsics, events, and storage at those blocks.
+- **[Runtime APIs](https://docs.rs/subxt/latest/subxt/runtime_apis/index.html){target=\_blank}**: Makes calls into pallet runtime APIs to fetch data.
+- **[Custom values](https://docs.rs/subxt/latest/subxt/custom_values/index.html){target=\_blank}**: Accesses "custom values" contained within metadata.
+- **[Raw RPC calls](https://docs.rs/subxt/latest/subxt/index.html#re-exports){target=\_blank}**: Facilitates raw RPC requests to compatible nodes.
 
 ### Initialize the Subxt Client
 
@@ -127,4 +127,4 @@ To submit a transaction, you must construct an extrinsic, sign it with your priv
 
 ## Where to Go Next
 
-Now that you've covered the basics dive into the official [subxt documentation](https://docs.rs/subxt/latest/subxt/book/index.html){target=\_blank} for comprehensive reference materials and advanced features.
+Now that you've covered the basics dive into the official [subxt documentation](https://docs.rs/subxt/latest/subxt/introduction/index.html){target=\_blank} for comprehensive reference materials and advanced features.


### PR DESCRIPTION
## Summary

- Updates 9 broken `docs.rs/subxt` links in `reference/tools/subxt.md`
- The subxt crate restructured its documentation — the old `book/usage/` path no longer exists on docs.rs

## Changes

| Old path | New path |
|---|---|
| `subxt/book/usage/transactions/` | `subxt/transactions/` |
| `subxt/book/usage/storage/` | `subxt/storage/` |
| `subxt/book/usage/events/` | `subxt/events/` |
| `subxt/book/usage/constants/` | `subxt/constants/` |
| `subxt/book/usage/blocks/` | `subxt/extrinsics/` (blocks module removed) |
| `subxt/book/usage/runtime_apis/` | `subxt/runtime_apis/` |
| `subxt/book/usage/custom_values/` | `subxt/custom_values/` |
| `subxt/book/usage/rpc/` | `subxt/index.html#re-exports` (rpcs is a re-export) |
| `subxt/book/index.html` | `subxt/introduction/index.html` |

## Context

These broken links are causing the link check to fail on all open PRs (e.g. #1521).

## Test plan

- [ ] Link check passes with the updated URLs