### PR TITLE
fix: correct event field name in reset_something.rs snippet

### DIFF
--- a/.snippets/code/parachains/runtime-maintenance/runtime-upgrades/reset_something.rs
+++ b/.snippets/code/parachains/runtime-maintenance/runtime-upgrades/reset_something.rs
@@ -8,6 +8,6 @@
 pub fn reset_counter(origin: OriginFor<T>) -> DispatchResult {
 	ensure_root(origin)?;
 	<CounterValue<T>>::put(0u32);
-	Self::deposit_event(Event::CounterValueSet { counter_value: 0 });
+	Self::deposit_event(Event::CounterValueSet { new_value: 0 });
 	Ok(())
 }


### PR DESCRIPTION
## Summary
- Fixes a bug in `.snippets/code/parachains/runtime-maintenance/runtime-upgrades/reset_something.rs`
- The `CounterValueSet` event field is named `new_value` (defined in `lib-complete.rs` and all other create-a-pallet snippets), but `reset_something.rs` incorrectly used `counter_value`
- This snippet would fail to compile against the pallet's Event enum

## Test plan
- [x] Verified `CounterValueSet` event definition uses `new_value` in `lib-complete.rs`, `lib-04.rs`, and `lib-08.rs`
- [x] Confirmed `counter_value` is not used anywhere else as a field name