### PR TITLE
docs: add hardhat nft badge

### DIFF
--- a/smart-contracts/cookbook/smart-contracts/deploy-nft/nft-hardhat.md
+++ b/smart-contracts/cookbook/smart-contracts/deploy-nft/nft-hardhat.md
@@ -3,6 +3,10 @@ title: Deploy an ERC-721 Using Hardhat
 description: Learn how to deploy an ERC-721 NFT contract to Polkadot Hub using Hardhat, a comprehensive development environment with built-in deployment capabilities.
 tutorial_badge: Beginner
 categories: Basics, Smart Contracts
+page_badges:
+  test_workflow: polkadot-docs-nft-hardhat
+page_tests:
+  path: polkadot-docs/smart-contracts/nft-hardhat/tests/docs.test.ts
 ---
 
 # Deploy an ERC-721 Using Hardhat

--- a/smart-contracts/cookbook/smart-contracts/deploy-nft/nft-hardhat.md
+++ b/smart-contracts/cookbook/smart-contracts/deploy-nft/nft-hardhat.md
@@ -3,6 +3,7 @@ title: Deploy an ERC-721 Using Hardhat
 description: Learn how to deploy an ERC-721 NFT contract to Polkadot Hub using Hardhat, a comprehensive development environment with built-in deployment capabilities.
 categories: Basics, Smart Contracts
 page_badges:
+  tutorial_badge: Beginner
   test_workflow: polkadot-docs-nft-hardhat
 page_tests:
   path: polkadot-docs/smart-contracts/nft-hardhat/tests/docs.test.ts


### PR DESCRIPTION
## 📝 Description

This pull request adds configuration for automated documentation testing to the NFT deployment tutorial. The main change is the addition of badges and test metadata to the tutorial's frontmatter.

Documentation/testing improvements:

* Added `page_badges` and `page_tests` fields to the frontmatter of `nft-hardhat.md` to enable automated test workflow and specify the test file for the tutorial.

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed

Holding this PR until https://github.com/polkadot-developers/polkadot-docs/pull/1609 is merged, but keeping the content here aligned with the new style