### PR TITLE
Update dependencies in variables.yml

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -10,16 +10,16 @@ dependencies:
       version: v0.0.2
     srtool:
       repository_url: https://github.com/paritytech/srtool
-      version: v0.18.3
+      version: v0.18.4
       docker_image_name: paritytech/srtool
-      docker_image_version: 1.88.0
+      docker_image_version: 1.93.0
     polkadot_sdk:
       repository_url: https://github.com/paritytech/polkadot-sdk
-      version: polkadot-stable2512-2
-      docker_image_version: stable2512-2
+      version: polkadot-stable2512-3
+      docker_image_version: stable2512-3
     open_zeppelin_contracts:
       repository_url: https://github.com/OpenZeppelin/openzeppelin-contracts
-      version: v5.6.0
+      version: v5.6.1
     polkadot_sdk_contracts_node:
       repository_url: https://github.com/paritytech/polkadot-sdk
       version: polkadot-stable2503-6
@@ -54,17 +54,17 @@ dependencies:
       ignore_updates: true
     polkadot_omni_node:
       name: polkadot-omni-node
-      version: 0.13.2
+      version: 0.14.0
   javascript_packages:
     chopsticks:
       name: '@acala-network/chopsticks'
-      version: 1.2.7
+      version: 1.2.8
     moonwall:
       name: '@moonwall/cli'
       version: 5.18.3
     polkadot_js_api:
       name: '@polkadot/api'
-      version: 16.5.4
+      version: 16.5.6
     polkadot_api:
       name: polkadot-api
       version: 1.23.3
@@ -88,20 +88,20 @@ dependencies:
       version: 6.16.0
     paraspell_sdk:
       name: '@paraspell/sdk'
-      version: 12.8.0
+      version: 12.8.8
     hdkd:
       name: '@polkadot-labs/hdkd'
-      version: 0.0.26
+      version: 0.0.27
     hdkd_helpers:
       name: '@polkadot-labs/hdkd-helpers'
-      version: 0.0.27
+      version: 0.0.28
     polkadot_util:
       name: '@polkadot/util'
-      version: 14.0.1
+      version: 14.0.2
     polkadot_util_crypto:
       name: '@polkadot/util-crypto'
-      version: 14.0.1
+      version: 14.0.2
     polkadot_keyring:
       name: '@polkadot/keyring'
-      version: 14.0.1
+      version: 14.0.2
 #   python_packages:


### PR DESCRIPTION
## Summary

Updates 12 dependencies to their latest versions:

**Repositories:**
- `srtool`: v0.18.3 → v0.18.4 (Docker image: 1.88.0 → 1.93.0, Rust 1.93.0)
- `open_zeppelin_contracts`: v5.6.0 → v5.6.1
- `polkadot_sdk`: polkadot-stable2512-2 → polkadot-stable2512-3 (Docker: stable2512-2 → stable2512-3)

**Crates:**
- `polkadot_omni_node`: 0.13.2 → 0.14.0

**JavaScript packages:**
- `chopsticks`: 1.2.7 → 1.2.8
- `polkadot_js_api`: 16.5.4 → 16.5.6
- `paraspell_sdk`: 12.8.0 → 12.8.8
- `hdkd`: 0.0.26 → 0.0.27
- `hdkd_helpers`: 0.0.27 → 0.0.28
- `polkadot_util`: 14.0.1 → 14.0.2
- `polkadot_util_crypto`: 14.0.1 → 14.0.2
- `polkadot_keyring`: 14.0.1 → 14.0.2

**Skipped (parachain template still at v0.0.5, no new release):**
- #1563, #1594, #1595, #1596 — subdependencies pinned to template's Cargo.lock

All GitHub blob URL line ranges validated against the new `polkadot-stable2512-3` tag — no code shifts detected.

Closes #1557, closes #1560, closes #1562, closes #1564, closes #1565, closes #1566, closes #1567, closes #1577, closes #1578, closes #1580, closes #1581, closes #1597

## Test plan
- [x] All target package versions verified to exist (npm, crates.io, Docker Hub, GitHub releases)
- [x] All GitHub blob URL line ranges validated — identical code at old and new tags
- [x] `mkdocs build` passes with no template errors
- [x] CI link checker passes
- [x] CI docs build passes