### PR TITLE
Fix eth-rpc docs

### DIFF
--- a/node-infrastructure/run-a-node/polkadot-hub-rpc.md
+++ b/node-infrastructure/run-a-node/polkadot-hub-rpc.md
@@ -563,10 +563,10 @@ The adapter accepts the following key parameters:
 
     | Previous Flag | Replacement |
     |:-------------:|:-----------:|
-    | `--cache-size N` | `--eth-pruning N` |
-    | `--database-url sqlite::memory:` | `--eth-pruning N` |
-    | `--database-url /path/to/db` | `--base-path /path/to/dir` |
-    | `--index-last-n-blocks N` | `--eth-pruning archive` |
+    | `--cache-size N` | `--eth-pruning=<N>` |
+    | `--database-url sqlite::memory:` | `--eth-pruning=<N>` |
+    | `--database-url /path/to/db` | `--base-path=/path/to/dir` |
+    | `--index-last-n-blocks N` | `--eth-pruning=archive` |
     | `--earliest-receipt-block N` | Removed — the adapter now auto-discovers the first EVM block |
 
 ### API Endpoints


### PR DESCRIPTION
## 📝 Description

This pull request updates the Polkadot Hub Ethereum RPC adapter documentation to reflect recent changes in configuration and usage, focusing on improved data persistence and updated CLI flags. The changes clarify how to persist the adapter’s database, update Docker and systemd instructions, and document the migration from deprecated to new command-line options.

**Key documentation updates:**

**Persistent data and usage instructions:**
- Added Docker `-v /var/lib/eth-rpc:/data` volume mapping and the `--base-path=/data` flag to persist the `eth-rpc.db` database, with an explanatory note. Updated CLI flags to use equals (`=`) syntax for consistency.
- Updated systemd service example to include the `--base-path=/var/lib/eth-rpc` flag for persistent storage and switched to equals (`=`) syntax for CLI flags.

**CLI flags and migration guidance:**
- Updated the CLI flags table to add new options (`--eth-pruning`, `--base-path`, `--dev`), removed deprecated flags, and provided a migration guide mapping old flags to their replacements, referencing the relevant upstream PR.

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
