### PR TITLE
fix: polkadot app and polkadot desktop official download links

### DIFF
--- a/apps/get-started/index.md
+++ b/apps/get-started/index.md
@@ -29,7 +29,7 @@ Before getting started, ensure you have:
 
 ## Install Polkadot Desktop
 
-1. Download the development build of Polkadot Desktop (official distribution link pending).
+1. Download the development build of [Polkadot Desktop](TODO: add polkadot desktop download link here).
 
 2. Install the application using your platform's standard installer.
 

--- a/apps/index.md
+++ b/apps/index.md
@@ -11,11 +11,8 @@ categories: Apps
 The Polkadot App is your wallet, identity, and signer: the center of everything you build. Install it first; every path below connects through it.
 
 <div class="button-wrapper" markdown>
-[:material-apple: App Store](#){ .md-button }   [:material-google-play: Google Play](#){ .md-button }
+[:material-apple: App Store](TODO: add polkadot app app store (IOS) link here){ .md-button }   [:material-google-play: Google Play](TODO: add polkadot app google play (Android) link here){ .md-button }
 </div>
-
-!!! warning "Provisional"
-    Store links are pending the public release of the Polkadot App. Open the App and follow the on-screen instructions to create your account, which becomes your developer identity for Polkadot Products.
 
 ## Then Pick Your Path
 


### PR DESCRIPTION
## 📝 Description

This pull request updates documentation to prepare for the inclusion of official download links for Polkadot Desktop and the Polkadot App. The changes clarify where users will eventually find these links and remove outdated warnings.

**Documentation updates for download links:**

* Updated the instructions in `apps/get-started/index.md` to reference a placeholder for the official Polkadot Desktop download link, indicating where the link will be added once available.
* Updated the button links in `apps/index.md` for the App Store (iOS) and Google Play (Android) to use placeholders, clarifying that the official links will be added in the future.

**Removal of outdated warnings:**

* Removed the warning about pending store links in `apps/index.md`, streamlining the documentation and reducing confusion for users.

## 🔍 Review Preference

Choose one:
- [ ] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [ ] Changes tested  
- [ ] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
