### PR TITLE
Add uniswap v3 core tutorial

### DIFF
--- a/.snippets/code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/compilation-output.html
+++ b/.snippets/code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/compilation-output.html
@@ -1,0 +1,6 @@
+<div id="termynal" data-termynal>
+  <span data-ty="input"><span class="file-path"></span>npx hardhat compile</span>
+  <span data-ty>Generating typings for: 50 artifacts in dir: typechain-types for target: ethers-v6</span>
+  <span data-ty>Successfully generated 78 typings!</span>
+  <span data-ty>Compiled 50 Solidity files successfully (evm target: istanbul).</span>
+</div>

--- a/.snippets/code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/deployment-output.html
+++ b/.snippets/code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/deployment-output.html
@@ -1,15 +1,18 @@
-<div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>npx hardhat run scripts/deploy.ts --network localNode</span>
-  <span data-ty>Compiled 50 Solidity files successfully (evm target: istanbul).</span>
-  <span data-ty>Deploying contracts with account: 0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac</span>
-  <span data-ty>UniswapV3Factory deployed to: 0x2e234DAe75C793f67A35089C9d99245E1C58470b</span>
-  <span data-ty>TokenA deployed to: 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE</span>
-  <span data-ty>TokenB deployed to: 0xc8C0C4f9f3A6f93Ba042E2a9323f8B8D8D6A7E13</span>
-  <span data-ty>UniswapV3Pool (0.3% fee) created at: 0x6D3aA6f2d3CF5e4B4e1e2E0d3C8F7B2a1D5E9C4b</span>
-  <span data-ty></span>
-  <span data-ty>Deployment summary:</span>
-  <span data-ty>  Factory:    0x2e234DAe75C793f67A35089C9d99245E1C58470b</span>
-  <span data-ty>  Token0:     0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE</span>
-  <span data-ty>  Token1:     0xc8C0C4f9f3A6f93Ba042E2a9323f8B8D8D6A7E13</span>
-  <span data-ty>  Pool (0.3%): 0x6D3aA6f2d3CF5e4B4e1e2E0d3C8F7B2a1D5E9C4b</span>
+<div id="termynal" data-termynal markdown>
+  <span data-ty="input">npx hardhat ignition deploy ./ignition/modules/UniswapV3Factory.ts --network polkadotTestnet</span>
+  <span data-ty>✔ Confirm deploy to network polkadotTestnet (420420417)? … yes</span>
+  <span data-ty>&nbsp;</span>
+  <span data-ty>Hardhat Ignition 🚀</span>
+  <span data-ty>&nbsp;</span>
+  <span data-ty>Deploying [ UniswapV3FactoryModule ]</span>
+  <span data-ty>&nbsp;</span>
+  <span data-ty>Batch #1</span>
+  <span data-ty> Executed UniswapV3FactoryModule#UniswapV3Factory</span>
+  <span data-ty>&nbsp;</span>
+  <span data-ty>[ UniswapV3FactoryModule ] successfully deployed 🚀</span>
+  <span data-ty>&nbsp;</span>
+  <span data-ty>Deployed Addresses</span>
+  <span data-ty>&nbsp;</span>
+  <span data-ty>UniswapV3FactoryModule#UniswapV3Factory - 0x2e234DAe75C793f67A35089C9d99245E1C58470b</span>
+  <span data-ty="input"><span class="file-path"></span></span>
 </div>

--- a/.snippets/code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/deployment-output.html
+++ b/.snippets/code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/deployment-output.html
@@ -1,0 +1,15 @@
+<div id="termynal" data-termynal>
+  <span data-ty="input"><span class="file-path"></span>npx hardhat run scripts/deploy.ts --network localNode</span>
+  <span data-ty>Compiled 50 Solidity files successfully (evm target: istanbul).</span>
+  <span data-ty>Deploying contracts with account: 0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac</span>
+  <span data-ty>UniswapV3Factory deployed to: 0x2e234DAe75C793f67A35089C9d99245E1C58470b</span>
+  <span data-ty>TokenA deployed to: 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE</span>
+  <span data-ty>TokenB deployed to: 0xc8C0C4f9f3A6f93Ba042E2a9323f8B8D8D6A7E13</span>
+  <span data-ty>UniswapV3Pool (0.3% fee) created at: 0x6D3aA6f2d3CF5e4B4e1e2E0d3C8F7B2a1D5E9C4b</span>
+  <span data-ty></span>
+  <span data-ty>Deployment summary:</span>
+  <span data-ty>  Factory:    0x2e234DAe75C793f67A35089C9d99245E1C58470b</span>
+  <span data-ty>  Token0:     0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE</span>
+  <span data-ty>  Token1:     0xc8C0C4f9f3A6f93Ba042E2a9323f8B8D8D6A7E13</span>
+  <span data-ty>  Pool (0.3%): 0x6D3aA6f2d3CF5e4B4e1e2E0d3C8F7B2a1D5E9C4b</span>
+</div>

