### PR TITLE
Remove cookie consent 

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1337,26 +1337,8 @@ a.tests-button {
   border-top-right-radius: var(--rounded);
 }
 
-/* --- Cookie consent --- */
-.md-typeset .md-consent__controls .md-button {
-  width: fit-content;
-}
-
 .md-typeset .task-list-indicator:before {
   background-color: var(--color-border-strong);
-}
-
-.md-typeset.md-consent__form h4 {
-  font-size: 0.9rem;
-}
-
-/* Show cookie consent on top of Kapa widget */
-.md-consent__overlay {
-  z-index: 200;
-}
-
-.md-consent__inner {
-  z-index: 201;
 }
 
 /* --- Toast / dialog --- */

--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -1337,10 +1337,6 @@ a.tests-button {
   border-top-right-radius: var(--rounded);
 }
 
-.md-typeset .task-list-indicator:before {
-  background-color: var(--color-border-strong);
-}
-
 /* --- Toast / dialog --- */
 /* Material's .md-dialog defaults to z-index:4, which sits behind the
    fixed footer (z-index:100).  Bump it above the footer so toasts are

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,14 +184,6 @@ extra:
   glossary_tooltips:
     exclude_terms:
       - Polkadot
-  consent:
-    title: Cookie Consent
-    description: >-
-      We use cookies to recognize your repeated visits and preferences, as well as to measure the effectiveness of our documentation.
-      By consenting to the use of cookies, you help us improve the site. Review the <a href="https://docs.polkadot.com/policies/cookie-policy/" target="_blank" rel="noopener">cookie policy</a> for more information.
-    actions:
-      - accept
-      - manage
   generator: False
   social:
     - icon: fontawesome/brands/discord


### PR DESCRIPTION
## 📝 Description

This pull request removes all code and configuration related to the cookie consent feature from the project. The most important changes are:

**Removal of cookie consent feature:**

* Deleted all CSS rules in `polkadot.css` related to the styling and z-index of the cookie consent UI, including `.md-consent__controls`, `.md-consent__form`, `.md-consent__overlay`, and `.md-consent__inner`.
* Removed the entire `consent` configuration block from `mkdocs.yml`, which included the cookie consent title, description, and actions.

## 🔍 Review Preference

Choose one:
- [x] ✅ I have time to handle formatting/style feedback myself 
- [ ] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [x] Changes tested  
- [x] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
