### PR TITLE
docs: add CI badge for Register a Foreign Asset guide

### DIFF
--- a/chain-interactions/token-operations/register-foreign-asset.md
+++ b/chain-interactions/token-operations/register-foreign-asset.md
@@ -4,6 +4,9 @@ description: Learn step-by-step how to register a foreign asset on Polkadot Hub 
 categories: Interoperability, Parachains
 page_badges:
   tutorial_badge: Intermediate
+  test_workflow: polkadot-docs-register-foreign-asset
+page_tests:
+  path: polkadot-docs/chain-interactions/register-foreign-asset/tests/docs.test.ts
 ---
 
 # Register a Foreign Asset on Polkadot Hub


### PR DESCRIPTION
## 📝 Description

Companion PR to polkadot-developers/polkadot-cookbook#268.

Adds `page_badges.test_workflow` and `page_tests` metadata to the Register a
Foreign Asset guide so the CI badge and automated test path are wired up.

## ✅ Checklist

- [ ] Changes tested
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed