### PR TITLE
docs: add CI status badge and view tests link to local dev node page

### DIFF
--- a/smart-contracts/dev-environments/local-dev-node.md
+++ b/smart-contracts/dev-environments/local-dev-node.md
@@ -6,6 +6,10 @@ categories: Smart Contracts
 
 # Local Development Node
 
+<div class="status-badge" markdown>
+[![Local Development Node](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-local-dev-node.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-local-dev-node.yml){target=\_blank}
+</div>
+
 ## Introduction
 
 A local development node provides an isolated blockchain environment where you can deploy, test, and debug smart contracts without incurring network fees or waiting for block confirmations. This guide demonstrates how to set up a local Polkadot SDK-based node with smart contract capabilities.
@@ -84,3 +88,8 @@ RUST_LOG="info,eth-rpc=debug" ./target/release/eth-rpc --dev
 Your local development environment is now active and accessible at `http://localhost:8545`. This endpoint accepts standard Ethereum JSON-RPC requests, enabling seamless integration with existing Ethereum development tools and workflows. 
 
 You can connect wallets, deploy contracts using Remix or Hardhat, and interact with your smart contracts as you would on any Ethereum-compatible network.
+
+<div class="status-badge" markdown>
+[![Local Development Node](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-local-dev-node.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-local-dev-node.yml){target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/smart-contracts/local-dev-node/tests/recipe.test.ts){ .tests-button target=\_blank}
+</div>


### PR DESCRIPTION
## 📝 Description

This pull request adds status badges to the `smart-contracts/dev-environments/local-dev-node.md` documentation to indicate the workflow status and provide quick access to related tests. These badges help users quickly assess the health of the documentation and find relevant test suites.

Documentation enhancements:

* Added a GitHub Actions status badge for the Local Development Node workflow at the top of the documentation to show the current build status.
* Appended a status badge and a direct link to view related tests at the end of the guide, improving visibility of test coverage and workflow status.

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
