### PR TITLE
Fix broken cookbook test links after test file rename

### DIFF
--- a/chain-interactions/accounts/create-account.md
+++ b/chain-interactions/accounts/create-account.md
@@ -155,7 +155,7 @@ Rust provides low-level access to Substrate primitives for account creation thro
 
 <div class="status-badge" markdown>
 [![Create an Account](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-account.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-account.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/chain-interactions/create-account/tests/recipe.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/chain-interactions/create-account/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/chain-interactions/accounts/query-accounts.md
+++ b/chain-interactions/accounts/query-accounts.md
@@ -306,7 +306,7 @@ The total balance is the sum of free and reserved balances.
 
 <div class="status-badge" markdown>
 [![Query Account Information](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-query-accounts.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-query-accounts.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/chain-interactions/query-accounts/tests/recipe.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/chain-interactions/query-accounts/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/chain-interactions/query-data/query-sdks.md
+++ b/chain-interactions/query-data/query-sdks.md
@@ -398,7 +398,7 @@ Select your preferred SDK below to see complete, runnable examples that query Po
 
 <div class="status-badge" markdown>
 [![Query On-Chain State with SDKs](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-query-sdks.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-query-sdks.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/chain-interactions/query-sdks/tests/recipe.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/chain-interactions/query-sdks/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/parachains/customize-runtime/add-existing-pallets.md
+++ b/parachains/customize-runtime/add-existing-pallets.md
@@ -269,7 +269,7 @@ You can now test the pallet's functionality by submitting transactions through t
 
 <div class="status-badge" markdown>
 [![Add Existing Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/add-existing-pallets/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/add-existing-pallets/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/parachains/customize-runtime/add-pallet-instances.md
+++ b/parachains/customize-runtime/add-pallet-instances.md
@@ -421,7 +421,7 @@ You can now use both collective instances for different governance purposes in y
 
 <div class="status-badge" markdown>
 [![Add Pallet Instances](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/add-pallet-instances/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/add-pallet-instances/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/parachains/customize-runtime/pallet-development/benchmark-pallet.md
+++ b/parachains/customize-runtime/pallet-development/benchmark-pallet.md
@@ -469,7 +469,7 @@ Congratulations, you've successfully benchmarked a pallet and updated your runti
 
 <div class="status-badge" markdown>
 [![Benchmark Pallet](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Related Resources

--- a/parachains/customize-runtime/pallet-development/create-a-pallet.md
+++ b/parachains/customize-runtime/pallet-development/create-a-pallet.md
@@ -412,7 +412,7 @@ These components form the foundation for developing sophisticated blockchain log
 
 <div class="status-badge" markdown>
 [![Create a Custom Pallet](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-a-pallet.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-a-pallet.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/parachains/customize-runtime/pallet-development/mock-runtime.md
+++ b/parachains/customize-runtime/pallet-development/mock-runtime.md
@@ -173,7 +173,7 @@ The mock runtime with a genesis configuration is essential for test-driven devel
 
 <div class="status-badge" markdown>
 [![Mock Your Runtime](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/parachains/customize-runtime/pallet-development/pallet-testing.md
+++ b/parachains/customize-runtime/pallet-development/pallet-testing.md
@@ -602,7 +602,7 @@ These tests demonstrate comprehensive coverage including basic operations, error
 
 <div class="status-badge" markdown>
 [![Unit Test Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/parachains/install-polkadot-sdk.md
+++ b/parachains/install-polkadot-sdk.md
@@ -407,7 +407,7 @@ To stop the node, press `Control-C` in the terminal.
 
 <div class="status-badge" markdown>
 [![Install Polkadot SDK](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/install-polkadot-sdk/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/install-polkadot-sdk/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/parachains/interoperability/channels-between-parachains.md
+++ b/parachains/interoperability/channels-between-parachains.md
@@ -193,7 +193,7 @@ By following these steps, you will have successfully accepted the HRMP channel r
 
 <div class="status-badge" markdown>
 [![Channels Between Parachains](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-channels-between-parachains.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-channels-between-parachains.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/interoperability/channels-between-parachains/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/interoperability/channels-between-parachains/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 !!! note

--- a/parachains/interoperability/channels-with-system-parachains.md
+++ b/parachains/interoperability/channels-with-system-parachains.md
@@ -121,5 +121,5 @@ This bidirectional channel enables direct communication between the system chain
 
 <div class="status-badge" markdown>
 [![Channels with System Parachains](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-channels-with-system-parachains.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-channels-with-system-parachains.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/interoperability/channels-with-system-parachains/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/interoperability/channels-with-system-parachains/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>

--- a/parachains/launch-a-parachain/set-up-the-parachain-template.md
+++ b/parachains/launch-a-parachain/set-up-the-parachain-template.md
@@ -226,7 +226,7 @@ To stop the local node:
 
 <div class="status-badge" markdown>
 [![Set Up Parachain Template](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/set-up-parachain-template/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/set-up-parachain-template/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/parachains/runtime-maintenance/runtime-upgrades.md
+++ b/parachains/runtime-maintenance/runtime-upgrades.md
@@ -174,7 +174,7 @@ Test the new functionality:
 
 <div class="status-badge" markdown>
 [![Runtime Upgrades](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-runtime-upgrades.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-runtime-upgrades.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/runtime-maintenance/runtime-upgrades/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/runtime-maintenance/runtime-upgrades/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/parachains/testing/fork-a-parachain.md
+++ b/parachains/testing/fork-a-parachain.md
@@ -195,7 +195,7 @@ These are the methods that can be invoked and their parameters:
 
 <div class="status-badge" markdown>
 [![Fork a Parachain](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/testing/fork-a-parachain/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/parachains/testing/fork-a-parachain/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/parachains/testing/run-a-parachain-network.md
+++ b/parachains/testing/run-a-parachain-network.md
@@ -187,7 +187,7 @@ To stop the network, press **Ctrl + C** in the terminal where Zombienet is runni
 
 <div class="status-badge" markdown>
 [![Run a Parachain Network](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-run-a-parachain-network.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-run-a-parachain-network.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/networks/run-a-parachain-network/tests/guide.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/networks/run-a-parachain-network/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/smart-contracts/cookbook/smart-contracts/deploy-basic/basic-hardhat.md
+++ b/smart-contracts/cookbook/smart-contracts/deploy-basic/basic-hardhat.md
@@ -98,7 +98,7 @@ Congratulations! You've now deployed a basic smart contract to Polkadot Hub Test
 
 <div class="status-badge" markdown>
 [![Deploy a Basic Contract with Hardhat](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-basic-hardhat.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-basic-hardhat.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/smart-contracts/basic-hardhat/tests/recipe.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/smart-contracts/basic-hardhat/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/smart-contracts/cookbook/smart-contracts/deploy-erc20/erc20-hardhat.md
+++ b/smart-contracts/cookbook/smart-contracts/deploy-erc20/erc20-hardhat.md
@@ -112,7 +112,7 @@ Congratulations! You've successfully deployed an ERC-20 token contract to Polkad
 
 <div class="status-badge" markdown>
 [![Deploy ERC-20 Hardhat](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-erc20-hardhat.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-erc20-hardhat.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/smart-contracts/erc20-hardhat/tests/recipe.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/smart-contracts/erc20-hardhat/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>
 
 ## Where to Go Next

--- a/smart-contracts/dev-environments/local-dev-node.md
+++ b/smart-contracts/dev-environments/local-dev-node.md
@@ -91,5 +91,5 @@ You can connect wallets, deploy contracts using Remix or Hardhat, and interact w
 
 <div class="status-badge" markdown>
 [![Local Development Node](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-local-dev-node.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-local-dev-node.yml){target=\_blank}
-[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/smart-contracts/local-dev-node/tests/recipe.test.ts){ .tests-button target=\_blank}
+[:material-code-tags: View tests](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/polkadot-docs/smart-contracts/local-dev-node/tests/docs.test.ts){ .tests-button target=\_blank}
 </div>


### PR DESCRIPTION
## Summary

Updates all "View tests" links to reflect the test file naming convention change from polkadot-developers/polkadot-cookbook#206:

- `guide.test.ts` → `docs.test.ts` (13 files)
- `recipe.test.ts` → `docs.test.ts` (6 files)