### PR TITLE
docs(create-a-pallet): update tutorial on how new crates are added to the workspace

### DIFF
--- a/.snippets/code/parachains/customize-runtime/pallet-development/create-a-pallet/Cargo.toml
+++ b/.snippets/code/parachains/customize-runtime/pallet-development/create-a-pallet/Cargo.toml
@@ -25,9 +25,7 @@
         "frame/std",
     ]
 
-    [workspace.members]
-    members = [
-        "node",
-        "pallets/*",
-        "runtime",
-    ]
+    [workspace]
+    default-members = ["pallets/template", "runtime"]
+    members = ["node", "pallets/pallet-custom", "pallets/template", "runtime"]
+    resolver = "2"

--- a/parachains/customize-runtime/pallet-development/create-a-pallet.md
+++ b/parachains/customize-runtime/pallet-development/create-a-pallet.md
@@ -90,10 +90,10 @@ To integrate your custom pallet into the Polkadot SDK-based runtime, configure t
     !!!note "Version Management"
         The parachain template uses workspace inheritance to maintain consistent dependency versions across all packages. The actual versions are defined in the root `Cargo.toml` file, ensuring compatibility throughout the project. By using `workspace = true`, your pallet automatically inherits the correct versions.
 
-2. The parachain template already includes `pallets/*` in the workspace members, so your new pallet is automatically recognized. Verify this by checking the root `Cargo.toml`:
+2. `pallets/pallet-custom` has already been automatically included in the workspace members of the parachain template, so your new pallet is automatically recognized. Verify this by checking the root `Cargo.toml`:
 
     ```toml title="Cargo.toml"
-    --8<-- 'code/parachains/customize-runtime/pallet-development/create-a-pallet/Cargo.toml:28:33'
+    --8<-- 'code/parachains/customize-runtime/pallet-development/create-a-pallet/Cargo.toml:28:31'
     ```
 
 ## Initialize the Pallet Structure


### PR DESCRIPTION

## 📝 Description
This updates the tutorial to show that cargo automatically adds new crates as members of the workspace using their actual path, not a wildcard.
<img width="1440" height="900" alt="Screenshot 2026-06-07 at 10 50 53" src="https://github.com/user-attachments/assets/133edc9b-fd7b-499f-953d-6a6dccc53d61" />



## 🔍 Review Preference

Choose one:
- [x] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
