### PR TITLE
Fix tutorial Badge

### DIFF
--- a/chain-interactions/accounts/create-account.md
+++ b/chain-interactions/accounts/create-account.md
@@ -3,6 +3,7 @@ title: Create an Account
 description: Step-by-step guide to creating Polkadot accounts using different programming languages and libraries, including JavaScript, Python, and Rust examples.
 categories: Basics, Chain Interactions
 page_badges:
+  tutorial_badge: Beginner
   test_workflow: polkadot-docs-create-account
 page_tests:
   path: polkadot-docs/chain-interactions/create-account/tests/docs.test.ts

--- a/chain-interactions/accounts/query-accounts.md
+++ b/chain-interactions/accounts/query-accounts.md
@@ -3,6 +3,7 @@ title: Query Account Information with SDKs
 description: Learn how to query account information using five popular SDKs—Polkadot API (PAPI), Polkadot.js API, Dedot, Python Substrate Interface, and Subxt.
 categories: Chain Interactions, Tooling
 page_badges:
+  tutorial_badge: Beginner
   test_workflow: polkadot-docs-query-accounts
 page_tests:
   path: polkadot-docs/chain-interactions/query-accounts/tests/docs.test.ts

--- a/chain-interactions/query-data/query-sdks.md
+++ b/chain-interactions/query-data/query-sdks.md
@@ -3,6 +3,7 @@ title: Query On-Chain State with SDKs
 description: Learn how to query on-chain storage data on Polkadot Hub using PAPI, Polkadot.js, Dedot, Python Substrate Interface, and Subxt.
 categories: Chain Interactions, Tooling
 page_badges:
+  tutorial_badge: Intermediate
   test_workflow: polkadot-docs-query-sdks
 page_tests:
   path: polkadot-docs/chain-interactions/query-sdks/tests/docs.test.ts

--- a/chain-interactions/send-transactions/calculate-transaction-fees.md
+++ b/chain-interactions/send-transactions/calculate-transaction-fees.md
@@ -3,7 +3,7 @@ title: Calculate Transaction Fees
 description: Learn how to calculate transaction fees on Polkadot using Polkadot-API, Polkadot.js API, and the Polkadot.js Apps UI to estimate transfer costs.
 categories: Chain Interactions, Tooling
 page_badges:
-  tutorial_badge: Intermediate
+  tutorial_badge: Beginner
   test_workflow: polkadot-docs-calculate-transaction-fees
 page_tests:
   path: polkadot-docs/chain-interactions/calculate-transaction-fees/tests/docs.test.ts

--- a/chain-interactions/send-transactions/calculate-transaction-fees.md
+++ b/chain-interactions/send-transactions/calculate-transaction-fees.md
@@ -3,6 +3,7 @@ title: Calculate Transaction Fees
 description: Learn how to calculate transaction fees on Polkadot using Polkadot-API, Polkadot.js API, and the Polkadot.js Apps UI to estimate transfer costs.
 categories: Chain Interactions, Tooling
 page_badges:
+  tutorial_badge: Intermediate
   test_workflow: polkadot-docs-calculate-transaction-fees
 page_tests:
   path: polkadot-docs/chain-interactions/calculate-transaction-fees/tests/docs.test.ts

--- a/chain-interactions/send-transactions/interoperability/debug-and-preview-xcms.md
+++ b/chain-interactions/send-transactions/interoperability/debug-and-preview-xcms.md
@@ -3,6 +3,7 @@ title: Replay and Dry Run XCMs
 description: Replay and dry-run XCMs using Chopsticks with full logging enabled. Diagnose issues, trace message flow, and debug complex cross-chain interactions.
 categories: Interoperability, Tooling
 page_badges:
+  tutorial_badge: Advanced
   test_workflow: polkadot-docs-debug-and-preview-xcms
 page_tests:
   path: polkadot-docs/chain-interactions/debug-and-preview-xcms/tests/docs.test.ts

--- a/chain-interactions/send-transactions/interoperability/estimate-xcm-fees.md
+++ b/chain-interactions/send-transactions/interoperability/estimate-xcm-fees.md
@@ -3,6 +3,7 @@ title: XCM Fee Estimation
 description: This tutorial demonstrates how to estimate the fees for teleporting assets from the Polkadot Hub TestNet to the Paseo People Chain.
 categories: Interoperability, Chain Interactions
 page_badges:
+  tutorial_badge: Intermediate
   test_workflow: polkadot-docs-estimate-xcm-fees
 page_tests:
   path: polkadot-docs/chain-interactions/estimate-xcm-fees/tests/docs.test.ts

--- a/chain-interactions/send-transactions/interoperability/transfer-assets-parachains.md
+++ b/chain-interactions/send-transactions/interoperability/transfer-assets-parachains.md
@@ -3,6 +3,7 @@ title: Transfer Assets Between Parachains
 description: A step-by-step guide to using the ParaSpell XCM SDK to build, verify, and execute a transfer from one Parachain to another.
 categories: Interoperability, Parachains
 page_badges:
