### PR TITLE
Remove dead chain-snapshot link from validator requirements

### DIFF
--- a/docs/node-infrastructure/run-a-validator/requirements.md
+++ b/docs/node-infrastructure/run-a-validator/requirements.md
@@ -41,7 +41,7 @@ Polkadot validators rely on high-performance hardware to process blocks efficien
 - Storage:
 
     - **NVMe SSD**: At least 2 TB for blockchain data recommended (prioritize latency rather than throughput).
-    - Storage requirements will increase as the chain grows. For current estimates, see the [current chain snapshot](https://stakeworld.github.io/docs/dbsize){target=\_blank}.
+    - Storage requirements will increase as the chain grows.
 
 - Memory:
 


### PR DESCRIPTION
The `stakeworld.github.io/docs/dbsize` link in the validator storage requirements is offline (404). StakeWorld moved to `stakeworld.io`, but the database-sizes page wasn't carried over (the site is an SPA that returns 200 for any path, so a link there would falsely pass the checker while showing an empty page). The link is a supplementary "for current estimates" pointer; the storage guidance is complete without it, so this removes it.