### PR TITLE
docs: add send tx with sdks badge

### DIFF
--- a/chain-interactions/send-transactions/with-sdks.md
+++ b/chain-interactions/send-transactions/with-sdks.md
@@ -2,6 +2,10 @@
 title: Send Transactions with SDKs
 description: Learn how to construct, sign, and submit transactions using PAPI, Polkadot.js, Dedot, Python Substrate Interface, and Subxt.
 categories: Chain Interactions, Tooling
+page_badges:
+  test_workflow: polkadot-docs-send-transactions
+page_tests:
+  path: polkadot-docs/chain-interactions/send-transactions/tests/docs.test.ts
 ---
 
 # Send Transactions with SDKs


### PR DESCRIPTION
## 📝 Description

This pull request adds automated testing configuration to the `chain-interactions/send-transactions/with-sdks.md` documentation. The changes introduce workflow and test metadata to enable continuous validation of the documentation's code examples.

Documentation testing integration:

* Added the `page_badges` section with a `test_workflow` badge to display the test status for the documentation page.
* Added the `page_tests` section specifying the path to the test file (`polkadot-docs/chain-interactions/send-transactions/tests/docs.test.ts`) for automated testing of the documentation examples.

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed

Holding this PR until https://github.com/polkadot-developers/polkadot-docs/pull/1609 is merged, but keeping the content here aligned with the new style