### PR TITLE
Update dependencies in variables.yml

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -15,8 +15,8 @@ dependencies:
       docker_image_version: 1.93.0
     polkadot_sdk:
       repository_url: https://github.com/paritytech/polkadot-sdk
-      version: polkadot-stable2603
-      docker_image_version: stable2603
+      version: polkadot-stable2603-1
+      docker_image_version: stable2603-1
     open_zeppelin_contracts:
       repository_url: https://github.com/OpenZeppelin/openzeppelin-contracts
       version: v5.6.1
@@ -41,24 +41,24 @@ dependencies:
   crates:
     subxt:
       name: subxt
-      version: 0.50.0
+      version: 0.50.1
     subxt_cli:
       name: subxt-cli
-      version: 0.50.0
+      version: 0.50.1
     subxt_signer:
       name: subxt-signer
-      version: 0.50.0
+      version: 0.50.1
     tokio:
       name: tokio
       version: 1.44.2
       ignore_updates: true
     polkadot_omni_node:
       name: polkadot-omni-node
-      version: 0.14.0
+      version: 0.15.0
   javascript_packages:
     chopsticks:
       name: '@acala-network/chopsticks'
-      version: 1.3.0
+      version: 1.3.1
     moonwall:
       name: '@moonwall/cli'
       version: 5.18.3
@@ -67,16 +67,16 @@ dependencies:
       version: 16.5.6
     polkadot_api:
       name: polkadot-api
-      version: 2.0.1
+      version: 2.1.0
     resolc:
       name: '@parity/resolc'
-      version: 1.1.0
+      version: 1.2.0
     hardhat_polkadot:
       name: '@parity/hardhat-polkadot'
-      version: 0.2.7
+      version: 0.3.0
     solc:
       name: 'solc'
-      version: 0.8.34
+      version: 0.8.35
     web3_js:
       name: '@web3js'
       version: 4.16.0
@@ -88,13 +88,13 @@ dependencies:
       version: 6.16.0
     paraspell_sdk:
       name: '@paraspell/sdk'
-      version: 13.2.2
+      version: 13.4.0
     hdkd:
       name: '@polkadot-labs/hdkd'
       version: 0.0.28
     hdkd_helpers:
       name: '@polkadot-labs/hdkd-helpers'
-      version: 0.0.29
+      version: 0.0.30
     polkadot_util:
       name: '@polkadot/util'
       version: 14.0.3


### PR DESCRIPTION
## Summary

Bumps 12 dependencies flagged by the `check-dependencies` bot, in the central `variables.yml`.

**Repositories:**
- `polkadot_sdk`: `polkadot-stable2603` → `polkadot-stable2603-1` (Docker: `stable2603` → `stable2603-1`)

**Crates:**
- `subxt` / `subxt_cli` / `subxt_signer`: `0.50.0` → `0.50.1`
- `polkadot_omni_node`: `0.14.0` → `0.15.0`

**JavaScript packages:**
- `chopsticks`: `1.3.0` → `1.3.1`
- `polkadot_api`: `2.0.1` → `2.1.0`
- `resolc`: `1.1.0` → `1.2.0`
- `hardhat_polkadot`: `0.2.7` → `0.3.0`
- `solc`: `0.8.34` → `0.8.35`
- `paraspell_sdk`: `13.2.2` → `13.4.0`
- `hdkd_helpers`: `0.0.29` → `0.0.30`

## Snippet line-number check

The embedded polkadot_sdk snippets — `single-block-migrations/src/lib.rs`, `migrations/v1.rs` (storage-migrations.md) and `revive/src/precompiles/builtin/bn128.rs` (eth-native.md) — are **byte-identical** between `polkadot-stable2603` and `polkadot-stable2603-1`, so no snippet line ranges needed adjusting.

## Companion PR

Test harnesses are synced in polkadot-developers/polkadot-cookbook#298. Live tutorial/recipe tests run there via the `versions.yml` CI triggers.

## Test plan
- [x] All target versions verified to exist (npm / crates.io / GitHub tag, HTTP 200)
- [x] `polkadot-stable2603-1` relay binaries (`polkadot`, `*-worker`, `polkadot-parachain`) resolve
- [x] Embedded snippet files unchanged between tags (no line drift)
- [x] `variables.yml` parses as valid YAML
- [ ] CI docs build + link checker (run on PR)

## Not actioned — pinned to template lockfile (close as not-applicable)

#1667, #1668, #1669, #1670 — `polkadot_sdk_parachain_template` subdependencies are pinned to template **v0.0.5**'s `Cargo.lock` and only change when the template version bumps (see comment in `variables.yml`).

Closes #1656, closes #1657, closes #1658, closes #1660, closes #1661, closes #1662, closes #1663, closes #1665, closes #1666, closes #1671, closes #1672, closes #1693