+  tutorial_badge: Intermediate
   test_workflow: polkadot-docs-transfer-assets-parachains
 page_tests:
   path: polkadot-docs/chain-interactions/transfer-assets-parachains/tests/docs.test.ts

--- a/chain-interactions/send-transactions/pay-fees-with-different-tokens.md
+++ b/chain-interactions/send-transactions/pay-fees-with-different-tokens.md
@@ -3,6 +3,7 @@ title: Pay Transaction Fees with Different Tokens
 description: Learn how to send a DOT transfer transaction while paying the fees using a different token on Polkadot Hub using multiple SDKs.
 categories: Chain Interactions, Tooling
 page_badges:
+  tutorial_badge: Intermediate
   test_workflow: polkadot-docs-pay-fees-different-tokens
 page_tests:
   path: polkadot-docs/chain-interactions/pay-fees-different-tokens/tests/docs.test.ts

--- a/chain-interactions/send-transactions/with-sdks.md
+++ b/chain-interactions/send-transactions/with-sdks.md
@@ -3,6 +3,7 @@ title: Send Transactions with SDKs
 description: Learn how to construct, sign, and submit transactions using PAPI, Polkadot.js, Dedot, Python Substrate Interface, and Subxt.
 categories: Chain Interactions, Tooling
 page_badges:
+  tutorial_badge: Intermediate
   test_workflow: polkadot-docs-send-transactions
 page_tests:
   path: polkadot-docs/chain-interactions/send-transactions/tests/docs.test.ts

--- a/chain-interactions/store-data/bulletin-chain.md
+++ b/chain-interactions/store-data/bulletin-chain.md
@@ -3,7 +3,7 @@ title: Store and Retrieve Data on the Bulletin Chain
 description: Learn how to store and retrieve an image on the Polkadot Bulletin Chain using the Console UI or PAPI, with step-by-step instructions.
 categories: Chain Interactions
 page_badges:
-  tutorial_badge: Beginner
+  tutorial_badge: Intermediate
 ---
 
 # Store and Retrieve Data on the Bulletin Chain

--- a/chain-interactions/store-data/bulletin-chain.md
+++ b/chain-interactions/store-data/bulletin-chain.md
@@ -2,7 +2,8 @@
 title: Store and Retrieve Data on the Bulletin Chain
 description: Learn how to store and retrieve an image on the Polkadot Bulletin Chain using the Console UI or PAPI, with step-by-step instructions.
 categories: Chain Interactions
-tutorial_badge: Beginner
+page_badges:
+  tutorial_badge: Beginner
 ---
 
 # Store and Retrieve Data on the Bulletin Chain

--- a/parachains/customize-runtime/pallet-development/benchmark-pallet.md
+++ b/parachains/customize-runtime/pallet-development/benchmark-pallet.md
@@ -3,6 +3,7 @@ title: Benchmark Your Pallet
 description: Learn how to benchmark extrinsics in your custom pallet to generate precise weight calculations suitable for production use.
 categories: Parachains
 page_badges:
+  tutorial_badge: Advanced
   test_workflow: polkadot-docs-benchmark-pallet
 page_tests:
   path: polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/tests/docs.test.ts

--- a/parachains/customize-runtime/pallet-development/create-a-pallet.md
+++ b/parachains/customize-runtime/pallet-development/create-a-pallet.md
@@ -3,7 +3,7 @@ title: Create a Custom Pallet
 description: Learn how to create custom pallets using FRAME, allowing for flexible, modular, and scalable blockchain development. Follow the step-by-step guide.
 categories: Parachains
 page_badges:
-  tutorial_badge: Intermediate
+  tutorial_badge: Beginner
   test_workflow: polkadot-docs-create-a-pallet
 page_tests:
   path: polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/tests/docs.test.ts

--- a/parachains/customize-runtime/pallet-development/create-a-pallet.md
+++ b/parachains/customize-runtime/pallet-development/create-a-pallet.md
@@ -3,6 +3,7 @@ title: Create a Custom Pallet
 description: Learn how to create custom pallets using FRAME, allowing for flexible, modular, and scalable blockchain development. Follow the step-by-step guide.
 categories: Parachains
 page_badges:
+  tutorial_badge: Intermediate
   test_workflow: polkadot-docs-create-a-pallet
 page_tests:
   path: polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/tests/docs.test.ts

--- a/parachains/customize-runtime/pallet-development/mock-runtime.md
+++ b/parachains/customize-runtime/pallet-development/mock-runtime.md
@@ -3,6 +3,7 @@ title: Mock Your Runtime
 description: Learn how to create a mock runtime environment for testing your custom pallets in isolation, enabling comprehensive unit testing before runtime integration.
 categories: Parachains
 page_badges:
