### PR TITLE
feat: add CI badge for register-local-asset guide

### DIFF
--- a/chain-interactions/token-operations/register-local-asset.md
+++ b/chain-interactions/token-operations/register-local-asset.md
@@ -4,6 +4,9 @@ description: Learn how to register a local asset on Polkadot Hub, including prer
 categories: Basics, Chain Interactions
 page_badges:
   tutorial_badge: Beginner
+  test_workflow: polkadot-docs-register-local-asset
+page_tests:
+  path: polkadot-docs/chain-interactions/register-local-asset/tests/docs.test.ts
 ---
 
 # Register a Local Asset on Polkadot Hub


### PR DESCRIPTION
## Summary

Wires up the CI badge and "View tests" link on the [Register a Local Asset](https://docs.polkadot.com/chain-interactions/token-operations/register-local-asset/) guide page.

Adds `test_workflow: polkadot-docs-register-local-asset` under `page_badges` and `page_tests.path` to the frontmatter. Existing `tutorial_badge: Beginner` is preserved.

Companion to polkadot-developers/polkadot-cookbook#280, which introduces the test harness that this badge tracks.

## Verification

The referenced workflow and test path will be live once the cookbook PR merges:

- Workflow: `.github/workflows/polkadot-docs-register-local-asset.yml`
- Tests: `polkadot-docs/chain-interactions/register-local-asset/tests/docs.test.ts` (7 tests, ~2.5 min, Chopsticks fork of Polkadot Asset Hub)