### PR TITLE
docs: add CI badge for Replay and Dry Run XCMs guide

### DIFF
--- a/chain-interactions/send-transactions/interoperability/debug-and-preview-xcms.md
+++ b/chain-interactions/send-transactions/interoperability/debug-and-preview-xcms.md
@@ -2,6 +2,10 @@
 title: Replay and Dry Run XCMs
 description: Replay and dry-run XCMs using Chopsticks with full logging enabled. Diagnose issues, trace message flow, and debug complex cross-chain interactions.
 categories: Interoperability, Tooling
+page_badges:
+  test_workflow: polkadot-docs-debug-and-preview-xcms
+page_tests:
+  path: polkadot-docs/chain-interactions/debug-and-preview-xcms/tests/docs.test.ts
 ---
 
 # Replay and Dry Run XCMs Using Chopsticks


### PR DESCRIPTION
## 📝 Description

Companion PR to polkadot-developers/polkadot-cookbook#281.

Adds `page_badges.test_workflow` and `page_tests` metadata to the Replay and
Dry Run XCMs guide so the CI badge and automated test path are wired up.

## ✅ Checklist

- [ ] Changes tested
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed