### PR TITLE
ci(skills): bump dispatcher batch-size default 5 → 7

### DIFF
--- a/.github/workflows/monitor-skills.yml
+++ b/.github/workflows/monitor-skills.yml
@@ -38,10 +38,10 @@ on:
         type: number
         default: 5
       batch-size:
-        description: "Max new candidates to generate per run (default 5)"
+        description: "Max skills to generate per run, pending + stale combined (default 7)"
         required: false
         type: number
-        default: 5
+        default: 7
       no-chain:
         description: "If true, run one batch and stop (no auto-chaining)"
         required: false
@@ -106,7 +106,7 @@ jobs:
           #   (workflows-private includes them when dispatching generate-batch or triage-batch-*)
           # - repository_dispatch without a payload → fall back to defaults
           TRIAGE_BATCH_SIZE="${{ github.event.inputs['triage-batch-size'] || github.event.client_payload['triage-batch-size'] || 5 }}"
-          BATCH_SIZE="${{ github.event.inputs['batch-size'] || github.event.client_payload['batch-size'] || 5 }}"
+          BATCH_SIZE="${{ github.event.inputs['batch-size'] || github.event.client_payload['batch-size'] || 7 }}"
           NO_CHAIN="${{ github.event.inputs['no-chain'] || github.event.client_payload['no-chain'] || 'false' }}"
           # Self-chain safety counters. Initial runs default to iteration 1; chained
           # runs receive the next iteration via client_payload (set by workflows-private


### PR DESCRIPTION
## Summary

Align the dispatcher's \`batch-size\` default with the new default in [\`papermoonio/workflows-private#15\`](https://github.com/papermoonio/workflows-private/pull/15) (5 → 7).

## Why

Without this change, the dispatcher passes its own default of 5 through to workflows-private even though the upstream default is now 7 — defeating the throughput bump for the common case of users triggering with no explicit batch-size override.

The recent stale-sweep run on \`auto/update-skills\` proved this — workflows-private was already at default 7, but the run still processed only 5 skills per batch because the dispatcher was overriding with its own default of 5.

## Two places updated

1. \`workflow_dispatch\` input default + description (was "default 5")
2. Shell fallback in the \`Determine mode\` step — when neither \`workflow_dispatch\` input nor \`repository_dispatch\` payload provides a value, the \`BATCH_SIZE\` shell variable now falls back to 7

## Companion changes (in flight)

- ✅ Merged: \`papermoonio/workflows-private#15\` (upstream default 5 → 7, stale counts against batch limit)
- 🔜 Open: \`papermoonio/workflows-private#16\` (chain considers stale/alerts, canonicalize state file JSON)
- ✅ Merged: \`papermoonio/agent-ready-docs-hub#6\` (stale-management tools)

## Test plan

- [ ] Merge this PR + workflows-private#16
- [ ] Trigger Monitor Skills via the Actions UI with no input overrides
- [ ] Confirm logs show \`batch-size: 7\` in the dispatcher's "Determine mode" step
- [ ] Confirm the generate-skills job processes 7 stale skills per chained iteration