### PR TITLE
Add missing llvm and libclang-dev to Linux install dependencies

### DIFF
--- a/parachains/install-polkadot-sdk.md
+++ b/parachains/install-polkadot-sdk.md
@@ -142,13 +142,13 @@ To install the Rust toolchain on Linux:
     === "Ubuntu"
 
         ```bash
-        sudo apt install --assume-yes git clang curl libssl-dev protobuf-compiler
+        sudo apt install --assume-yes git clang curl libssl-dev llvm libclang-dev libudev-dev make protobuf-compiler
         ```
 
     === "Debian"
 
         ```sh
-        sudo apt install --assume-yes git clang curl libssl-dev llvm libudev-dev make protobuf-compiler
+        sudo apt install --assume-yes git clang curl libssl-dev llvm libclang-dev libudev-dev make protobuf-compiler
         ```
 
     === "Arch"
@@ -269,7 +269,7 @@ To install the Rust toolchain on WSL:
 5. Add the required packages for the Ubuntu distribution by running the following command:
 
     ```bash
-    sudo apt install --assume-yes git clang curl libssl-dev llvm libudev-dev make protobuf-compiler
+    sudo apt install --assume-yes git clang curl libssl-dev llvm libclang-dev libudev-dev make protobuf-compiler
     ```
 
 6. Download the `rustup` installation program and use it to install Rust for the Ubuntu distribution by running the following command:


### PR DESCRIPTION
## Summary

- Add `llvm`, `libclang-dev`, `libudev-dev`, and `make` to the Ubuntu install command, which was missing these packages and causing build failures on Ubuntu 24.04 LTS
- Add `libclang-dev` to the Debian and standalone Ubuntu install commands for consistency

## Test plan

- [x] Verify the updated install commands render correctly on the page
- [x] Confirm a fresh Ubuntu 24.04 LTS install can build Polkadot SDK after running the updated command

Closes #1559