### PR TITLE
chore: disable MCP install section on AI resources page

### DIFF
--- a/llms_config.json
+++ b/llms_config.json
@@ -6,8 +6,8 @@
     "name": "Polkadot",
     "project_url": "https://polkadot.network/",
     "docs_base_url": "https://docs.polkadot.com/",
-    "mcp_name": "polkadot-docs",
-    "mcp_url": "https://docs-mcp.polkadot.com"
+    "_mcp_name": "polkadot-docs",
+    "_mcp_url": "https://docs-mcp.polkadot.com"
   },
 
   "repository": {


### PR DESCRIPTION
## Summary

- Disables the MCP install section (Cursor / VS Code / Claude Desktop / Codex install buttons) on the `/ai-resources/` page by renaming `mcp_name` → `_mcp_name` and `mcp_url` → `_mcp_url` in `llms_config.json`.
- The `ai_docs` plugin gates the section on both keys being present (`plugin.py:223`), so this short-circuits the render without code changes.

## Re-enable

Rename `_mcp_name` and `_mcp_url` back to `mcp_name` and `mcp_url`.

## Test plan

- [ ] Local build (`mkdocs serve`) — confirm `/ai-resources/` no longer shows the MCP install buttons
- [ ] Confirm the rest of the AI resources page (downloads, category bundles) still renders