### PR TITLE
Update dependencies in variables.yml

### DIFF
--- a/parachains/runtime-maintenance/storage-migrations.md
+++ b/parachains/runtime-maintenance/storage-migrations.md
@@ -122,9 +122,9 @@ Examine the following migration example that transforms a simple `StorageValue` 
 - New `StorageValue` format:
 
     ```rust
-    --8<-- 'https://raw.githubusercontent.com/paritytech/polkadot-sdk/refs/tags/{{dependencies.repositories.polkadot_sdk.version}}/substrate/frame/examples/single-block-migrations/src/lib.rs:166:177'
+    --8<-- 'https://raw.githubusercontent.com/paritytech/polkadot-sdk/refs/tags/{{dependencies.repositories.polkadot_sdk.version}}/substrate/frame/examples/single-block-migrations/src/lib.rs:172:178'
 
-    --8<-- 'https://raw.githubusercontent.com/paritytech/polkadot-sdk/refs/tags/{{dependencies.repositories.polkadot_sdk.version}}/substrate/frame/examples/single-block-migrations/src/lib.rs:200:201'
+    --8<-- 'https://raw.githubusercontent.com/paritytech/polkadot-sdk/refs/tags/{{dependencies.repositories.polkadot_sdk.version}}/substrate/frame/examples/single-block-migrations/src/lib.rs:201:202'
     ```
 
 - Migration:

--- a/variables.yml
+++ b/variables.yml
@@ -15,8 +15,8 @@ dependencies:
       docker_image_version: 1.93.0
     polkadot_sdk:
       repository_url: https://github.com/paritytech/polkadot-sdk
-      version: polkadot-stable2512-3
-      docker_image_version: stable2512-3
+      version: polkadot-stable2603
+      docker_image_version: stable2603
     open_zeppelin_contracts:
       repository_url: https://github.com/OpenZeppelin/openzeppelin-contracts
       version: v5.6.1
@@ -58,7 +58,7 @@ dependencies:
   javascript_packages:
     chopsticks:
       name: '@acala-network/chopsticks'
-      version: 1.2.8
+      version: 1.3.0
     moonwall:
       name: '@moonwall/cli'
       version: 5.18.3
@@ -70,7 +70,7 @@ dependencies:
       version: 1.23.3
     resolc:
       name: '@parity/resolc'
-      version: 1.0.0
+      version: 1.1.0
     hardhat_polkadot:
       name: '@parity/hardhat-polkadot'
       version: 0.2.7
@@ -91,17 +91,17 @@ dependencies:
       version: 12.8.8
     hdkd:
       name: '@polkadot-labs/hdkd'
-      version: 0.0.27
+      version: 0.0.28
     hdkd_helpers:
       name: '@polkadot-labs/hdkd-helpers'
-      version: 0.0.28
+      version: 0.0.29
     polkadot_util:
       name: '@polkadot/util'
-      version: 14.0.2
+      version: 14.0.3
     polkadot_util_crypto:
       name: '@polkadot/util-crypto'
-      version: 14.0.2
+      version: 14.0.3
     polkadot_keyring:
       name: '@polkadot/keyring'
-      version: 14.0.2
+      version: 14.0.3
 #   python_packages:


### PR DESCRIPTION
## Summary

Updates 8 dependencies to their latest versions:

**Repositories:**
- `polkadot_sdk`: polkadot-stable2512-3 → polkadot-stable2603 (Docker: stable2512-3 → stable2603)

**JavaScript packages:**
- `chopsticks`: 1.2.8 → 1.3.0
- `resolc`: 1.0.0 → 1.1.0
- `hdkd`: 0.0.27 → 0.0.28
- `hdkd_helpers`: 0.0.28 → 0.0.29
- `polkadot_util`: 14.0.2 → 14.0.3
- `polkadot_util_crypto`: 14.0.2 → 14.0.3
- `polkadot_keyring`: 14.0.2 → 14.0.3

**polkadot_sdk line-number fix:** The `single-block-migrations/src/lib.rs` file shifted between stable2512-3 and stable2603 (removed `extern crate alloc`, inlined derives onto one line, added `#[docify::export]` attribute before `#[pallet::storage]`). Updated `storage-migrations.md` snippet ranges:
- `:166:177` → `:172:178` (struct + derives + body)
- `:200:201` → `:201:202` (`#[pallet::storage]` + `pub type Value`)

The third snippet (`migrations/v1.rs:24:122`) was verified unchanged between tags.

**Deferred (tracked separately — require full tutorial rewrites):**
- `polkadot_api`: 1.23.3 → 2.0.0 (#1625) — v2 removes `polkadot-sdk-compat` and the `Binary` class; all 16 papi snippets use both. Needs dedicated PR per the [v2 migration guide](https://papi.how/v2migration).
- `paraspell_sdk`: 12.8.8 → 13.1.0 (#1612) — breaking renames (`node`→`chain`, `senderAddress`→`sender`, etc.), ESM-only, removed `getOriginFeeDetails`. Affects 2 snippet files.

Closes #1610, closes #1611, closes #1613, closes #1614, closes #1615, closes #1630, closes #1631, closes #1632

## Test plan
- [x] All target package versions verified to exist on npm
- [x] All GitHub blob URLs at polkadot-stable2603 verified (HTTP 200 + line content matches intent)
- [x] `bn128.rs#L31/#L59/#L87` in `eth-native.md` re-verified at stable2603
- [x] `variables.yml` YAML parses cleanly
- [x] CI docs build passes
- [x] CI link checker passes