### PR TITLE
Fix duplicate word error in benchmark-pallet.md

### DIFF
--- a/parachains/customize-runtime/pallet-development/benchmark-pallet.md
+++ b/parachains/customize-runtime/pallet-development/benchmark-pallet.md
@@ -245,7 +245,7 @@ To execute benchmarks, your pallet must be integrated into the runtime's benchma
 
     When you build the runtime with `--features runtime-benchmarks`, this configuration ensures all necessary benchmarking code across all pallets (including yours) is included.
 
-2. **Update runtime configuration**: Using the the placeholder implementation, run development benchmarks as follows:
+2. **Update runtime configuration**: Using the placeholder implementation, run development benchmarks as follows:
 
     ```rust title="runtime/src/configs/mod.rs"
     impl pallet_custom::Config for Runtime {


### PR DESCRIPTION
## 📝 Description

This PR fixes a duplicate word error in benchmark-pallet.md

## 🔍 Review Preference

Choose one:
- [x] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed


