### PR TITLE
docs(collator): include "id" placeholder in start command example

### DIFF
--- a/parachains/launch-a-parachain/deploy-to-polkadot.md
+++ b/parachains/launch-a-parachain/deploy-to-polkadot.md
@@ -209,7 +209,7 @@ After running the command, you should see the following output, indicating the b
 
 --8<-- 'code/parachains/launch-a-parachain/deploy-to-polkadot/deploy-on-paseo.html'
 
-You must have the ports for the collator publicly accessible and discoverable to enable parachain nodes to peer with Paseo validator nodes to produce blocks. You can specify the ports with the `--port` command-line option. You can start the collator with a command similar to the following:
+You must have the ports for the collator publicly accessible and discoverable to enable parachain nodes to peer with Paseo validator nodes to produce blocks. You can specify the ports with the `--port` command-line option. You can start the collator with a command similar to the following (ensure you replace <YOUR_ID> with the "id" you used in the plain_chain_spec.json file:
 
 ```bash
 polkadot-omni-node --collator \
@@ -218,7 +218,7 @@ polkadot-omni-node --collator \
 --port 40333 \
 --rpc-port 8845 \
 --force-authoring \
---node-key-file ./data/chains/custom/network/secret_ed25519 \
+--node-key-file ./data/chains/<YOUR_ID>/network/secret_ed25519 \
 -- \
 --sync warp \
 --chain paseo \

--- a/parachains/launch-a-parachain/deploy-to-polkadot.md
+++ b/parachains/launch-a-parachain/deploy-to-polkadot.md
@@ -209,7 +209,7 @@ After running the command, you should see the following output, indicating the b
 
 --8<-- 'code/parachains/launch-a-parachain/deploy-to-polkadot/deploy-on-paseo.html'
 
-You must have the ports for the collator publicly accessible and discoverable to enable parachain nodes to peer with Paseo validator nodes to produce blocks. You can specify the ports with the `--port` command-line option. You can start the collator with a command similar to the following (ensure you replace <YOUR_ID> with the "id" you used in the plain_chain_spec.json file:
+You must have the ports for the collator publicly accessible and discoverable to enable parachain nodes to peer with Paseo validator nodes to produce blocks. You can specify the ports with the `--port` command-line option. You can start the collator with a command similar to the following (ensure you replace `INSERT_ID` with the `"id"` you used in the `plain_chain_spec.json` file:
 
 ```bash
 polkadot-omni-node --collator \

--- a/parachains/launch-a-parachain/deploy-to-polkadot.md
+++ b/parachains/launch-a-parachain/deploy-to-polkadot.md
@@ -218,7 +218,7 @@ polkadot-omni-node --collator \
 --port 40333 \
 --rpc-port 8845 \
 --force-authoring \
---node-key-file ./data/chains/<YOUR_ID>/network/secret_ed25519 \
+--node-key-file ./data/chains/INSERT_ID/network/secret_ed25519 \
 -- \
 --sync warp \
 --chain paseo \


### PR DESCRIPTION
## 📝 Description

Updated the command example for starting the collator to include a placeholder for the "id". This ensures the path is properly created and detected, helping prevent routing and initialisation errors when running the command.

### Error if the user doesn't use their "id" in the command:
<img width="1440" height="900" alt="Screenshot 2026-05-31 at 22 15 54" src="https://github.com/user-attachments/assets/81fe25c0-3be2-4a03-97fd-a4d92ef7f152" />

### Test to confirm that the command that starts the collator needs the "id"
<img width="1440" height="900" alt="Screenshot 2026-05-31 at 22 39 58" src="https://github.com/user-attachments/assets/4802fffa-d2c0-4b61-b180-cbb865cd0e05" />
You'd see in the screenshot above that, even though the parachain name is Ethereum, the collator still starts since I used the id name in the path. This is because the Polkadot Omni node uses the "id" to create the base path for storing the node key.


## 🔍 Review Preference

Choose one:
- [x] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
