### PR TITLE
docs: fix awesome-prometheus-alerts link

### DIFF
--- a/node-infrastructure/run-a-validator/operational-tasks/general-management.md
+++ b/node-infrastructure/run-a-validator/operational-tasks/general-management.md
@@ -486,7 +486,7 @@ Complete the integration by following these steps to enable communication betwee
     -8<-- 'code/node-infrastructure/run-a-validator/operational-tasks/general-management/instance-down.yml'
     ```
 
-    If any of the conditions defined in the rules file are met, an alert will be triggered. For more on alert rules, refer to [Alerting Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/){target=\_blank} and [additional alerts](https://samber.github.io/awesome-prometheus-alerts/rules.html){target=\_blank}.
+    If any of the conditions defined in the rules file are met, an alert will be triggered. For more on alert rules, refer to [Alerting Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/){target=\_blank} and [additional alerts](https://samber.github.io/awesome-prometheus-alerts/rules/){target=\_blank}.
 
 3. Update the file ownership to `prometheus`:
 


### PR DESCRIPTION
## Summary
- Update the `awesome-prometheus-alerts` reference in the validator general-management guide from `/rules.html` (404) to `/rules/`.

## Test plan
- [ ] Link checker passes on this PR