+  tutorial_badge: Intermediate
   test_workflow: polkadot-docs-mock-runtime
 page_tests:
   path: polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/tests/docs.test.ts

--- a/parachains/customize-runtime/pallet-development/pallet-testing.md
+++ b/parachains/customize-runtime/pallet-development/pallet-testing.md
@@ -3,6 +3,7 @@ title: Unit Test Pallets
 description: Learn how to efficiently test pallets in the Polkadot SDK, ensuring the reliability and security of your pallets operations.
 categories: Parachains
 page_badges:
+  tutorial_badge: Intermediate
   test_workflow: polkadot-docs-pallet-testing
 page_tests:
   path: polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/tests/docs.test.ts

--- a/parachains/install-polkadot-sdk.md
+++ b/parachains/install-polkadot-sdk.md
@@ -3,6 +3,7 @@ title: Install Polkadot SDK
 description: Install all required Polkadot SDK dependencies, set up the SDK itself, and verify that it runs correctly on your machine.
 categories: Basics, Tooling
 page_badges:
+  tutorial_badge: Beginner
   test_workflow: polkadot-docs-install-polkadot-sdk
 page_tests:
   path: polkadot-docs/parachains/install-polkadot-sdk/tests/docs.test.ts

--- a/parachains/testing/fork-a-parachain.md
+++ b/parachains/testing/fork-a-parachain.md
@@ -3,6 +3,7 @@ title: Fork a Parachain Using Chopsticks
 description: Simplify Polkadot SDK development with Chopsticks. Learn essential features, how to install Chopsticks, and how to configure local blockchain forks.
 categories: Parachains, Tooling
 page_badges:
+  tutorial_badge: Intermediate
   test_workflow: polkadot-docs-fork-a-parachain
 page_tests:
   path: polkadot-docs/parachains/testing/fork-a-parachain/tests/docs.test.ts

--- a/parachains/testing/run-a-parachain-network.md
+++ b/parachains/testing/run-a-parachain-network.md
@@ -3,6 +3,7 @@ title: Run a Parachain Network
 description: Learn how to deploy a local parachain test network using Zombienet, including building a custom collator and verifying block production.
 categories: Parachains, Tooling
 page_badges:
+  tutorial_badge: Intermediate
   test_workflow: polkadot-docs-run-a-parachain-network
 page_tests:
   path: polkadot-docs/networks/run-a-parachain-network/tests/docs.test.ts

--- a/smart-contracts/cookbook/eth-dapps/uniswap-v2/core-v2.md
+++ b/smart-contracts/cookbook/eth-dapps/uniswap-v2/core-v2.md
@@ -1,8 +1,9 @@
 ---
 title: Uniswap V2 Core with EVM on Polkadot
 description: Deploy and test unmodified Uniswap V2 Core contracts on Polkadot Hub using standard Hardhat and TypeScript with the EVM execution path.
-tutorial_badge: Intermediate
 categories: Smart Contracts, Tooling
+page_badges:
+  tutorial_badge: Intermediate
 toggle:
   group: uniswap-v2-core
   canonical: true

--- a/smart-contracts/cookbook/smart-contracts/deploy-basic/basic-hardhat.md
+++ b/smart-contracts/cookbook/smart-contracts/deploy-basic/basic-hardhat.md
@@ -3,6 +3,7 @@ title: Deploy a Basic Contract with Hardhat
 description: Learn how to deploy a basic smart contract to Polkadot Hub using Hardhat, ideal for professional workflows that require comprehensive testing and debugging.
 categories: Smart Contracts
 page_badges:
+  tutorial_badge: Beginner
   test_workflow: polkadot-docs-basic-hardhat
 page_tests:
   path: polkadot-docs/smart-contracts/basic-hardhat/tests/docs.test.ts

--- a/smart-contracts/dev-environments/local-dev-node.md
+++ b/smart-contracts/dev-environments/local-dev-node.md
@@ -3,6 +3,7 @@ title: Local Development Node
 description: Follow this step-by-step guide to install a Revive Dev node and ETH-RPC adapter for smart contract development in a local environment.
 categories: Smart Contracts
 page_badges:
+  tutorial_badge: Beginner
   test_workflow: polkadot-docs-local-dev-node
 page_tests:
   path: polkadot-docs/smart-contracts/local-dev-node/tests/docs.test.ts


### PR DESCRIPTION
## 📝 Description


This pull request makes a minor update to the frontmatter of the `core-v2.md` documentation file for Uniswap V2 Core. The change restructures how the `tutorial_badge` is defined in the metadata, moving it under a new `page_badges` section for improved organization.

## 🔍 Review Preference

Choose one:
- [x] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [x] Changes tested  
- [x] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