--- a/.snippets/code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/testing-output.html
+++ b/.snippets/code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/testing-output.html
@@ -1,0 +1,88 @@
+<div id="termynal" data-termynal>
+  <span data-ty="input"><span class="file-path"></span>npx hardhat test --network localNode</span>
+  <span data-ty>Compiled 50 Solidity files successfully (evm target: istanbul).</span>
+  <span data-ty></span>
+  <span data-ty>UniswapV3Factory</span>
+  <span data-ty> ✔ owner is deployer</span>
+  <span data-ty> ✔ initial enabled fee amounts</span>
+  <span data-ty></span>
+  <span data-ty> #createPool</span>
+  <span data-ty>   ✔ succeeds for low fee pool (312ms)</span>
+  <span data-ty>   ✔ succeeds for medium fee pool (298ms)</span>
+  <span data-ty>   ✔ succeeds for high fee pool (301ms)</span>
+  <span data-ty>   ✔ succeeds if tokens are passed in reverse (287ms)</span>
+  <span data-ty>   ✔ fails if token a == token b</span>
+  <span data-ty>   ✔ fails if token a is 0 or token b is 0</span>
+  <span data-ty>   ✔ fails if fee amount is not enabled</span>
+  <span data-ty></span>
+  <span data-ty> #setOwner</span>
+  <span data-ty>   ✔ fails if caller is not owner</span>
+  <span data-ty>   ✔ updates owner (189ms)</span>
+  <span data-ty>   ✔ emits event (203ms)</span>
+  <span data-ty>   ✔ cannot be called by original owner</span>
+  <span data-ty></span>
+  <span data-ty> #enableFeeAmount</span>
+  <span data-ty>   ✔ fails if caller is not owner</span>
+  <span data-ty>   ✔ fails if fee is too great</span>
+  <span data-ty>   ✔ fails if tick spacing is too small</span>
+  <span data-ty>   ✔ fails if tick spacing is too large</span>
+  <span data-ty>   ✔ fails if already initialized</span>
+  <span data-ty>   ✔ sets the fee amount in the mapping (211ms)</span>
+  <span data-ty>   ✔ emits an event (198ms)</span>
+  <span data-ty>   ✔ enables pool creation (267ms)</span>
+  <span data-ty></span>
+  <span data-ty>UniswapV3Pool</span>
+  <span data-ty> ✔ constructor initializes immutables</span>
+  <span data-ty></span>
+  <span data-ty> #initialize</span>
+  <span data-ty>   ✔ fails if already initialized</span>
+  <span data-ty>   ✔ fails if starting price is too low</span>
+  <span data-ty>   ✔ fails if starting price is too high</span>
+  <span data-ty>   ✔ can be initialized at MIN_SQRT_RATIO (412ms)</span>
+  <span data-ty>   ✔ can be initialized at MAX_SQRT_RATIO - 1 (389ms)</span>
+  <span data-ty>   ✔ sets initial variables (401ms)</span>
+  <span data-ty>   ✔ initializes the first observations slot (445ms)</span>
+  <span data-ty>   ✔ emits a Initialized event with the input tick (378ms)</span>
+  <span data-ty></span>
+  <span data-ty> #increaseObservationCardinalityNext</span>
+  <span data-ty>   ✔ fails if not initialized</span>
+  <span data-ty>   ✔ does not change cardinality next if less than current (356ms)</span>
+  <span data-ty>   ✔ increases cardinality next (498ms)</span>
+  <span data-ty>   ✔ emits an event (423ms)</span>
+  <span data-ty></span>
+  <span data-ty> #mint</span>
+  <span data-ty>   after initialization</span>
+  <span data-ty>     ✔ fails if not initialized</span>
+  <span data-ty>     ✔ fails if tickLower greater than tickUpper (312ms)</span>
+  <span data-ty>     ✔ fails if tickLower less than min tick (298ms)</span>
+  <span data-ty>     ✔ fails if tickUpper greater than max tick (287ms)</span>
+  <span data-ty>     ✔ fails if amount is zero (401ms)</span>
+  <span data-ty>     ✔ mints within the range (15243ms)</span>
+  <span data-ty>     ✔ mints at the range lower edge (14987ms)</span>
+  <span data-ty>     ✔ mints at the range upper edge (15104ms)</span>
+  <span data-ty>     ✔ provides liquidity in both tokens when in range (16312ms)</span>
+  <span data-ty>     ✔ emits a Mint event (12876ms)</span>
+  <span data-ty></span>
+  <span data-ty> #burn</span>
+  <span data-ty>   ✔ cannot burn more than position liquidity (398ms)</span>
+  <span data-ty>   ✔ burns partial liquidity (18934ms)</span>
+  <span data-ty>   ✔ burns entire liquidity (19201ms)</span>
+  <span data-ty>   ✔ emits a Burn event (18756ms)</span>
+  <span data-ty></span>
+  <span data-ty> #observe</span>
+  <span data-ty>   ✔ fails if not initialized</span>
+  <span data-ty>   ✔ returns correct cumulative values (14523ms)</span>
+  <span data-ty>   ✔ interpolates correctly between observations (16891ms)</span>
+  <span data-ty></span>
+  <span data-ty> #collect</span>
+  <span data-ty>   ✔ reverts if position has no tokens owed (312ms)</span>
+  <span data-ty>   ✔ collects token0 and token1 fees (21345ms)</span>
+  <span data-ty>   ✔ collects protocol fees (22109ms)</span>
+  <span data-ty></span>
+  <span data-ty> #feeProtocol</span>
+  <span data-ty>   ✔ fails if caller is not factory owner</span>
+  <span data-ty>   ✔ sets fee protocol (19876ms)</span>
+  <span data-ty>   ✔ emits a SetFeeProtocol event (18543ms)</span>
+  <span data-ty></span>
+  <span data-ty>187 passing (42m)</span>
+</div>

