### PR TITLE
Add Solidity scale codec reference to documentation

### DIFF
--- a/reference/parachains/data-encoding.md
+++ b/reference/parachains/data-encoding.md
@@ -109,4 +109,5 @@ Several SCALE codec implementations are available in various languages. Here's a
 - **Python**: [`polkascan/py-scale-codec`](https://github.com/polkascan/py-scale-codec){target=\_blank}
 - **Ruby**: [` wuminzhe/scale_rb`](https://github.com/wuminzhe/scale_rb){target=\_blank}
 - **TypeScript**: [`parity-scale-codec-ts`](https://github.com/tjjfvi/subshape){target=\_blank}, [`scale-ts`](https://github.com/unstoppablejs/unstoppablejs/tree/main/packages/scale-ts#scale-ts){target=\_blank}, [`soramitsu/scale-codec-js-library`](https://github.com/soramitsu/scale-codec-js-library){target=\_blank}, [`subsquid/scale-codec`](https://github.com/subsquid/squid-sdk/tree/master/substrate/scale-codec){target=\_blank}
+- **Solidity**: [`LucasGrasso/solidity-scale-codec`](https://github.com/LucasGrasso/solidity-scale-codec){target=\_blank}
 


### PR DESCRIPTION
## 📝 Description

I’ve developed an implementation of the SCALE-codec in Solidity. Adding this to the implementations section provides an useful resource for EVM developers needing to parse Substrate-native data formats directly on-chain

## 🔍 Review Preference

Choose one:
- [X] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [X] Changes tested  
- [X] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
