### PR TITLE
Migrate tutorials to @paraspell/sdk v13

### DIFF
--- a/.snippets/code/chain-interactions/send-transactions/interoperability/transfer-assets-into-polkadot/index.ts
+++ b/.snippets/code/chain-interactions/send-transactions/interoperability/transfer-assets-into-polkadot/index.ts
@@ -10,8 +10,8 @@ const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 // WETH has 18 decimals
 const WETH_UNITS = 1_000_000_000_000_000_000n;
 
-// Amount to bridge: 0.001 WETH
-const AMOUNT = (WETH_UNITS / 1000n).toString();
+// Amount to bridge: 0.001 WETH (raw units as bigint)
+const AMOUNT = WETH_UNITS / 1000n;
 
 // Your Polkadot address to receive the bridged tokens (SS58 format)
 const RECIPIENT_ADDRESS = 'INSERT_YOUR_POLKADOT_ADDRESS';
@@ -42,7 +42,7 @@ async function approveTokens() {
   }
 
   // Approve the Snowbridge Gateway contract to spend WETH
-  const { result: approveTx } = await approveToken(signer, BigInt(AMOUNT), 'WETH');
+  const { result: approveTx } = await approveToken(signer, AMOUNT, 'WETH');
   console.log(`Approval transaction hash: ${approveTx.hash}`);
 
   // Wait for confirmation

--- a/.snippets/code/chain-interactions/send-transactions/interoperability/transfer-assets-into-polkadot/index.ts
+++ b/.snippets/code/chain-interactions/send-transactions/interoperability/transfer-assets-into-polkadot/index.ts
@@ -61,23 +61,26 @@ async function bridgeToPolkadot() {
 
   // Build and execute the bridge transfer
   // Note: 'AssetHubPolkadot' is the SDK identifier for Polkadot Hub
-  const result = await EvmBuilder(provider)
+  const txHash = await EvmBuilder(provider)
+    .from('Ethereum')
     .to('AssetHubPolkadot')
     .currency({
       symbol: 'WETH',
       amount: AMOUNT,
     })
-    .address(RECIPIENT_ADDRESS)
+    .recipient(RECIPIENT_ADDRESS)
     .signer(signer)
     .build();
 
   console.log('Bridge transaction submitted!');
-  console.log(`Transaction hash: ${result.response.hash}`);
+  console.log(`Transaction hash: ${txHash}`);
   console.log('Transfer will arrive in approximately 30 minutes.');
 
   // Wait for Ethereum confirmation
-  await result.response.wait();
-  console.log('Ethereum transaction confirmed! Waiting for bridge relay...');
+  const receipt = await provider.waitForTransaction(txHash);
+  console.log(
+    `Ethereum transaction confirmed in block ${receipt?.blockNumber}. Waiting for bridge relay...`,
+  );
 }
 
 bridgeToPolkadot();

--- a/.snippets/code/chain-interactions/send-transactions/interoperability/transfer-assets-parachains/index.ts
+++ b/.snippets/code/chain-interactions/send-transactions/interoperability/transfer-assets-parachains/index.ts
@@ -36,7 +36,7 @@ async function transfer() {
       symbol: 'PAS',
       amount: 10n * PAS_UNITS, // 10 PAS
     })
-    .address(RECIPIENT_ADDRESS)
+    .recipient(RECIPIENT_ADDRESS)
     .build();
 
   console.log('Built transaction:', inspect(tx, { colors: true, depth: null }));
@@ -59,8 +59,8 @@ async function dryRunTransfer() {
       symbol: 'PAS',
       amount: 10n * PAS_UNITS,
     })
-    .address(RECIPIENT_ADDRESS)
-    .senderAddress(SENDER_ADDRESS)
+    .recipient(RECIPIENT_ADDRESS)
+    .sender(SENDER_ADDRESS)
     .dryRun();
 
   console.log(inspect(tx, { colors: true, depth: null }));
@@ -77,8 +77,8 @@ async function verifyED() {
       symbol: 'PAS',
       amount: 10n * PAS_UNITS,
     })
-    .address(RECIPIENT_ADDRESS)
-    .senderAddress(SENDER_ADDRESS)
+    .recipient(RECIPIENT_ADDRESS)
+    .sender(SENDER_ADDRESS)
     .verifyEdOnDestination();
 
   console.log(`ED verification ${isValid ? 'successful' : 'failed'}.`);
@@ -95,8 +95,8 @@ async function XcmTransferInfo() {
       symbol: 'PAS',
       amount: 10n * PAS_UNITS,
     })
-    .address(RECIPIENT_ADDRESS)
-    .senderAddress(SENDER_ADDRESS)
+    .recipient(RECIPIENT_ADDRESS)
+    .sender(SENDER_ADDRESS)
     .getTransferInfo();
 
   console.log('Transfer Info:', info);

--- a/.snippets/code/chain-interactions/send-transactions/interoperability/transfer-assets-parachains/index.ts
+++ b/.snippets/code/chain-interactions/send-transactions/interoperability/transfer-assets-parachains/index.ts
@@ -37,6 +37,7 @@ async function transfer() {
       amount: 10n * PAS_UNITS, // 10 PAS
     })
     .recipient(RECIPIENT_ADDRESS)