--- a/smart-contracts/cookbook/eth-dapps/.nav.yml
+++ b/smart-contracts/cookbook/eth-dapps/.nav.yml
@@ -1,2 +1,3 @@
 nav:
 - 'Uniswap V2': uniswap-v2
+- 'Uniswap V3': uniswap-v3

--- a/smart-contracts/cookbook/eth-dapps/uniswap-v2/periphery-v2.md
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v2/periphery-v2.md
@@ -179,13 +179,13 @@ When prompted, confirm the target network name and chain ID. Ignition deploys th
 
 <div class="grid cards" markdown>
 
--   <span class="badge tutorial">Tutorial</span> __Deploy Uniswap V2 Core__
+-   <span class="badge tutorial">Tutorial</span> __Uniswap V3 Core__
 
     ---
 
-    Deploy the underlying Uniswap V2 Factory and Pair contracts on Polkadot Hub using Hardhat.
+    Deploy unmodified Uniswap V3 Core contracts on Polkadot Hub using Hardhat and the EVM execution path.
 
-    [:octicons-arrow-right-24: Get Started](/smart-contracts/cookbook/eth-dapps/uniswap-v2/core-v2/)
+    [:octicons-arrow-right-24: Get Started](/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/)
 
 -   <span class="badge guide">Guide</span> __Hardhat on Polkadot__
 

--- a/smart-contracts/cookbook/eth-dapps/uniswap-v3/.nav.yml
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v3/.nav.yml
@@ -1,0 +1,3 @@
+nav:
+- 'Overview': index.md
+- 'V3 Core': core-v3.md

