### PR TITLE
Update contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@
       - [Adding Images](#adding-images)
       - [Using Code Snippets](#using-code-snippets)
       - [Adding Callout Boxes](#adding-callout-boxes)
+- [Frontmatter Reference](#frontmatter-reference)
 
 ## Quick Start
 
@@ -112,7 +113,7 @@ To add a page to an existing section:
 
 1. Create your markdown file following [naming conventions](https://github.com/papermoonio/documentation-style-guide/blob/main/style-guide.md#naming-conventions).
 
-2. Include required frontmatter:
+2. Include required frontmatter (see [Frontmatter Reference](#frontmatter-reference) for all available fields):
 
    ```markdown
    ---
@@ -134,7 +135,7 @@ To add a page to an existing section:
 
    **Categories**
 
-   Available categories for pages are found in [scripts/llms_config.json](./scripts/llms_config.json).
+   Available categories for pages are listed in the `categories_info` section of `llms_config.json` in the `polkadot-mkdocs` repository.
 
    **Search Engine Optimization (SEO)**
 
@@ -166,24 +167,17 @@ To create an entirely new section of documentation:
    ```yaml
    title: Section Display Name
    nav: 
-     - index.md
+     - 'Overview': index.md
      - 'Page Display Name': 'file-name.md'
      - subdirectory-name
    ```
    
    - **`title`**: Displayed in left navigation
-   - **`index.md`**: Always first in nav list
+   - **`index.md`**: Always first in nav list (if exists)
    - **Files**: `'Display Name': 'file-name.md'`
    - **Subdirectories**: Listed by directory name
 
 3. Create the `index.md` landing page with frontmatter and content introducing the section.
-   
-   - In the `index.md` add the following snippet to display what content is available in the section:
-   ```markdown
-   ## In This Section
-
-   :::INSERT_IN_THIS_SECTION:::
-   ```
 
 ## Write a Tutorial
 
@@ -191,56 +185,49 @@ This section covers tutorial-specific requirements and formatting.
 
 **Requirement**: Follow the [PaperMoon Documentation Style Guide](https://github.com/papermoonio/documentation-style-guide).
 
-### Choose Your Tutorial Section
-```
-tutorials/
-├── dapps/              # Application development guides
-├── interoperability/   # XCM, cross-chain operations
-├── onchain-governance/ # Governance operations
-├── polkadot-sdk/       # SDK-based development
-└── smart-contracts/    # Smart contract development
-```
-
-### Set Up Directory Structure
+Place your tutorial under the most relevant existing section of the docs. Set up file and asset paths to match the surrounding structure:
 
 ```
-tutorials/<section>/<subsection>/<tutorial-name>.md
-images/tutorials/<section>/<subsection>/<tutorial-name>/
-.snippets/code/tutorials/<section>/<subsection>/<tutorial-name>/
+<section>/<subsection>/<tutorial-name>.md
+images/<section>/<subsection>/<tutorial-name>/
+.snippets/code/<section>/<subsection>/<tutorial-name>/
 ```
 
-### Use the Tutorial Template
+### Tutorial Template
 
 ```markdown
 ---
 title: Tutorial Title (max 60 chars)
 description: Description 120-160 chars.
-tutorial_badge: Beginner | Intermediate | Advanced
 categories: Category1, Category2
+page_badges:
+  tutorial_badge: Beginner | Intermediate | Advanced
 ---
 
 # Tutorial Title
 
 ## Introduction
 
-Brief explanation of what users will learn/build
+Brief explanation of what users will learn/build.
 
 ## Prerequisites
 
-Required knowledge/tools
+Required knowledge/tools.
 
 ## [Action-Oriented Section Title]
 
-Instructions with commands
+Instructions with commands.
 
 ## Verification
 
-How to confirm it worked
+How to confirm it worked.
 
 ## Where to Go Next
 
-Related tutorials
+Related tutorials.
 ```
+
+See [Frontmatter Reference](#frontmatter-reference) for a full list of available frontmatter fields.
 
 ### Tutorial Requirements
 
@@ -264,7 +251,7 @@ Related tutorials
 **How to use**:
 
 ```markdown
-![Alt text description](/docs/images/<subdirectory>/<image-file-name>.webp)
+![Alt text description](/images/<subdirectory>/<image-file-name>.webp)
 ```
 
 **Adding annotations**:
@@ -295,13 +282,13 @@ Learn more about [snippets syntax](https://facelessuser.github.io/pymdown-extens
 Use these to highlight important information:
 
 ```markdown
-!!!tip
+!!! tip
     Helpful tips and shortcuts.
 
-!!!note
+!!! note
     Important information to remember.
 
-!!!warning
+!!! warning
     Potential issues or caveats.
 ```
 
@@ -320,4 +307,65 @@ Use these to highlight important information:
     <span data-ty>Output line 1</span>
     <span data-ty>Output line 2</span>
 </div>
+```
+
+## Frontmatter Reference
+
+Every page begins with a YAML frontmatter block between `---` delimiters. The fields below are all supported options.
+
+### Required fields
+
+| Field | Description |
+|---|---|
+| `title` | Page title. Keep to 60 characters or fewer for good SEO. |
+| `description` | Meta description shown in search results. Aim for 120–160 characters. |
+| `categories` | Comma-separated list of content categories used to group AI artifacts. Valid values are defined in `llms_config.json`. |
+
+### Optional fields
+
+| Field | Type | Description |
+|---|---|---|
+| `short_description` | string | A shorter description used in auto-generated index tables (falls back to `description` if absent). |
+| `tools` | string or list | Tools used on the page, shown in index tables. Accepts a comma-separated string or a YAML list. |
+| `hide` | list | Hides page elements. Accepted values: `navigation` (hides left nav), `toc` (hides table of contents). |
+| `template` | string | Overrides the page template. Only used on the homepage (`home.html`). |
+| `footer_nav` | bool or int | Adds the page to the footer navigation. Use `true` to include in discovery order, or an integer for explicit ordering (lower numbers appear first). |
+| `extra_javascript` | list | Additional JavaScript files to load on this page only. Used to activate interactive widgets. |
+| `extra_css` | list | Additional CSS files to load on this page only. Used alongside `extra_javascript` for interactive widgets. |
+| `page_badges` | object | Displays difficulty and CI status badges in the page header. See [`page_badges`](#page_badges) below. |
+| `page_tests` | object | Links a test file to the page, shown as a "View tests" link. See [`page_tests`](#page_tests) below. |
+| `toggle` | object | Groups pages into a switchable variant toggle (e.g. EVM vs PVM). See [`toggle`](#toggle) below. |
+
+### `page_badges`
+
+Displays badge labels in the page header.
+
+```yaml
+page_badges:
+  tutorial_badge: Beginner   # or Intermediate, Advanced
+  test_workflow: workflow-name  # filename of the GitHub Actions workflow (without .yml)
+```
+
+- `tutorial_badge` — renders a difficulty badge: `Beginner`, `Intermediate`, `Advanced`. Also used by index tables for the Difficulty column.
+- `test_workflow` — links to a GitHub Actions status badge for the named workflow. Workflows must exist in the [`polkadot-developers/polkadot-cookbook`](https://github.com/polkadot-developers/polkadot-cookbook) repository under `.github/workflows/`.
+
+### `page_tests`
+
+Links a test file to the page, displayed as a "View tests" link in the page header. The `path` is relative to the root of the [`polkadot-developers/polkadot-cookbook`](https://github.com/polkadot-developers/polkadot-cookbook) repository.
+
+```yaml
+page_tests:
+  path: polkadot-docs/path/to/tests/docs.test.ts
+```
+
+### `toggle`
+
+Powers the page toggle feature, which groups related pages and lets readers switch between variants (e.g. EVM vs PVM) without leaving the section. All pages in a group must share the same `group` value.
+
+```yaml
+toggle:
+  group: my-group-name     # shared identifier across all pages in the toggle
+  variant: evm             # this page's variant identifier
+  label: EVM               # label shown on the toggle button
+  canonical: true          # mark one page as canonical (the default shown in nav)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -315,26 +315,26 @@ Every page begins with a YAML frontmatter block between `---` delimiters. The fi
 
 ### Required fields
 
-| Field | Description |
-|---|---|
-| `title` | Page title. Keep to 60 characters or fewer for good SEO. |
-| `description` | Meta description shown in search results. Aim for 120–160 characters. |
-| `categories` | Comma-separated list of content categories used to group AI artifacts. Valid values are defined in `llms_config.json`. |
+| Field         | Description                                                                                                            |
+|---------------|------------------------------------------------------------------------------------------------------------------------|
+| `title`       | Page title. Keep to 60 characters or fewer for good SEO.                                                               |
+| `description` | Meta description shown in search results. Aim for 120–160 characters.                                                  |
+| `categories`  | Comma-separated list of content categories used to group AI artifacts. Valid values are defined in `llms_config.json`. |
 
 ### Optional fields
 
-| Field | Type | Description |
-|---|---|---|
-| `short_description` | string | A shorter description used in auto-generated index tables (falls back to `description` if absent). |
-| `tools` | string or list | Tools used on the page, shown in index tables. Accepts a comma-separated string or a YAML list. |
-| `hide` | list | Hides page elements. Accepted values: `navigation` (hides left nav), `toc` (hides table of contents). |
-| `template` | string | Overrides the page template. Only used on the homepage (`home.html`). |
-| `footer_nav` | bool or int | Adds the page to the footer navigation. Use `true` to include in discovery order, or an integer for explicit ordering (lower numbers appear first). |
-| `extra_javascript` | list | Additional JavaScript files to load on this page only. Used to activate interactive widgets. |
-| `extra_css` | list | Additional CSS files to load on this page only. Used alongside `extra_javascript` for interactive widgets. |
-| `page_badges` | object | Displays difficulty and CI status badges in the page header. See [`page_badges`](#page_badges) below. |
-| `page_tests` | object | Links a test file to the page, shown as a "View tests" link. See [`page_tests`](#page_tests) below. |
-| `toggle` | object | Groups pages into a switchable variant toggle (e.g. EVM vs PVM). See [`toggle`](#toggle) below. |
+| Field               | Type           | Description                                                                                                                                         |
+|---------------------|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `short_description` | string         | A shorter description used in auto-generated index tables (falls back to `description` if absent).                                                  |
+| `tools`             | string or list | Tools used on the page, shown in index tables. Accepts a comma-separated string or a YAML list.                                                     |
+| `hide`              | list           | Hides page elements. Accepted values: `navigation` (hides left nav), `toc` (hides table of contents).                                               |
+| `template`          | string         | Overrides the page template. Only used on the homepage (`home.html`).                                                                               |
+| `footer_nav`        | bool or int    | Adds the page to the footer navigation. Use `true` to include in discovery order, or an integer for explicit ordering (lower numbers appear first). |
+| `extra_javascript`  | list           | Additional JavaScript files to load on this page only. Used to activate interactive widgets.                                                        |
+| `extra_css`         | list           | Additional CSS files to load on this page only. Used alongside `extra_javascript` for interactive widgets.                                          |
+| `page_badges`       | object         | Displays difficulty and CI status badges in the page header. See [`page_badges`](#page_badges) below.                                               |
+| `page_tests`        | object         | Links a test file to the page, shown as a "View tests" link. See [`page_tests`](#page_tests) below.                                                 |
+| `toggle`            | object         | Groups pages into a switchable variant toggle (e.g. EVM vs PVM). See [`toggle`](#toggle) below.                                                     |
 
 ### `page_badges`
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To work on the docs again:
 
 ## Contributing
 
-See [.CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute to this repository.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute to this repository.
 
 We're excited to have you contribute to the Polkadot docs and help improve our ecosystem! 🚀 Every contribution, whether it's fixing a typo, improving documentation, or adding new content, helps make Polkadot more accessible to developers worldwide. Thank you for being part of our community! 🙏✨
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To set up the structure, follow these steps:
     cd polkadot-mkdocs
     git clone https://github.com/polkadot-developers/polkadot-docs.git
     ```
-    > **📋 Contributing?** If you plan to [contribute](./CONTRIBUTING.md) to the documentation, fork the `polkadot-docs` repository first and clone your fork instead:
+    > **📋 Contributing?** If you plan to [contribute](CONTRIBUTING.md) to the documentation, fork the `polkadot-docs` repository first and clone your fork instead:
     > ```bash
     > git clone https://github.com/YOUR_USERNAME/polkadot-docs.git
     > ```
@@ -91,7 +91,7 @@ To work on the docs again:
 
 ## Contributing
 
-See [.CONTRIBUTING.md](./CONTRIBUTING.md) for how to contribute to this repository.
+See [.CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute to this repository.
 
 We're excited to have you contribute to the Polkadot docs and help improve our ecosystem! 🚀 Every contribution, whether it's fixing a typo, improving documentation, or adding new content, helps make Polkadot more accessible to developers worldwide. Thank you for being part of our community! 🙏✨
 

--- a/reference/polkadot-hub/consensus-and-security/agile-coretime.md
+++ b/reference/polkadot-hub/consensus-and-security/agile-coretime.md
@@ -25,7 +25,7 @@ In this guide, you'll learn how bulk coretime enables continuous core access wit
 
 ## Bulk Coretime
 
-Bulk coretime is a fixed duration of continuous coretime represented by an NFT that can be purchased through coretime sales in DOT and can be split, shared, or resold. Currently, the duration of bulk coretime is set to 28 days. Coretime purchased in bulk and assigned to a single parachain is eligible for a price-capped renewal, providing a form of rent-controlled access, which is important for predicting the running costs in the near future. Suppose the bulk coretime is [interlaced](#coretime-interlacing) or [split](#coretime-splitting) or is kept idle without assigning it to a parachain. In that case, it will be ineligible for the price-capped renewal.
+Bulk coretime is a fixed duration of continuous coretime represented by an NFT that can be purchased through [coretime sales](https://wiki.polkadot.com/learn/learn-agile-coretime/#coretime-sales){target=_blank} in DOT and can be split, shared, or resold. Currently, the duration of bulk coretime is set to 28 days. Coretime purchased in bulk and assigned to a single parachain is eligible for a price-capped renewal, providing a form of rent-controlled access, which is important for predicting the running costs in the near future. Suppose the bulk coretime is [interlaced](#coretime-interlacing) or [split](#coretime-splitting) or is kept idle without assigning it to a parachain. In that case, it will be ineligible for the price-capped renewal.
 
 ### Coretime Interlacing
 

--- a/reference/polkadot-hub/consensus-and-security/agile-coretime.md
+++ b/reference/polkadot-hub/consensus-and-security/agile-coretime.md
@@ -25,7 +25,7 @@ In this guide, you'll learn how bulk coretime enables continuous core access wit
 
 ## Bulk Coretime
 
-Bulk coretime is a fixed duration of continuous coretime represented by an NFT that can be purchased through [coretime sales](#coretime-sales) in DOT and can be split, shared, or resold. Currently, the duration of bulk coretime is set to 28 days. Coretime purchased in bulk and assigned to a single parachain is eligible for a price-capped renewal, providing a form of rent-controlled access, which is important for predicting the running costs in the near future. Suppose the bulk coretime is [interlaced](#coretime-interlacing) or [split](#coretime-splitting) or is kept idle without assigning it to a parachain. In that case, it will be ineligible for the price-capped renewal.
+Bulk coretime is a fixed duration of continuous coretime represented by an NFT that can be purchased through coretime sales in DOT and can be split, shared, or resold. Currently, the duration of bulk coretime is set to 28 days. Coretime purchased in bulk and assigned to a single parachain is eligible for a price-capped renewal, providing a form of rent-controlled access, which is important for predicting the running costs in the near future. Suppose the bulk coretime is [interlaced](#coretime-interlacing) or [split](#coretime-splitting) or is kept idle without assigning it to a parachain. In that case, it will be ineligible for the price-capped renewal.
 
 ### Coretime Interlacing
 


### PR DESCRIPTION
## 📝 Description

This pull request updates the documentation contribution guidelines and related references to improve clarity, accuracy, and usability for contributors. The most significant changes include a comprehensive rewrite and expansion of the `CONTRIBUTING.md` file (renamed from `.CONTRIBUTING.md`), the addition of a detailed frontmatter reference section, and minor corrections to file paths and links in other documentation files.

**Documentation Guidelines and Structure Updates:**

* `.CONTRIBUTING.md` was renamed to `CONTRIBUTING.md`, and the file was extensively rewritten for clarity and completeness. It now includes improved instructions for adding pages, tutorials, and sections, and clarifies file and directory structure conventions. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R18) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L115-R116) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L137-R138) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L169-R231) [[5]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L267-R254) [[6]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R311-R371)

**Frontmatter Reference Addition:**

* A new "Frontmatter Reference" section was added to `CONTRIBUTING.md`, providing a clear table of all required and optional YAML frontmatter fields, their descriptions, and usage examples for fields like `page_badges`, `page_tests`, and `toggle`. This helps contributors correctly format metadata for new documentation pages. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R18) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R311-R371)

**Link and Path Corrections:**

* Updated references to the contributing guide in `README.md` to point to the correct `CONTRIBUTING.md` file (removing unnecessary path prefixes and updating the filename after the rename). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R94)
* Fixed image path examples to remove the `/docs/` prefix, reflecting the actual directory structure.

**Content Clarification:**

* Clarified where to find the list of valid categories for pages, now pointing to the `categories_info` section of `llms_config.json` in the `polkadot-mkdocs` repository.
* Minor edit for clarity in the description of bulk coretime in `agile-coretime.md`.

---

### Goes with https://github.com/papermoonio/polkadot-mkdocs/pull/276