### PR TITLE
Fix - Evm vs PVM diagram feedback

### DIFF
--- a/smart-contracts/for-eth-devs/evm-vs-pvm.md
+++ b/smart-contracts/for-eth-devs/evm-vs-pvm.md
@@ -27,7 +27,7 @@ graph TD
     subgraph "PVM Path"
         ReviveCompile["Revive Compiler"]
         RISCV_Bytecode["RISC-V Bytecode"]
-        PVMNode["RISC-V Based PVM"]
+        PVMNode["RISC-V-based PVM"]
     end
 
     Execution["Contract Execution"]


### PR DESCRIPTION
## 📝 Description

This pull request updates the architecture diagram in the `smart-contracts/for-eth-devs/evm-vs-pvm.md` documentation to clarify the differences between the Ethereum and PVM contract execution paths. The changes make the diagram more accurate and easier to follow for developers comparing EVM and PVM.

Diagram improvements:

* Added a single starting point (`Solidity Source Code`) and a unified `Contract Execution` node to illustrate the shared aspects of both execution paths.
* Updated node names for clarity (e.g., specifying `Standard Solidity Compiler (solc)`, renaming `PVM` to `PVMNode`, and simplifying bytecode labels).
* Made the flow explicit by showing both compilers branching from Solidity and converging at contract execution, removing the previous "Key Differences" annotation in favor of a clearer visual structure.

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
