### PR TITLE
docs: add CI badge for transfer-assets-parachains guide

### DIFF
--- a/chain-interactions/send-transactions/interoperability/transfer-assets-parachains.md
+++ b/chain-interactions/send-transactions/interoperability/transfer-assets-parachains.md
@@ -2,6 +2,10 @@
 title: Transfer Assets Between Parachains
 description: A step-by-step guide to using the ParaSpell XCM SDK to build, verify, and execute a transfer from one Parachain to another.
 categories: Interoperability, Parachains
+page_badges:
+  test_workflow: polkadot-docs-transfer-assets-parachains
+page_tests:
+  path: polkadot-docs/chain-interactions/transfer-assets-parachains/tests/docs.test.ts
 ---
 
 # Transfer Assets Between Parachains


### PR DESCRIPTION
Adds the test-workflow frontmatter (badge + tests link) pointing at the new cookbook harness.

Companion to polkadot-developers/polkadot-cookbook#258