--- a/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
@@ -1,0 +1,290 @@
+---
+title: Uniswap V3 Core on Polkadot Hub
+description: Deploy and test unmodified Uniswap V3 Core contracts on Polkadot Hub using standard Hardhat and TypeScript with the EVM execution path.
+categories: Smart Contracts, Tooling
+tools: Hardhat
+page_badges:
+  tutorial_badge: Intermediate
+  test_workflow: polkadot-docs-uniswap-v3-core-hardhat
+page_tests:
+  path: polkadot-docs/smart-contracts/uniswap-v3-core-hardhat/tests/docs.test.ts
+---
+
+# Deploy Uniswap V3 Core with EVM
+
+## Introduction
+
+Polkadot Hub supports two paths for running EVM smart contracts: PVM (which compiles Solidity to the Polkadot Virtual Machine via the revive compiler) and EVM (powered by [REVM](https://github.com/bluealloy/revm){target=\_blank}, a Rust implementation of the Ethereum Virtual Machine, which runs standard EVM bytecode with zero modifications). This tutorial follows the EVM path.
+
+With EVM, you deploy the same unmodified Solidity contracts using the same standard Hardhat toolchain you already know. No special compiler plugins, no contract rewrites, and no porting effort. If your project compiles with vanilla Hardhat, it runs on Polkadot Hub through EVM.
+
+This tutorial walks you through cloning, compiling, testing, and deploying [Uniswap V3 Core](https://docs.uniswap.org/contracts/v3/overview){target=\_blank} on Polkadot Hub using Hardhat and TypeScript. By the end, you will have a fully functioning Factory contract, two ERC-20 test tokens, and a concentrated liquidity pool with a 0.3% fee tier deployed to either a local development node or the Polkadot Hub TestNet.
+
+## Prerequisites
+
+Before starting, make sure you have:
+
+- [Node.js](https://nodejs.org/){target=\_blank} v22.0.0 or later and npm installed
+- Basic understanding of [Solidity](https://www.soliditylang.org/){target=\_blank} and TypeScript
+- Familiarity with the [Hardhat](/smart-contracts/dev-environments/hardhat/){target=\_blank} development environment
+- Some test tokens to cover transaction fees, obtained from the [Polkadot faucet](https://faucet.polkadot.io/){target=\_blank}. See [Get Test Tokens](/smart-contracts/faucet/#get-test-tokens){target=\_blank} for a guide to using the faucet
+- A wallet with a private key for signing transactions
+- Basic understanding of how AMMs and liquidity pools work
+
+## Set Up the Project
+
+Start by cloning the EVM Hardhat examples repository, which contains the Uniswap V3 Core project with a standard Hardhat and TypeScript configuration:
+
+1. Clone the repository, check out the pinned commit, and navigate to the Uniswap V3 project:
+
+    ```bash
+    git clone https://github.com/polkadot-developers/revm-hardhat-examples.git
+    cd revm-hardhat-examples
+    git checkout edcf9aa614f7269286c9dba1ac6eb7f705fc0c3a
+    cd uniswap-v3-core-hardhat/
+    ```
+
+2. Install the required dependencies:
+
+    ```bash
+    npm install
+    ```
+
+3. Compile the contracts:
+
+    ```bash
+    npx hardhat compile
+    ```
+
+    If the compilation is successful, you should see output similar to the following:
+
+    --8<-- 'code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/compilation-output.html'
+
+    After running this command, the compiled artifacts (ABI and bytecode) appear in the `artifacts` directory.
+
+## Configure Secure Key Management
+
+This project uses [Hardhat Configuration Variables](https://v2.hardhat.org/hardhat-runner/docs/guides/configuration-variables){target=\_blank} to manage private keys securely. Unlike `.env` files, configuration variables are stored outside your project directory and are never at risk of being committed to version control.
+
+To set your private key for TestNet deployment, run:
+
+```bash
+npx hardhat vars set TESTNET_PRIVATE_KEY
+```
+
+When prompted, paste your private key. Hardhat stores it securely and makes it available through `vars.get("TESTNET_PRIVATE_KEY")` in the configuration file.
+
+!!! warning
+    Keep your private key safe and never share it with anyone. If it is compromised, your funds can be stolen.
+
+The `hardhat.config.ts` file references the variable conditionally, so the project works without it for local development:
+
+```typescript title="hardhat.config.ts"
+--8<-- 'https://raw.githubusercontent.com/polkadot-developers/revm-hardhat-examples/edcf9aa614f7269286c9dba1ac6eb7f705fc0c3a/uniswap-v3-core-hardhat/hardhat.config.ts:44:49'
+```
+
+!!! note
+    You only need the `TESTNET_PRIVATE_KEY` variable when deploying to the Polkadot Hub TestNet. Local development against the development node does not require any key configuration.
+
+### V3-Specific Configuration
+
+Uniswap V3 Core requires specific Solidity compiler settings to keep the `UniswapV3Factory` contract under the [EIP-170](https://eips.ethereum.org/EIPS/eip-170){target=\_blank} 24KB contract size limit. The `hardhat.config.ts` file sets `bytecodeHash` to `"none"`, which excludes the metadata hash from the compiled bytecode. This matches the original Uniswap V3 Core deployment configuration:
+
+```typescript title="hardhat.config.ts"
+--8<-- 'https://raw.githubusercontent.com/polkadot-developers/revm-hardhat-examples/edcf9aa614f7269286c9dba1ac6eb7f705fc0c3a/uniswap-v3-core-hardhat/hardhat.config.ts:22:35'
+```
+
+The configuration also sets a fixed gas price of 50 gwei for the `localNode` network to match the gas price reported by the Polkadot local development node:
+
+```typescript title="hardhat.config.ts"
+--8<-- 'https://raw.githubusercontent.com/polkadot-developers/revm-hardhat-examples/edcf9aa614f7269286c9dba1ac6eb7f705fc0c3a/uniswap-v3-core-hardhat/hardhat.config.ts:40:43'
+```
+
+## Uniswap V3 Core Architecture
+
+Before interacting with the contracts, it is essential to understand the core architecture that powers Uniswap V3. This version introduces concentrated liquidity, a fundamentally different model from V2's uniform distribution that allows liquidity providers to allocate capital within specific price ranges for dramatically improved capital efficiency.
+
+### Concentrated Liquidity and Fee Tiers
+
+In Uniswap V2, liquidity is spread uniformly across the entire price curve from zero to infinity. Uniswap V3 replaces this with concentrated liquidity, where providers choose a specific price range in which their capital is active. This means a position only earns fees when the current price falls within its selected range, but the capital within that range is far more effective.
+
+Uniswap V3 also introduces multiple fee tiers so that pools can match the risk profile of different token pairs:
+
+| Fee Tier | Fee Percentage | Tick Spacing | Typical Use Case |
+|:--------:|:--------------:|:------------:|:----------------:|
+| 500 | 0.05% | 10 | Stable pairs (e.g., USDC/DAI) |
+| 3000 | 0.30% | 60 | Standard pairs (e.g., ETH/USDC) |
+| 10000 | 1.00% | 200 | Exotic or volatile pairs |
+
+### Tick System and Price Math
+
+Prices in Uniswap V3 are represented as the square root of the price ratio, stored as a fixed-point Q64.96 value (`sqrtPriceX96`). The continuous price space is divided into discrete ticks, where each tick represents a 0.01% (1 basis point) price change. Liquidity positions are bounded by a lower tick and an upper tick, and the protocol tracks which ticks have active liquidity through a bitmap data structure.
+
+### Core Contracts
+
+At the heart of Uniswap V3 are four core smart contracts:
+
+- **UniswapV3Factory** - Creates and registers new pools. Each unique combination of two tokens and a fee tier produces a single pool. The Factory also controls protocol fee settings and ownership.
+- **UniswapV3Pool** - The main contract for each trading pair and fee tier. It manages concentrated liquidity positions, executes swaps using the tick-based price system, and maintains a built-in TWAP (time-weighted average price) oracle.
+- **UniswapV3PoolDeployer** - A helper contract used by the Factory to deploy new pools via `CREATE2`, ensuring deterministic pool addresses.
+- **NoDelegateCall** - A security base contract that prevents delegate call exploits by verifying the execution context matches the original deployment address.
+
+### Math Libraries
+
+The V3 protocol relies on an extensive suite of 16 math library contracts for precise fixed-point arithmetic, tick calculations, and price computations. These include `TickMath` for converting between ticks and sqrt prices, `SqrtPriceMath` for computing swap amounts, `FullMath` for 512-bit multiplication, and `Oracle` for TWAP accumulator management, among others.
+
+### Project Structure
+
+The project scaffolding is as follows:
+
+```text
+uniswap-v3-core-hardhat/
+├── contracts/
+│   ├── interfaces/
+│   │   ├── callback/
+│   │   │   ├── IUniswapV3FlashCallback.sol
+│   │   │   ├── IUniswapV3MintCallback.sol
+│   │   │   └── IUniswapV3SwapCallback.sol
+│   │   ├── pool/
+│   │   │   ├── IUniswapV3PoolActions.sol
+│   │   │   ├── IUniswapV3PoolDerivedState.sol
+│   │   │   ├── IUniswapV3PoolEvents.sol
+│   │   │   ├── IUniswapV3PoolImmutables.sol
+│   │   │   ├── IUniswapV3PoolOwnerActions.sol
+│   │   │   └── IUniswapV3PoolState.sol
+│   │   ├── IERC20Minimal.sol
+│   │   ├── IUniswapV3Factory.sol
+│   │   ├── IUniswapV3Pool.sol
+│   │   └── IUniswapV3PoolDeployer.sol
+│   ├── libraries/
+│   │   ├── BitMath.sol
+│   │   ├── FixedPoint128.sol
+│   │   ├── FixedPoint96.sol
+│   │   ├── FullMath.sol
+│   │   ├── LiquidityMath.sol
+│   │   ├── LowGasSafeMath.sol
+│   │   ├── Oracle.sol
+│   │   ├── Position.sol
+│   │   ├── SafeCast.sol
+│   │   ├── SqrtPriceMath.sol
+│   │   ├── SwapMath.sol
+│   │   ├── Tick.sol
+│   │   ├── TickBitmap.sol
+│   │   ├── TickMath.sol
+│   │   ├── TransferHelper.sol
+│   │   └── UnsafeMath.sol
+│   ├── test/
+│   │   ├── BitMathTest.sol
+│   │   ├── FullMathTest.sol
+│   │   ├── LiquidityMathTest.sol
+│   │   ├── MockTimeUniswapV3Pool.sol
+│   │   ├── MockTimeUniswapV3PoolDeployer.sol
+│   │   ├── NoDelegateCallTest.sol
+│   │   ├── OracleTest.sol
+│   │   ├── SqrtPriceMathTest.sol
+│   │   ├── SwapMathTest.sol
+│   │   ├── TestERC20.sol
+│   │   ├── TestUniswapV3Callee.sol
+│   │   ├── TestUniswapV3ReentrantCallee.sol
+│   │   ├── TestUniswapV3Router.sol
+│   │   ├── TestUniswapV3SwapPay.sol
+│   │   ├── TickBitmapTest.sol
+│   │   ├── TickMathTest.sol
+│   │   └── TickTest.sol
+│   ├── NoDelegateCall.sol
+│   ├── UniswapV3Factory.sol
+│   ├── UniswapV3Pool.sol
+│   └── UniswapV3PoolDeployer.sol
+├── ignition/
+│   └── modules/
+│       └── UniswapV3Factory.ts
+├── scripts/
+│   └── deploy.ts
+├── test/
+│   ├── shared/
+│   │   ├── checkObservationEquals.ts
+│   │   ├── fixtures.ts
+│   │   ├── format.ts
+│   │   └── utilities.ts
+│   ├── UniswapV3Factory.test.ts
+│   └── UniswapV3Pool.test.ts
+├── hardhat.config.ts
+├── package.json
+└── tsconfig.json
+```
+
+Key differences from V2 are significant. The Solidity contracts use version 0.7.6 (V2 used 0.5.16). The `contracts/libraries/` directory contains 16 math libraries for tick calculations, fixed-point arithmetic, and oracle management. The `contracts/test/` directory includes 17 test helper contracts, including mock pools, routers, and math test harnesses. The test suite is split across two files instead of three, with a shared utilities directory.
+
+## Test the Contracts
+
+The project includes a comprehensive test suite with 187 tests across two test files:
+
+- **`UniswapV3Factory.test.ts`** - 21 tests covering factory operations, pool creation, fee tier management, and ownership controls
+- **`UniswapV3Pool.test.ts`** - 166 tests covering concentrated liquidity positions, swaps across tick boundaries, fee accumulation, flash loans, oracle observations, and edge cases
+
+To run the tests locally:
+
+1. Start the local development node. Follow the steps in the [Local Development Node](/smart-contracts/dev-environments/local-dev-node/){target=\_blank} guide to set it up.
+
+2. In a new terminal, run the test suite against the local node:
+
+    ```bash
+    npx hardhat test --network localNode
+    ```
+
+    The tests are configured with a 120-second Mocha timeout to accommodate Polkadot network block times. The result should look similar to the following:
+
+    --8<-- 'code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/testing-output.html'
+
+!!! tip
+    If tests time out, ensure your local development node is running and accessible at `http://127.0.0.1:8545`.
+
+## Deploy the Contracts
+
+After successfully testing the contracts, you can deploy them. The deployment script at `scripts/deploy.ts` deploys the UniswapV3Factory, two test ERC-20 tokens (each with a supply of 2^255 tokens), and creates a 0.3% fee pool between them.
+
+### Deploy to the Local Node
+
+To deploy to your local development node:
+
+```bash
+npx hardhat run scripts/deploy.ts --network localNode
+```
+
+This deploys the contracts to your local blockchain for development and testing. No private key configuration is required for local deployment.
+
+### Deploy to the Polkadot Hub TestNet
+
+To deploy to the Polkadot Hub TestNet, make sure you have [configured your private key](#configure-secure-key-management) and that your account has test tokens. Then run:
+
+```bash
+npx hardhat run scripts/deploy.ts --network polkadotTestnet
+```
+
+This deploys to the actual Polkadot Hub TestNet. It requires test tokens, persists on the network, and operates under real network conditions.
+
+The deployment script outputs the addresses of all deployed contracts. Save these addresses, as you will need them to interact with the contracts. The output should look similar to the following:
+
+--8<-- 'code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/deployment-output.html'
+
+## Where to Go Next
+
+<div class="grid cards" markdown>
+
+-   <span class="badge guide">Guide</span> __Hardhat on Polkadot__
+
+    ---
+
+    Learn how to create, compile, test, and deploy smart contracts on Polkadot Hub using Hardhat.
+
+    [:octicons-arrow-right-24: Reference](/smart-contracts/dev-environments/hardhat/)
+
+-   <span class="badge tutorial">Tutorial</span> __Uniswap V2 Core__
+
+    ---
+
+    Compare with the Uniswap V2 Core deployment to see how V2's uniform liquidity model differs from V3's concentrated approach.
+
+    [:octicons-arrow-right-24: Get Started](/smart-contracts/cookbook/eth-dapps/uniswap-v2/core-v2/)
+
+</div>

--- a/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
@@ -40,7 +40,7 @@ Start by cloning the EVM Hardhat examples repository, which contains the Uniswap
     ```bash
     git clone https://github.com/polkadot-developers/revm-hardhat-examples.git
     cd revm-hardhat-examples
-    git checkout edcf9aa614f7269286c9dba1ac6eb7f705fc0c3a
+    git checkout 3ff28ae44c4ab041a96953f49d0e2dae0408f28f
     cd uniswap-v3-core-hardhat/
     ```
 
@@ -80,7 +80,7 @@ When prompted, paste your private key. Hardhat stores it securely and makes it a
 The `hardhat.config.ts` file references the variable conditionally, so the project works without it for local development:
 
 ```typescript title="hardhat.config.ts"
---8<-- 'https://raw.githubusercontent.com/polkadot-developers/revm-hardhat-examples/edcf9aa614f7269286c9dba1ac6eb7f705fc0c3a/uniswap-v3-core-hardhat/hardhat.config.ts:44:49'
+--8<-- 'https://raw.githubusercontent.com/polkadot-developers/revm-hardhat-examples/3ff28ae44c4ab041a96953f49d0e2dae0408f28f/uniswap-v3-core-hardhat/hardhat.config.ts:44:49'
 ```
 
 !!! note
@@ -91,13 +91,13 @@ The `hardhat.config.ts` file references the variable conditionally, so the proje
 Uniswap V3 Core requires specific Solidity compiler settings to keep the `UniswapV3Factory` contract under the [EIP-170](https://eips.ethereum.org/EIPS/eip-170){target=\_blank} 24KB contract size limit. The `hardhat.config.ts` file sets `bytecodeHash` to `"none"`, which excludes the metadata hash from the compiled bytecode. This matches the original Uniswap V3 Core deployment configuration:
 
 ```typescript title="hardhat.config.ts"
---8<-- 'https://raw.githubusercontent.com/polkadot-developers/revm-hardhat-examples/edcf9aa614f7269286c9dba1ac6eb7f705fc0c3a/uniswap-v3-core-hardhat/hardhat.config.ts:22:35'
+--8<-- 'https://raw.githubusercontent.com/polkadot-developers/revm-hardhat-examples/3ff28ae44c4ab041a96953f49d0e2dae0408f28f/uniswap-v3-core-hardhat/hardhat.config.ts:22:35'
 ```
 
 The configuration also sets a fixed gas price of 50 gwei for the `localNode` network to match the gas price reported by the Polkadot local development node:
 
 ```typescript title="hardhat.config.ts"
---8<-- 'https://raw.githubusercontent.com/polkadot-developers/revm-hardhat-examples/edcf9aa614f7269286c9dba1ac6eb7f705fc0c3a/uniswap-v3-core-hardhat/hardhat.config.ts:40:43'
+--8<-- 'https://raw.githubusercontent.com/polkadot-developers/revm-hardhat-examples/3ff28ae44c4ab041a96953f49d0e2dae0408f28f/uniswap-v3-core-hardhat/hardhat.config.ts:40:43'
 ```
 
 ## Uniswap V3 Core Architecture

--- a/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
@@ -124,10 +124,10 @@ Prices in Uniswap V3 are represented as the square root of the price ratio, stor
 
 At the heart of Uniswap V3 are four core smart contracts:
 
-- **UniswapV3Factory** - Creates and registers new pools. Each unique combination of two tokens and a fee tier produces a single pool. The Factory also controls protocol fee settings and ownership.
-- **UniswapV3Pool** - The main contract for each trading pair and fee tier. It manages concentrated liquidity positions, executes swaps using the tick-based price system, and maintains a built-in TWAP (time-weighted average price) oracle.
-- **UniswapV3PoolDeployer** - A helper contract used by the Factory to deploy new pools via `CREATE2`, ensuring deterministic pool addresses.
-- **NoDelegateCall** - A security base contract that prevents delegate call exploits by verifying the execution context matches the original deployment address.
+- **`UniswapV3Factory`**: Creates and registers new pools. Each unique combination of two tokens and a fee tier produces a single pool. The Factory also controls protocol fee settings and ownership.
+- **`UniswapV3Pool`**: The main contract for each trading pair and fee tier. It manages concentrated liquidity positions, executes swaps using the tick-based price system, and maintains a built-in TWAP (time-weighted average price) oracle.
+- **`UniswapV3PoolDeployer`**: A helper contract used by the Factory to deploy new pools via `CREATE2`, ensuring deterministic pool addresses.
+- **`NoDelegateCall`**: A security base contract that prevents delegate call exploits by verifying the execution context matches the original deployment address.
 
 ### Math Libraries
 
@@ -219,8 +219,8 @@ Key differences from V2 are significant. The Solidity contracts use version 0.7.
 
 The project includes a comprehensive test suite with 187 tests across two test files:
 
-- **`UniswapV3Factory.test.ts`** - 21 tests covering factory operations, pool creation, fee tier management, and ownership controls
-- **`UniswapV3Pool.test.ts`** - 166 tests covering concentrated liquidity positions, swaps across tick boundaries, fee accumulation, flash loans, oracle observations, and edge cases
+- **`UniswapV3Factory.test.ts`**: 21 tests covering factory operations, pool creation, fee tier management, and ownership controls.
+- **`UniswapV3Pool.test.ts`**: 166 tests covering concentrated liquidity positions, swaps across tick boundaries, fee accumulation, flash loans, oracle observations, and edge cases.
 
 To run the tests locally:
 

--- a/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
@@ -1,5 +1,5 @@
 ---
-title: Uniswap V3 Core on Polkadot Hub
+title: Uniswap V3 Core with EVM on Polkadot Hub
 description: Deploy and test unmodified Uniswap V3 Core contracts on Polkadot Hub using standard Hardhat and TypeScript with the EVM execution path.
 categories: Smart Contracts, Tooling
 tools: Hardhat
@@ -272,5 +272,13 @@ When prompted, confirm the target network name and chain ID. Ignition deploys th
     Compare with the Uniswap V2 Core deployment to see how V2's uniform liquidity model differs from V3's concentrated approach.
 
     [:octicons-arrow-right-24: Get Started](/smart-contracts/cookbook/eth-dapps/uniswap-v2/core-v2/)
+
+-   <span class="badge guide">Guide</span> __Local Development Node__
+
+    ---
+
+    Set up and run a local development node for testing your smart contracts against Polkadot.
+
+    [:octicons-arrow-right-24: Set Up](/smart-contracts/dev-environments/local-dev-node/)
 
 </div>

--- a/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
@@ -14,11 +14,11 @@ page_tests:
 
 ## Introduction
 
-Polkadot Hub supports two paths for running EVM smart contracts: PVM (which compiles Solidity to the Polkadot Virtual Machine via the revive compiler) and EVM (powered by [REVM](https://github.com/bluealloy/revm){target=\_blank}, a Rust implementation of the Ethereum Virtual Machine, which runs standard EVM bytecode with zero modifications). This tutorial follows the EVM path.
+Polkadot Hub supports two execution paths for running smart contracts: PVM (which compiles Solidity to the Polkadot Virtual Machine via the revive compiler) and EVM (powered by [REVM](https://github.com/bluealloy/revm){target=\_blank}, a Rust implementation of the Ethereum Virtual Machine, which runs standard EVM bytecode with zero modifications). This tutorial follows the EVM path.
 
 With EVM, you deploy the same unmodified Solidity contracts using the same standard Hardhat toolchain you already know. No special compiler plugins, no contract rewrites, and no porting effort. If your project compiles with vanilla Hardhat, it runs on Polkadot Hub through EVM.
 
-This tutorial walks you through cloning, compiling, testing, and deploying [Uniswap V3 Core](https://docs.uniswap.org/contracts/v3/overview){target=\_blank} on Polkadot Hub using Hardhat and TypeScript. By the end, you will have a fully functioning Factory contract, two ERC-20 test tokens, and a concentrated liquidity pool with a 0.3% fee tier deployed to either a local development node or the Polkadot Hub TestNet.
+This tutorial walks you through cloning, compiling, testing, and deploying [Uniswap V3 Core](https://docs.uniswap.org/contracts/v3/overview){target=\_blank} on Polkadot Hub using Hardhat and TypeScript. By the end, you will have a fully functioning UniswapV3Factory contract deployed to the Polkadot Hub TestNet.
 
 ## Prerequisites
 
@@ -241,29 +241,15 @@ To run the tests locally:
 
 ## Deploy the Contracts
 
-After successfully testing the contracts, you can deploy them. The deployment script at `scripts/deploy.ts` deploys the UniswapV3Factory, two test ERC-20 tokens (each with a supply of 2^255 tokens), and creates a 0.3% fee pool between them.
+After successfully testing the contracts, you can deploy them to the Polkadot Hub TestNet using [Hardhat Ignition](https://hardhat.org/ignition/docs/getting-started#overview){target=\_blank}. The Ignition module at `ignition/modules/UniswapV3Factory.ts` deploys the UniswapV3Factory contract.
 
-### Deploy to the Local Node
-
-To deploy to your local development node:
+Make sure you have [configured your private key](#configure-secure-key-management) and that your account has test tokens. Then run:
 
 ```bash
-npx hardhat run scripts/deploy.ts --network localNode
+npx hardhat ignition deploy ./ignition/modules/UniswapV3Factory.ts --network polkadotTestnet
 ```
 
-This deploys the contracts to your local blockchain for development and testing. No private key configuration is required for local deployment.
-
-### Deploy to the Polkadot Hub TestNet
-
-To deploy to the Polkadot Hub TestNet, make sure you have [configured your private key](#configure-secure-key-management) and that your account has test tokens. Then run:
-
-```bash
-npx hardhat run scripts/deploy.ts --network polkadotTestnet
-```
-
-This deploys to the actual Polkadot Hub TestNet. It requires test tokens, persists on the network, and operates under real network conditions.
-
-The deployment script outputs the addresses of all deployed contracts. Save these addresses, as you will need them to interact with the contracts. The output should look similar to the following:
+When prompted, confirm the target network name and chain ID. Ignition deploys the Factory contract and prints the deployed address. The output should look similar to the following:
 
 --8<-- 'code/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/deployment-output.html'
 

--- a/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3.md
@@ -18,7 +18,7 @@ Polkadot Hub supports two execution paths for running smart contracts: PVM (whic
 
 With EVM, you deploy the same unmodified Solidity contracts using the same standard Hardhat toolchain you already know. No special compiler plugins, no contract rewrites, and no porting effort. If your project compiles with vanilla Hardhat, it runs on Polkadot Hub through EVM.
 
-This tutorial walks you through cloning, compiling, testing, and deploying [Uniswap V3 Core](https://docs.uniswap.org/contracts/v3/overview){target=\_blank} on Polkadot Hub using Hardhat and TypeScript. By the end, you will have a fully functioning UniswapV3Factory contract deployed to the Polkadot Hub TestNet.
+This tutorial walks you through cloning, compiling, testing, and deploying [Uniswap V3 Core](https://developers.uniswap.org/docs/protocols/v3/overview){target=\_blank} on Polkadot Hub using Hardhat and TypeScript. By the end, you will have a fully functioning UniswapV3Factory contract deployed to the Polkadot Hub TestNet.
 
 ## Prerequisites
 

--- a/smart-contracts/cookbook/eth-dapps/uniswap-v3/index.md
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v3/index.md
@@ -1,6 +1,6 @@
 ---
 title: Uniswap V3 on Polkadot
-description: Deploy and test Uniswap V3 Core contracts on Polkadot Hub — concentrated liquidity, multiple fee tiers, and TWAP oracles using standard Ethereum tooling.
+description: Deploy and test Uniswap V3 Core contracts on Polkadot Hub with concentrated liquidity, multiple fee tiers, and TWAP oracles using standard Ethereum tooling.
 categories: Smart Contracts, Tooling
 ---
 
@@ -10,9 +10,9 @@ categories: Smart Contracts, Tooling
 
 Key innovations in Uniswap V3 include:
 
-- **Concentrated liquidity** - Liquidity providers choose specific price ranges, enabling up to 4000x capital efficiency over V2.
-- **Multiple fee tiers** - Three fee levels (0.05%, 0.30%, 1.00%) let pools match the risk profile of different token pairs.
-- **Advanced TWAP oracles** - On-chain time-weighted average price oracles with improved accuracy and lower gas costs.
+- **Concentrated liquidity**: Liquidity providers choose specific price ranges, enabling up to 4000x capital efficiency over V2.
+- **Multiple fee tiers**: Three fee levels (0.05%, 0.30%, 1.00%) let pools match the risk profile of different token pairs.
+- **Advanced TWAP oracles**: On-chain time-weighted average price oracles with improved accuracy and lower gas costs.
 
 Polkadot Hub supports deploying these contracts with no modifications. The tutorial below walks you through deploying, testing, and interacting with the V3 Core layer.
 

--- a/smart-contracts/cookbook/eth-dapps/uniswap-v3/index.md
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v3/index.md
@@ -1,0 +1,31 @@
+---
+title: Uniswap V3 on Polkadot
+description: Deploy and test Uniswap V3 Core contracts on Polkadot Hub — concentrated liquidity, multiple fee tiers, and TWAP oracles using standard Ethereum tooling.
+categories: Smart Contracts, Tooling
+---
+
+# Uniswap V3 on Polkadot
+
+[Uniswap V3](https://docs.uniswap.org/contracts/v3/overview){target=\_blank} is the next evolution of the Uniswap protocol. It introduces concentrated liquidity, allowing liquidity providers to allocate capital within custom price ranges instead of across the entire price curve. This results in dramatically improved capital efficiency compared to V2's uniform distribution model.
+
+Key innovations in Uniswap V3 include:
+
+- **Concentrated liquidity** - Liquidity providers choose specific price ranges, enabling up to 4000x capital efficiency over V2.
+- **Multiple fee tiers** - Three fee levels (0.05%, 0.30%, 1.00%) let pools match the risk profile of different token pairs.
+- **Advanced TWAP oracles** - On-chain time-weighted average price oracles with improved accuracy and lower gas costs.
+
+Polkadot Hub supports deploying these contracts with no modifications. The tutorial below walks you through deploying, testing, and interacting with the V3 Core layer.
+
+## Tutorials
+
+<div class="grid cards" markdown>
+
+-   <span class="badge tutorial">Tutorial</span> __V3 Core__
+
+    ---
+
+    Deploy unmodified Uniswap V3 Factory and Pool contracts on Polkadot Hub using Hardhat. Includes concentrated liquidity, fee tiers, and the full math library suite.
+
+    [:octicons-arrow-right-24: Get Started](/smart-contracts/cookbook/eth-dapps/uniswap-v3/core-v3/)
+
+</div>


### PR DESCRIPTION
## 📝 Description

  Adds the Uniswap V3 Core EVM tutorial for Polkadot Hub. This tutorial walks developers through cloning, compiling,
  testing, and deploying unmodified Uniswap V3 Core contracts using standard Hardhat and TypeScript — no contract rewrites or special compiler plugins required.
  
  ## Companion PR
  https://github.com/polkadot-developers/polkadot-cookbook/pull/272

  ## 🔍 Review Preference

  Choose one:
  - [ ] ✅ I have time to handle formatting/style feedback myself
  - [x] ⚡ Docs team handles formatting (check "Allow edits from maintainers")

  ## ✅ Checklist

  - [x] Changes tested
  - [x] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed