### PR TITLE
docs: add CI badge for Convert Assets on Asset Hub guide

### DIFF
--- a/chain-interactions/token-operations/convert-assets.md
+++ b/chain-interactions/token-operations/convert-assets.md
@@ -4,6 +4,9 @@ description: A guide detailing the step-by-step process of converting assets on 
 categories: Chain Interactions, Tooling
 page_badges:
   tutorial_badge: Intermediate
+  test_workflow: polkadot-docs-convert-assets
+page_tests:
+  path: polkadot-docs/chain-interactions/convert-assets/tests/docs.test.ts
 ---
 
 # Convert Assets on Asset Hub


### PR DESCRIPTION
## 📝 Description

Companion PR to polkadot-developers/polkadot-cookbook#267.

Adds `page_badges.test_workflow` and `page_tests` metadata to the Convert
Assets on Asset Hub guide so the CI badge and automated test path are wired up.

## ✅ Checklist

- [ ] Changes tested
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed