### PR TITLE
fix: add missing macOS build dependencies to install guide

### DIFF
--- a/parachains/install-polkadot-sdk.md
+++ b/parachains/install-polkadot-sdk.md
@@ -31,6 +31,14 @@ Before you install Rust and set up your development environment on macOS, verify
 - Storage of at least 10 GB of available space.
 - Broadband Internet connection.
 
+### Install Command Line Tools
+
+Xcode Command Line Tools provide essential build dependencies including `clang`, `make`, and other tools required to compile native crates like `librocksdb-sys`. To install them, run:
+
+```bash
+xcode-select --install
+```
+
 ### Install Homebrew
 
 In most cases, you should use Homebrew to install and manage packages on macOS computers. If you don't already have Homebrew installed on your local computer, you should download and install it before continuing.
@@ -103,13 +111,7 @@ To install `openssl` and the Rust toolchain on macOS:
     rustup component add rust-src
     ```
 
-8. Install `cmake` using the following command:
-
-    ```bash
-    brew install cmake
-    ```
-
-9. Proceed to [Build the Polkadot SDK](#build-the-polkadot-sdk).
+8. Proceed to [Build the Polkadot SDK](#build-the-polkadot-sdk).
 
 ## Install Dependencies: Linux
 

--- a/reference/tools/omninode.md
+++ b/reference/tools/omninode.md
@@ -36,6 +36,9 @@ Download the pre-built `polkadot-omni-node` binary from the [Polkadot SDK releas
 
 Alternatively, you can install from source using `cargo`:
 
+!!! note
+    Building from source requires Rust and system dependencies. See [Install Dependencies: macOS](/parachains/install-polkadot-sdk/#install-dependencies-macos) or [Install Dependencies: Linux](/parachains/install-polkadot-sdk/#install-dependencies-linux) before proceeding.
+
 ```bash
 cargo install --locked polkadot-omni-node@{{dependencies.crates.polkadot_omni_node.version}}
 ```


### PR DESCRIPTION
## Summary

Closes https://github.com/polkadot-developers/polkadot-docs/issues/1582

- **Add Xcode Command Line Tools step to macOS install guide** — the macOS section was missing `clang` and other build tools that the Linux section explicitly lists. `xcode-select --install` provides `clang`, `make`, `cmake`, and other essentials needed to compile native crates like `librocksdb-sys`
- **Remove `brew install cmake` step** — Xcode Command Line Tools already includes `cmake`, so the separate Homebrew install is no longer needed
- **Add prerequisite note to omninode `cargo install` alternative** — points users to the install dependencies page before they attempt a source build, so they don't hit the same `libclang` error reported in #1582