+    .sender(SENDER_ADDRESS)
     .build();
 
   console.log('Built transaction:', inspect(tx, { colors: true, depth: null }));

--- a/chain-interactions/send-transactions/interoperability/transfer-assets-into-polkadot.md
+++ b/chain-interactions/send-transactions/interoperability/transfer-assets-into-polkadot.md
@@ -190,9 +190,10 @@ const wethSupported = hydrationAssets.some(a => a.symbol === 'WETH');
 
 if (wethSupported) {
   await EvmBuilder(provider)
+    .from('Ethereum')
     .to('Hydration')
     .currency({ symbol: 'WETH', amount: amount })
-    .address(recipientAddress)
+    .recipient(recipientAddress)
     .signer(signer)
     .build();
 }

--- a/variables.yml
+++ b/variables.yml
@@ -88,7 +88,7 @@ dependencies:
       version: 6.16.0
     paraspell_sdk:
       name: '@paraspell/sdk'
-      version: 13.1.0
+      version: 13.2.2
     hdkd:
       name: '@polkadot-labs/hdkd'
       version: 0.0.27

--- a/variables.yml
+++ b/variables.yml
@@ -88,7 +88,7 @@ dependencies:
       version: 6.16.0
     paraspell_sdk:
       name: '@paraspell/sdk'
-      version: 12.8.8
+      version: 13.1.0
     hdkd:
       name: '@polkadot-labs/hdkd'
       version: 0.0.27


### PR DESCRIPTION
## Summary

Migrates the two ParaSpell XCM SDK tutorials to `@paraspell/sdk@13.x` / `@paraspell/sdk-pjs@13.x`, and bumps `paraspell_sdk` in `variables.yml` from 12.8.8 to 13.1.0.

**Closes #1612, closes #1637.**

## v13 breaking changes applied

Per the [v13 migration guide](https://paraspell.github.io/docs/migration/v12-to-v13.html) and the [v13.0.0 release notes](https://github.com/paraspell/xcm-tools/releases/tag/sdk-v13.0.0):

- `Builder.address(addr)` → `Builder.recipient(addr)`
- `Builder.senderAddress(addr)` → `Builder.sender(addr)`
- `EvmBuilder.address(addr)` → `EvmBuilder.recipient(addr)`

## Other tutorial corrections (not v13-specific)

The existing `transfer-assets-into-polkadot` snippet was already out of step with the ParaSpell API independent of v13, and is corrected here at the same time:

- Add `.from('Ethereum')` before `.to('AssetHubPolkadot')` on `EvmBuilder` (required in v12 as well — the tutorial was relying on removed implicit behavior).
- Replace `result.response.hash` / `result.response.wait()` with the transaction hash returned from `.build()` + `provider.waitForTransaction(txHash)` (`.build()` has returned the hash string in prior versions too).

Thanks to @michaeldev5 for flagging that these last two were not v13 changes.

## Files changed

**`.snippets/code/chain-interactions/send-transactions/interoperability/transfer-assets-parachains/index.ts`** (`@paraspell/sdk`)
- `.address(...)` → `.recipient(...)` in `transfer()`, `dryRunTransfer()`, `verifyED()`, `XcmTransferInfo()`
- `.senderAddress(...)` → `.sender(...)` in `dryRunTransfer()`, `verifyED()`, `XcmTransferInfo()`

**`.snippets/code/chain-interactions/send-transactions/interoperability/transfer-assets-into-polkadot/index.ts`** (`@paraspell/sdk-pjs`)
- `.address(...)` → `.recipient(...)` (v13 rename)
- Add `.from('Ethereum')` before `.to('AssetHubPolkadot')` (tutorial correction)
- Switch to `const txHash = await ...build()` + `provider.waitForTransaction(txHash)` (tutorial correction)

**`chain-interactions/send-transactions/interoperability/transfer-assets-into-polkadot.md`** — same updates applied to the inline alternate-destination example.

**`variables.yml`** — `paraspell_sdk: 12.8.8 → 13.1.0`

## Verification

- [x] `tsc --noEmit` passes against `@paraspell/sdk@13.1.0` + `@paraspell/sdk-pjs@13.1.0` + supporting deps (polkadot-api@2.0.1, @polkadot-labs/hdkd, ethers@6.16.0) in a scratch workspace.
- [x] Errors from the v13 types surface exactly the breaking-change surface area; no other renames or removals hit our snippets (no `getOriginFeeDetails`, `foreign`/`native` balance, `multi` prefix, or deprecated `assetHub`/`bridgeHub` usage in these files).

Runtime-verification deferred: each snippet requires real live-network prerequisites (funded Paseo account + live Paseo endpoints; Ethereum mainnet RPC + private key + WETH balance) — the same prerequisites that gate a user running the tutorial itself.

## Test plan
- [ ] CI docs build passes
- [ ] CI link checker passes