### PR TITLE
Migrate tutorials to polkadot-api v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target
 Cargo.lock
 .DS_Store
 scripts/__pycache__/*
+.scratch/
 
 .github/instructions/kluster-code-verify.instructions.md
 .kluster

--- a/.snippets/code/chain-interactions/accounts/query-account/papi/query-account.ts
+++ b/.snippets/code/chain-interactions/accounts/query-account/papi/query-account.ts
@@ -1,6 +1,5 @@
 import { createClient } from 'polkadot-api';
-import { getWsProvider } from 'polkadot-api/ws-provider';
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat';
+import { getWsProvider } from 'polkadot-api/ws';
 import { polkadotTestNet } from '@polkadot-api/descriptors';
 
 const POLKADOT_HUB_RPC = 'INSERT_WS_ENDPOINT';
@@ -10,9 +9,7 @@ const PAS_UNITS = 10_000_000_000;
 async function main() {
   try {
     // Create the client connection
-    const client = createClient(
-      withPolkadotSdkCompat(getWsProvider(POLKADOT_HUB_RPC))
-    );
+    const client = createClient(getWsProvider(POLKADOT_HUB_RPC));
 
     // Get the typed API
     const api = client.getTypedApi(polkadotTestNet);

--- a/.snippets/code/chain-interactions/query-data/query-sdks/papi/query-asset.ts
+++ b/.snippets/code/chain-interactions/query-data/query-sdks/papi/query-asset.ts
@@ -1,6 +1,5 @@
-import { createClient } from 'polkadot-api';
-import { getWsProvider } from 'polkadot-api/ws-provider/node';
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat';
+import { Binary, createClient } from 'polkadot-api';
+import { getWsProvider } from 'polkadot-api/ws';
 import { pah } from '@polkadot-api/descriptors';
 
 const ASSET_HUB_RPC = 'INSERT_WS_ENDPOINT';
@@ -13,9 +12,7 @@ const ADDRESS = 'INSERT_ADDRESS';
 
 async function main() {
   // Create the client connection
-  const client = createClient(
-    withPolkadotSdkCompat(getWsProvider(ASSET_HUB_RPC))
-  );
+  const client = createClient(getWsProvider(ASSET_HUB_RPC));
 
   // Get the typed API for Polkadot Hub
   const api = client.getTypedApi(pah);
@@ -28,8 +25,8 @@ async function main() {
 
   if (assetMetadata) {
     console.log('Asset Metadata:');
-    console.log(`  Name: ${assetMetadata.name.asText()}`);
-    console.log(`  Symbol: ${assetMetadata.symbol.asText()}`);
+    console.log(`  Name: ${Binary.toText(assetMetadata.name)}`);
+    console.log(`  Symbol: ${Binary.toText(assetMetadata.symbol)}`);
     console.log(`  Decimals: ${assetMetadata.decimals}`);
   }
 

--- a/.snippets/code/chain-interactions/query-data/query-sdks/papi/query-balance.ts
+++ b/.snippets/code/chain-interactions/query-data/query-sdks/papi/query-balance.ts
@@ -1,6 +1,5 @@
 import { createClient } from 'polkadot-api';
-import { getWsProvider } from 'polkadot-api/ws-provider/node';
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat';
+import { getWsProvider } from 'polkadot-api/ws';
 import { pah } from '@polkadot-api/descriptors';
 
 const ASSET_HUB_RPC = 'INSERT_WS_ENDPOINT';
@@ -10,9 +9,7 @@ const ADDRESS = 'INSERT_ADDRESS';
 
 async function main() {
   // Create the client connection
-  const client = createClient(
-    withPolkadotSdkCompat(getWsProvider(ASSET_HUB_RPC))
-  );
+  const client = createClient(getWsProvider(ASSET_HUB_RPC));
 
   // Get the typed API for Polkadot Hub
   const api = client.getTypedApi(pah);

--- a/.snippets/code/chain-interactions/query-data/runtime-api-calls/papi/runtime-apis.ts
+++ b/.snippets/code/chain-interactions/query-data/runtime-api-calls/papi/runtime-apis.ts
@@ -1,6 +1,5 @@
 import { createClient } from 'polkadot-api';
-import { getWsProvider } from 'polkadot-api/ws-provider/node';
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat';
+import { getWsProvider } from 'polkadot-api/ws';
 import { polkadotTestNet } from '@polkadot-api/descriptors';
 
 const POLKADOT_TESTNET_RPC = 'INSERT_WS_ENDPOINT';
@@ -10,9 +9,7 @@ const ADDRESS = 'INSERT_ADDRESS';
 
 async function main() {
   // Create the client connection
-  const client = createClient(
-    withPolkadotSdkCompat(getWsProvider(POLKADOT_TESTNET_RPC))
-  );
+  const client = createClient(getWsProvider(POLKADOT_TESTNET_RPC));
 
   // Get the typed API for Polkadot Hub TestNet
   const api = client.getTypedApi(polkadotTestNet);

--- a/.snippets/code/chain-interactions/send-transactions/calculate-transaction-fees/papi-fee-calculator.ts
+++ b/.snippets/code/chain-interactions/send-transactions/calculate-transaction-fees/papi-fee-calculator.ts
@@ -1,13 +1,10 @@
 import { createClient } from 'polkadot-api';
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat';
 import { polkadotTestNet } from '@polkadot-api/descriptors';
-import { getWsProvider } from 'polkadot-api/ws-provider';
+import { getWsProvider } from 'polkadot-api/ws';
 
 async function calculateFees() {
   // Connect to chain
-  const client = createClient(
-    withPolkadotSdkCompat(getWsProvider('INSERT_WS_ENDPOINT'))
-  );
+  const client = createClient(getWsProvider('INSERT_WS_ENDPOINT'));
 
   // Get typed API
   const api = client.getTypedApi(polkadotTestNet);

--- a/.snippets/code/chain-interactions/send-transactions/interoperability/debug-and-preview-xcms/dry-run-call.ts
+++ b/.snippets/code/chain-interactions/send-transactions/interoperability/debug-and-preview-xcms/dry-run-call.ts
@@ -1,6 +1,5 @@
 import { Binary, createClient, Enum } from 'polkadot-api';
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat';
-import { getWsProvider } from 'polkadot-api/ws-provider/web';
+import { getWsProvider } from 'polkadot-api/ws';
 import { polkadotHub } from '@polkadot-api/descriptors';
 import { sr25519CreateDerive } from '@polkadot-labs/hdkd';
 import {
@@ -13,8 +12,7 @@ import {
 const XCM_VERSION = 5;
 
 async function main() {
-  const provider = withPolkadotSdkCompat(getWsProvider('ws://localhost:8000'));
-  const client = createClient(provider);
+  const client = createClient(getWsProvider('ws://localhost:8000'));
   const api = client.getTypedApi(polkadotHub);
 
   const entropy = mnemonicToEntropy(DEV_PHRASE);

--- a/.snippets/code/chain-interactions/send-transactions/interoperability/debug-and-preview-xcms/replay-xcm.ts
+++ b/.snippets/code/chain-interactions/send-transactions/interoperability/debug-and-preview-xcms/replay-xcm.ts
@@ -1,7 +1,6 @@
 import { Binary, createClient, Transaction } from 'polkadot-api';
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat';
 import { getPolkadotSigner } from 'polkadot-api/signer';
-import { getWsProvider } from 'polkadot-api/ws-provider/web';
+import { getWsProvider } from 'polkadot-api/ws';
 import { polkadotHub } from '@polkadot-api/descriptors';
 import { sr25519CreateDerive } from '@polkadot-labs/hdkd';
 import {
@@ -15,8 +14,9 @@ const toHuman = (_key: any, value: any) => {
     return Number(value);
   }
 
-  if (value && typeof value === 'object' && typeof value.asHex === 'function') {
-    return value.asHex();
+  // In v2, raw binary values are Uint8Arrays rather than Binary instances.
+  if (value instanceof Uint8Array) {
+    return Binary.toHex(value);
   }
 
   return value;
@@ -32,16 +32,15 @@ function getSigner() {
 }
 
 async function main() {
-  const provider = withPolkadotSdkCompat(getWsProvider('ws://localhost:8000'));
-  const client = createClient(provider);
+  const client = createClient(getWsProvider('ws://localhost:8000'));
   const api = client.getTypedApi(polkadotHub);
   const aliceSigner = getSigner();
 
   const callData = Binary.fromHex(
     '0x1f0803010100411f0300010100fc39fcf04a8071b7409823b7c82427ce67910c6ed80aa0e5093aff234624c8200304000002043205011f0092e81d790000000000',
   );
-  const tx: Transaction<any, string, string, any> =
-    await api.txFromCallData(callData);
+  // In v2, Transaction has two generic parameters: <Asset, Ext>.
+  const tx: Transaction<string, any> = await api.txFromCallData(callData);
   console.log('👀 Executing XCM:', JSON.stringify(tx.decodedCall, toHuman, 2));
 
   await new Promise<void>((resolve) => {

--- a/.snippets/code/chain-interactions/send-transactions/interoperability/estimate-xcm-fees/teleport-polkadot-hub-to-people-chain.ts
+++ b/.snippets/code/chain-interactions/send-transactions/interoperability/estimate-xcm-fees/teleport-polkadot-hub-to-people-chain.ts
@@ -1,7 +1,6 @@
 import { polkadotHub, paseoPeopleChain } from '@polkadot-api/descriptors';
-import { createClient, FixedSizeBinary, Enum } from 'polkadot-api';
-import { getWsProvider } from 'polkadot-api/ws-provider/node';
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat';
+import { AccountId, Binary, createClient, Enum } from 'polkadot-api';
+import { getWsProvider } from 'polkadot-api/ws';
 import {
   XcmVersionedLocation,
   XcmVersionedAssetId,
@@ -28,6 +27,12 @@ const PEOPLE_CHAIN_RPC_ENDPOINT = 'ws://localhost:8000';
 const PEOPLE_CHAIN_PARA_ID = 1004;
 const PEOPLE_CHAIN_BENEFICIARY =
   '14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3'; // Bob (People Chain)
+
+// In polkadot-api v2, FixedSizeBinary is replaced by hex strings typed as
+// SizedHex<32>. Use the AccountId codec to convert an SS58 address into its
+// 32-byte hex representation.
+const accountIdCodec = AccountId();
+const ss58ToHex = (addr: string) => Binary.toHex(accountIdCodec.enc(addr));
 
 // Create the XCM message for teleport (Polkadot Hub → People Chain)
 function createTeleportXcmToPeopleChain(paraId: number) {
@@ -70,7 +75,7 @@ function createTeleportXcmToPeopleChain(paraId: number) {
             interior: XcmV5Junctions.X1(
               XcmV5Junction.AccountId32({
                 network: undefined,
-                id: FixedSizeBinary.fromAccountId32(PEOPLE_CHAIN_BENEFICIARY),
+                id: ss58ToHex(PEOPLE_CHAIN_BENEFICIARY),
               }),
             ),
           },
@@ -138,7 +143,7 @@ async function estimateXcmFeesFromPolkadotHubToPeopleChain(
     parents: 0,
     interior: XcmV5Junctions.X1(
       XcmV5Junction.AccountId32({
-        id: FixedSizeBinary.fromAccountId32(POLKADOT_HUB_ACCOUNT),
+        id: ss58ToHex(POLKADOT_HUB_ACCOUNT),
         network: undefined,
       }),
     ),
@@ -196,7 +201,7 @@ async function estimateXcmFeesFromPolkadotHubToPeopleChain(
       console.log('\n3. Calculating remote execution fees on People Chain');
       try {
         const peopleChainClient = createClient(
-          withPolkadotSdkCompat(getWsProvider(PEOPLE_CHAIN_RPC_ENDPOINT)),
+          getWsProvider(PEOPLE_CHAIN_RPC_ENDPOINT),
         );
         const peopleChainApi = peopleChainClient.getTypedApi(paseoPeopleChain);
         const remoteWeightResult =
@@ -265,7 +270,7 @@ async function estimateXcmFeesFromPolkadotHubToPeopleChain(
 async function main() {
   // Connect to the Polkadot Hub parachain
   const polkadotHubClient = createClient(
-    withPolkadotSdkCompat(getWsProvider(POLKADOT_HUB_RPC_ENDPOINT)),
+    getWsProvider(POLKADOT_HUB_RPC_ENDPOINT),
   );
 
   // Get the typed API for Polkadot Hub
@@ -295,7 +300,7 @@ async function main() {
     });
 
     console.log('\n=== Transaction Details ===');
-    console.log('Transaction hex:', (await tx.getEncodedData()).asHex());
+    console.log('Transaction hex:', Binary.toHex(await tx.getEncodedData()));
     console.log('Ready to submit!');
   } catch (error) {
     console.log('Error stack:', (error as Error).stack);
@@ -310,4 +315,3 @@ async function main() {
 }
 
 main().catch(console.error);
-

--- a/.snippets/code/chain-interactions/send-transactions/pay-fees-with-different-tokens/papi/fee-payment-transaction.ts
+++ b/.snippets/code/chain-interactions/send-transactions/pay-fees-with-different-tokens/papi/fee-payment-transaction.ts
@@ -7,8 +7,7 @@ import {
 import { getPolkadotSigner } from "polkadot-api/signer";
 import { createClient } from "polkadot-api";
 import { assetHub } from "@polkadot-api/descriptors";
-import { withPolkadotSdkCompat } from "polkadot-api/polkadot-sdk-compat";
-import { getWsProvider } from "polkadot-api/ws-provider/node";
+import { getWsProvider } from "polkadot-api/ws";
 import { MultiAddress } from "@polkadot-api/descriptors";
 
 const TARGET_ADDRESS = "14E5nqKAp3oAJcmzgZhUD2RcptBeUBScxKHgJKU4HPNcKVf3"; // Bob's address
@@ -29,9 +28,7 @@ const createSigner = async () => {
 };
 
 const client = createClient(
-  withPolkadotSdkCompat(
-    getWsProvider("ws://localhost:8000") // Chopsticks Polkadot Hub
-  )
+  getWsProvider("ws://localhost:8000") // Chopsticks Polkadot Hub
 );
 
 const api = client.getTypedApi(assetHub);

--- a/.snippets/code/chain-interactions/send-transactions/with-sdks/papi/send-transfer.ts
+++ b/.snippets/code/chain-interactions/send-transactions/with-sdks/papi/send-transfer.ts
@@ -1,6 +1,5 @@
 import { createClient } from 'polkadot-api';
-import { getWsProvider } from 'polkadot-api/ws-provider';
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat';
+import { getWsProvider } from 'polkadot-api/ws';
 import { polkadotTestNet } from '@polkadot-api/descriptors';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { Keyring } from '@polkadot/keyring';
@@ -21,9 +20,7 @@ async function main() {
     console.log(`Sender address: ${sender.address}`);
 
     // Create the client connection
-    const client = createClient(
-      withPolkadotSdkCompat(getWsProvider(POLKADOT_TESTNET_RPC))
-    );
+    const client = createClient(getWsProvider(POLKADOT_TESTNET_RPC));
 
     // Get the typed API
     const api = client.getTypedApi(polkadotTestNet);

--- a/.snippets/code/chain-interactions/store-data/bulletin-chain/store-data.ts
+++ b/.snippets/code/chain-interactions/store-data/bulletin-chain/store-data.ts
@@ -1,6 +1,5 @@
-import { Binary, createClient } from 'polkadot-api';
-import { getWsProvider } from 'polkadot-api/ws-provider/node';
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat';
+import { createClient } from 'polkadot-api';
+import { getWsProvider } from 'polkadot-api/ws';
 import { bulletin } from '@polkadot-api/descriptors';
 import { sr25519CreateDerive } from '@polkadot-labs/hdkd';
 import {
@@ -20,9 +19,7 @@ const FILE_PATH = 'INSERT_IMAGE_PATH';
 
 async function main() {
   // Create the client connection
-  const client = createClient(
-    withPolkadotSdkCompat(getWsProvider(BULLETIN_RPC))
-  );
+  const client = createClient(getWsProvider(BULLETIN_RPC));
 
   // Get the typed API for the Bulletin Chain
   const api = client.getTypedApi(bulletin);
@@ -47,7 +44,7 @@ async function main() {
   // Note: the signing account must have an active authorization (see Get Authorization section)
   console.log('Submitting store transaction...');
   const result = await api.tx.TransactionStorage.store({
-    data: Binary.fromBytes(new Uint8Array(fileData)),
+    data: new Uint8Array(fileData),
   }).signAndSubmit(signer);
 
   console.log(`Transaction included in block: ${result.block.hash}`);
@@ -57,8 +54,7 @@ async function main() {
   for (const event of result.events) {
     if (event.type === 'TransactionStorage' && event.value.type === 'Stored') {
       // Decode the raw CID bytes into a standard IPFS CID string
-      const cidBytes = event.value.value.cid.asBytes();
-      const cid = CID.decode(cidBytes);
+      const cid = CID.decode(event.value.value.cid);
 
       console.log('\nImage stored successfully!');
       console.log(`Index: ${event.value.value.index}`);

--- a/.snippets/code/reference/tools/papi/api-instantiation-smoldot-nodejs.ts
+++ b/.snippets/code/reference/tools/papi/api-instantiation-smoldot-nodejs.ts
@@ -14,10 +14,11 @@ const workerPath = fileURLToPath(
 
 const worker = new Worker(workerPath);
 const smoldot = startFromWorker(worker);
-const chain = await smoldot.addChain({ chainSpec });
 
 // Set up a client to connect to the Polkadot relay chain
-const client = createClient(getSmProvider(chain));
+const client = createClient(
+  getSmProvider(() => smoldot.addChain({ chainSpec })),
+);
 
 // To interact with the chain's API, use `TypedApi` for access to
 // all the necessary types and calls associated with this chain

--- a/.snippets/code/reference/tools/papi/api-instantiation-smoldot-webworker.ts
+++ b/.snippets/code/reference/tools/papi/api-instantiation-smoldot-webworker.ts
@@ -8,10 +8,11 @@ import SmWorker from 'polkadot-api/smoldot/worker?worker';
 
 const worker = new SmWorker();
 const smoldot = startFromWorker(worker);
-const chain = await smoldot.addChain({ chainSpec });
 
 // Establish connection to the Polkadot relay chain
-const client = createClient(getSmProvider(chain));
+const client = createClient(
+  getSmProvider(() => smoldot.addChain({ chainSpec })),
+);
 
 // To interact with the chain, obtain the `TypedApi`, which provides
 // the necessary types for every API call on this chain

--- a/.snippets/code/reference/tools/papi/api-instantiation-smoldot.ts
+++ b/.snippets/code/reference/tools/papi/api-instantiation-smoldot.ts
@@ -7,10 +7,11 @@ import { start } from 'polkadot-api/smoldot';
 
 // Initialize Smoldot client
 const smoldot = start();
-const chain = await smoldot.addChain({ chainSpec });
 
 // Set up a client to connect to the Polkadot relay chain
-const client = createClient(getSmProvider(chain));
+const client = createClient(
+  getSmProvider(() => smoldot.addChain({ chainSpec })),
+);
 
 // Access the `TypedApi` to interact with all available chain calls and types
 const dotApi = client.getTypedApi(dot);

--- a/.snippets/code/reference/tools/papi/api-instantiation-wss.ts
+++ b/.snippets/code/reference/tools/papi/api-instantiation-wss.ts
@@ -2,15 +2,10 @@
 import { dot } from '@polkadot-api/descriptors';
 import { createClient } from 'polkadot-api';
 // Use this import for Node.js environments
-import { getWsProvider } from 'polkadot-api/ws-provider/web';
-import { withPolkadotSdkCompat } from 'polkadot-api/polkadot-sdk-compat';
+import { getWsProvider } from 'polkadot-api/ws';
 
 // Establish a connection to the Polkadot relay chain
-const client = createClient(
-  // The Polkadot SDK nodes may have compatibility issues; using this enhancer is recommended.
-  // Refer to the Requirements page for additional details
-  withPolkadotSdkCompat(getWsProvider('wss://dot-rpc.stakeworld.io')),
-);
+const client = createClient(getWsProvider('wss://dot-rpc.stakeworld.io'));
 
 // To interact with the chain, obtain the `TypedApi`, which provides
 // the types for all available calls in that chain

--- a/variables.yml
+++ b/variables.yml
@@ -67,7 +67,7 @@ dependencies:
       version: 16.5.6
     polkadot_api:
       name: polkadot-api
-      version: 1.23.3
+      version: 2.0.1
     resolc:
       name: '@parity/resolc'
       version: 1.0.0


### PR DESCRIPTION
## Summary

Migrates all docs snippets using `polkadot-api` from v1 to v2 in a single consolidated PR, and bumps `polkadot_api` in `variables.yml` to `2.0.1`.

**Closes #1625. Tracks #1636.**

## What changed (11 tutorials, 10 snippet files)

| Tutorial | Snippets | Key v2 changes |
|---|---|---|
| `reference/tools/papi.md` | `api-instantiation-{wss,smoldot,smoldot-webworker,smoldot-nodejs}.ts` | drop `withPolkadotSdkCompat`; `ws-provider/{node,web}` → `ws`; `getSmProvider(chain)` → `getSmProvider(() => ...)` |
| `chain-interactions/query-data/query-sdks.md` | `query-balance.ts`, `query-asset.ts` | imports + `instance.asText()` → `Binary.toText(x)` |
| `chain-interactions/accounts/query-accounts.md` | `query-account.ts` | imports only |
| `chain-interactions/query-data/runtime-api-calls.md` | `runtime-apis.ts` | imports only |
| `chain-interactions/send-transactions/with-sdks.md` | `send-transfer.ts` | imports only |
| `chain-interactions/send-transactions/calculate-transaction-fees.md` | `papi-fee-calculator.ts` | imports only |
| `chain-interactions/send-transactions/pay-fees-with-different-tokens.md` | `fee-payment-transaction.ts` | imports only |
| `chain-interactions/store-data/bulletin-chain.md` | `store-data.ts` | `Binary.fromBytes(x)` → `x` (Uint8Array direct); `event.value.cid.asBytes()` → `event.value.cid` (now Uint8Array) |
| `chain-interactions/send-transactions/interoperability/estimate-xcm-fees.md` | `teleport-polkadot-hub-to-people-chain.ts` | `FixedSizeBinary.fromAccountId32(addr)` → `Binary.toHex(AccountId().enc(addr))`; `(await tx.getEncodedData()).asHex()` → `Binary.toHex(...)` |
| `chain-interactions/send-transactions/interoperability/debug-and-preview-xcms.md` | `dry-run-call.ts`, `replay-xcm.ts` | imports; `Transaction<Pallet,Name,Asset,Ext>` → `Transaction<Asset,Ext>`; `toHuman` checks `instanceof Uint8Array` instead of `.asHex` function |

`transfer-assets-parachains/index.ts` is paraspell-only (only imports `getPolkadotSigner` from `polkadot-api/signer`, which is unchanged in v2) — no changes needed here. It will be updated in the separate paraspell v13 migration (#1637).

## v2 migration patterns applied

Per https://papi.how/v2migration:

1. **`polkadot-api/polkadot-sdk-compat` removed** — `withPolkadotSdkCompat` dropped everywhere; `getWsProvider` from `polkadot-api/ws` auto-detects and applies middleware.
2. **`polkadot-api/ws-provider[/node|/web]` → `polkadot-api/ws`.**
3. **`getSmProvider` now takes a factory** — `getSmProvider(() => smoldot.addChain({ chainSpec }))`.
4. **`Binary` class reworked** — `Binary.fromBytes(x)` removed (use `Uint8Array` directly); `instance.asMethod()` → `Binary.toMethod(instance)` (e.g. `asHex()` → `Binary.toHex(x)`, `asText()` → `Binary.toText(x)`).
5. **`FixedSizeBinary` → `SizedHex<N>` hex strings.** For AccountId32: `Binary.toHex(AccountId().enc(ss58Address))`.
6. **`Transaction<Pallet,Name,Asset,Ext>` → `Transaction<Asset,Ext>`** (2 generic params).
7. **Codegen**: `Vec<u8>` fields now emit `Uint8Array` (not `Binary`) on both input and output.

## Verification

All 10 snippet files type-check against `polkadot-api@2.0.0` in a scratch workspace with generated descriptors for `dot`, `pah`, `assetHub`, `polkadotHub`, `polkadotTestNet`, `paseoPeopleChain`, and `bulletin` (via `npx papi add`).

### Runtime-verified

| Snippet | Environment | Result |
|---|---|---|
| `api-instantiation-wss.ts` | live `wss://dot-rpc.stakeworld.io` | Connected; fetched Polkadot block number |
| `query-balance.ts` | Chopsticks fork of Polkadot Asset Hub | Treasury account (`13UVJy...TB`) query returned nonce + free balance |
| `query-asset.ts` | Chopsticks fork of Polkadot Asset Hub | USDT (id 1984) metadata: `Tether USD` / `USDt` / 6dp — `Binary.toText` works |
| `query-account.ts` | (same pattern as query-balance) | Migration identical; covered by query-balance verification |
| `runtime-apis.ts` | live `wss://paseo.rpc.amforc.com` | `Metadata.metadata_versions()` → `[14, 15, 16]` |
| `papi-fee-calculator.ts` | live Paseo | `getEstimatedFees()` → 160953032 plancks for Alice→Bob |
| `send-transfer.ts` | live Paseo | Fee estimate 158953032 plancks; signing produced 145-byte signed extrinsic |
| `fee-payment-transaction.ts` | Chopsticks fork of Paseo Asset Hub | Fee estimation with USDT-as-fee-asset returned 9564336 USDT units |
| `dry-run-call.ts` | Chopsticks fork of Paseo Asset Hub | `DryRunApi.dry_run_call` returned `success=true` |
| `replay-xcm.ts` | Chopsticks fork of Paseo Asset Hub | Built + signed + submitted via `signSubmitAndWatch`; after minting a block, event with dispatch_info returned cleanly |
| `teleport-polkadot-hub-to-people-chain.ts` | Chopsticks forks of Paseo AH (8001) + Paseo People (8000) | XCM V5 message built, `AccountId().enc()` hex conversion worked, local dry-run succeeded, forwarded XCM detected. The subsequent `query_delivery_fees` RuntimeApi is incompatible with current Paseo AH runtime — an unrelated runtime-compat issue, not a migration bug |

### Typecheck-only (runtime verification intentionally deferred)

- **Smoldot instantiation snippets** (3): full smoldot sync from genesis isn't practical for docs verification and produces no functional difference from the runtime the user would see. The v2 factory-signature migration (`getSmProvider(() => ...)`) is mechanical per the guide.
- **`store-data.ts` on Bulletin Chain**: requires an authorized signer on Paseo Bulletin Chain, which docs verification cannot reasonably set up.

## Test plan
- [ ] CI docs build passes
- [ ] CI link checker passes
- [ ] Follow-up (if desired): dedicated end-to-end pass for Bulletin with a real authorization, once available