### PR TITLE
remove tools front matter

### DIFF
--- a/smart-contracts/cookbook/eth-dapps/uniswap-v2.md
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v2.md
@@ -3,7 +3,6 @@ title: Deploying Uniswap V2 on Polkadot
 description: Learn how to deploy and test Uniswap V2 on Polkadot Hub using Hardhat, bringing AMM-based token swaps to the Polkadot ecosystem.
 tutorial_badge: Intermediate
 categories: Smart Contracts, Tooling
-tools: Hardhat
 ---
 
 # Deploy Uniswap V2

--- a/smart-contracts/cookbook/smart-contracts/deploy-erc20/erc20-hardhat.md
+++ b/smart-contracts/cookbook/smart-contracts/deploy-erc20/erc20-hardhat.md
@@ -3,7 +3,6 @@ title: Deploy an ERC-20 Using Hardhat
 description: Deploy an ERC-20 token on Polkadot Hub using PVM. This guide covers contract creation, compilation, deployment, and interaction via Hardhat.
 tutorial_badge: Intermediate
 categories: Basics, Smart Contracts
-tools: Hardhat
 ---
 
 # Deploy an ERC-20 Using Hardhat

--- a/smart-contracts/cookbook/smart-contracts/deploy-erc20/erc20-remix.md
+++ b/smart-contracts/cookbook/smart-contracts/deploy-erc20/erc20-remix.md
@@ -3,7 +3,6 @@ title: Deploy an ERC-20 Using Remix IDE
 description: Deploy an ERC-20 token contract on Polkadot Hub. This guide covers contract creation, compilation, deployment, and interaction via the Remix IDE.
 tutorial_badge: Beginner
 categories: Basics, Smart Contracts
-tools: EVM Wallet, Remix
 ---
 
 # Deploy an ERC-20 Using Remix IDE

--- a/smart-contracts/cookbook/smart-contracts/deploy-nft/.foundry.md
+++ b/smart-contracts/cookbook/smart-contracts/deploy-nft/.foundry.md
@@ -3,7 +3,6 @@ title: Deploy an NFT to Polkadot Hub with Foundry
 description: Learn how to deploy an ERC-721 NFT contract to Polkadot Hub using Foundry, a Rust toolkit with high-performance compilation.
 tutorial_badge: Beginner
 categories: Basics, Smart Contracts
-tools: EVM Wallet, Foundry
 ---
 
 # Deploy an NFT with Foundry

--- a/smart-contracts/cookbook/smart-contracts/deploy-nft/nft-hardhat.md
+++ b/smart-contracts/cookbook/smart-contracts/deploy-nft/nft-hardhat.md
@@ -3,7 +3,6 @@ title: Deploy an ERC-721 Using Hardhat
 description: Learn how to deploy an ERC-721 NFT contract to Polkadot Hub using Hardhat, a comprehensive development environment with built-in deployment capabilities.
 tutorial_badge: Beginner
 categories: Basics, Smart Contracts
-tools: EVM Wallet, Hardhat
 ---
 
 # Deploy an ERC-721 Using Hardhat

--- a/smart-contracts/cookbook/smart-contracts/deploy-nft/nft-remix.md
+++ b/smart-contracts/cookbook/smart-contracts/deploy-nft/nft-remix.md
@@ -3,7 +3,6 @@ title: Deploy an ERC-721 NFT Using Remix
 description: Learn how to deploy an ERC-721 NFT contract to Polkadot Hub using Remix, a browser-based IDE for quick prototyping and learning.
 tutorial_badge: Beginner
 categories: Basics, Smart Contracts
-tools: Remix, EVM Wallet, OpenZeppelin
 ---
 
 # Deploy an NFT with Remix


### PR DESCRIPTION
## 📝 Description

This pull request makes a small documentation update across several smart contract deployment tutorials. The change removes the `tools` metadata field from the frontmatter of each guide, which previously listed the required development tools for each tutorial.

No other content or instructional changes are included.

