### PR TITLE
Remove the stale Web3 Summit announcement banner

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -34,9 +34,10 @@
   {%- endif -%} 
 {%- endblock -%}
 
-<!-- {% block announce %}
-  <strong>Web3 Summit 2026</strong> | A Festival for Digital Freedom | Funkhaus Berlin June 18-19th | <a href="https://web3summit.com/" target="_blank">https://web3summit.com/</a>
-{% endblock %} -->
+{# Announcement banner. Add content inside the block to show it; leave it
+   empty for no banner. (Wrapping the block in an HTML comment does NOT hide
+   it — Jinja still processes the block tag.) #}
+{% block announce %}{% endblock %}
 
 {% block libs %}
   {{ super() }}


### PR DESCRIPTION
The Web3 Summit 2026 banner is still rendering even though the `announce`
block in `material-overrides/main.html` was wrapped in an HTML comment.

That has no effect: Jinja processes `{% block %}` regardless of HTML
comments, so the child template still overrides the `announce` slot and
Material renders the banner. (Verified with a local build of the
commented-out version — the banner is still in the output.)

Fix: empty the block (`{% block announce %}{% endblock %}`) instead of
HTML-commenting it. Verified the built homepage no longer contains the banner.