### PR TITLE
Add JSON-LD structured data to docs pages

### DIFF
--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -61,16 +61,21 @@
       "@type": jsonld_type,
       "headline": page_title | default(config.site_name, true),
       "name": page_title | default(config.site_name, true),
-      "url": canonical_url,
       "description": page_description | default('', true),
       "inLanguage": "en-US",
       "isPartOf": {
         "@type": "WebSite",
-        "name": config.site_name | default('Documentation', true),
-        "url": config.site_url | default('', true)
+        "name": config.site_name | default('Documentation', true)
       }
     } %}
-    
+
+    {% if canonical_url %}
+      {% set _ = jsonld_data.update({"url": canonical_url}) %}
+    {% endif %}
+    {% if config.site_url %}
+      {% set _ = jsonld_data["isPartOf"].update({"url": config.site_url}) %}
+    {% endif %}
+
     {# Add publication date if available #}
     {% if page.meta and page.meta.date %}
       {% set _ = jsonld_data.update({"datePublished": page.meta.date}) %}

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -24,15 +24,82 @@
   {%- endif -%} 
 {%- endblock -%}
 
-{# --- BLOCK TO INJECT JSON-LD --- #}
+{# --- JSON-LD EXTRAHEAD IMPLEMENTATION --- #}
 {% block extrahead %}
-  {{ super() }} {# Preserve any existing content in the extrahead block #}
+  {{ super() }}
   
-  {# Check if a JSON-LD object exists in the page's front matter #}
-  {% if page and page.meta and page.meta.jsonld %}
-    {# Assume page.meta.jsonld contains a valid JSON-LD object (e.g., a dict) #}
+  {# Generate JSON-LD from context with per-page overrides #}
+  {% if page %}
+    {# Set default values from context #}
+    {% set page_title = page.meta.title if page.meta and page.meta.title else page.title %}
+    {% set page_description = page.meta.description if page.meta and page.meta.description else config.site_description %}
+    
+    {# Construct canonical URL #}
+    {% if page.canonical_url %}
+      {% set canonical_url = page.canonical_url %}
+    {% else %}
+      {# Build canonical URL from config and page path #}
+      {% set base_url = config.site_url | default('', true) %}
+      {% if base_url %}
+        {% set page_path = page.url | default('', true) %}
+        {% set canonical_url = base_url.rstrip('/') + '/' + page_path.lstrip('/') %}
+      {% else %}
+        {% set canonical_url = '' %}
+      {% endif %}
+    {% endif %}
+    
+    {# Determine JSON-LD type - allow override via frontmatter #}
+    {% if page.meta and page.meta.jsonld_type %}
+      {% set jsonld_type = page.meta.jsonld_type %}
+    {% else %}
+      {% set jsonld_type = "TechArticle" %} {# Default site-wide type #}
+    {% endif %}
+    
+    {# Build base JSON-LD object #}
+    {% set jsonld_data = {
+      "@context": "https://schema.org",
+      "@type": jsonld_type,
+      "headline": page_title | default(config.site_name, true),
+      "name": page_title | default(config.site_name, true),
+      "url": canonical_url,
+      "description": page_description | default('', true),
+      "inLanguage": "en-US",
+      "isPartOf": {
+        "@type": "WebSite",
+        "name": config.site_name | default('Documentation', true),
+        "url": config.site_url | default('', true)
+      }
+    } %}
+    
+    {# Add publication date if available #}
+    {% if page.meta and page.meta.date %}
+      {% set _ = jsonld_data.update({"datePublished": page.meta.date}) %}
+    {% endif %}
+    
+    {# Add modified date from page metadata #}
+    {% if page.meta and page.meta.updated %}
+      {% set _ = jsonld_data.update({"dateModified": page.meta.updated}) %}
+    {% endif %}
+    
+    {# Add author if available #}
+    {% if page.meta and page.meta.author %}
+      {% set _ = jsonld_data.update({"author": {
+        "@type": "Person",
+        "name": page.meta.author
+      }}) %}
+    {% endif %}
+    
+    {# Allow full JSON-LD override via frontmatter #}
+    {% if page.meta and page.meta.jsonld_override %}
+      {# Merge override - the entire object can be replaced or extended #}
+      {% if page.meta.jsonld_override is mapping %}
+        {% set jsonld_data = jsonld_data | combine(page.meta.jsonld_override, recursive=True) %}
+      {% endif %}
+    {% endif %}
+    
+    {# Output the JSON-LD script #}
     <script type="application/ld+json">
-      {{ page.meta.jsonld | tojson }}
+      {{ jsonld_data | tojson }}
     </script>
   {% endif %}
 {% endblock %}

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -59,7 +59,6 @@
     {% set jsonld_data = {
       "@context": "https://schema.org",
       "@type": jsonld_type,
-      "headline": page_title | default(config.site_name, true),
       "name": page_title | default(config.site_name, true),
       "inLanguage": "en-US",
       "isPartOf": {
@@ -76,6 +75,11 @@
     {% endif %}
     {% if config.site_url %}
       {% set _ = jsonld_data["isPartOf"].update({"url": config.site_url}) %}
+    {% endif %}
+
+    {# Add headline only for Article-type schemas, where it is meaningful #}
+    {% if 'Article' in jsonld_type %}
+      {% set _ = jsonld_data.update({"headline": page_title | default(config.site_name, true)}) %}
     {% endif %}
 
     {# Add publication date if available #}

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -98,7 +98,7 @@
     {% if page.meta and page.meta.jsonld_override %}
       {# Merge override - the entire object can be replaced or extended #}
       {% if page.meta.jsonld_override is mapping %}
-        {% set jsonld_data = jsonld_data | combine(page.meta.jsonld_override, recursive=True) %}
+        {% set _ = jsonld_data.update(page.meta.jsonld_override) %}
       {% endif %}
     {% endif %}
     

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -24,6 +24,20 @@
   {%- endif -%} 
 {%- endblock -%}
 
+{# --- BLOCK TO INJECT JSON-LD --- #}
+{% block extrahead %}
+  {{ super() }} {# Preserve any existing content in the extrahead block #}
+  
+  {# Check if a JSON-LD object exists in the page's front matter #}
+  {% if page and page.meta and page.meta.jsonld %}
+    {# Assume page.meta.jsonld contains a valid JSON-LD object (e.g., a dict) #}
+    <script type="application/ld+json">
+      {{ page.meta.jsonld | tojson }}
+    </script>
+  {% endif %}
+{% endblock %}
+{# --------------------------------------- #}
+
 {# Announcement banner. Add content inside the block to show it; leave it
    empty for no banner. (Wrapping the block in an HTML comment does NOT hide
    it — Jinja still processes the block tag.) #}

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -83,8 +83,10 @@
       {% set _ = jsonld_data.update({"datePublished": page.meta.date}) %}
     {% endif %}
     
-    {# Add modified date from page metadata #}
-    {% if page.meta and page.meta.updated %}
+    {# Add modified date, preferring the git revision date the build already computes #}
+    {% if page.meta and page.meta.git_revision_date_localized_raw_iso_datetime %}
+      {% set _ = jsonld_data.update({"dateModified": page.meta.git_revision_date_localized_raw_iso_datetime}) %}
+    {% elif page.meta and page.meta.updated %}
       {% set _ = jsonld_data.update({"dateModified": page.meta.updated}) %}
     {% endif %}
     
@@ -194,4 +196,3 @@
   </article>
 </div>
 {%- endblock -%} 
-

--- a/material-overrides/main.html
+++ b/material-overrides/main.html
@@ -61,7 +61,6 @@
       "@type": jsonld_type,
       "headline": page_title | default(config.site_name, true),
       "name": page_title | default(config.site_name, true),
-      "description": page_description | default('', true),
       "inLanguage": "en-US",
       "isPartOf": {
         "@type": "WebSite",
@@ -71,6 +70,9 @@
 
     {% if canonical_url %}
       {% set _ = jsonld_data.update({"url": canonical_url}) %}
+    {% endif %}
+    {% if page_description %}
+      {% set _ = jsonld_data.update({"description": page_description}) %}
     {% endif %}
     {% if config.site_url %}
       {% set _ = jsonld_data["isPartOf"].update({"url": config.site_url}) %}


### PR DESCRIPTION
## 📝 Description

This PR adds schema.org structured data (JSON-LD) to docs pages. (Solves #1726 , requested by @ReinhardHatko )

Notes:

This change implements a site-wide JSON-LD structure that populates from the template context with per-page override capabilities.

## Implementation details

1. **Automatic Population**: Automatically populates JSON-LD with:
   - Page title (from frontmatter or context)
   - Site name from `config.site_name`
   - Canonical URL (built from `config.site_url` and page path)
   - Page description (from frontmatter or site config)

2. **Default Type**: Uses "TechArticle" as the default schema type site-wide.

3. **Flexible Overrides**:
   - `jsonld_type`: Change the `@type` for specific pages
   - `date` and `updated`: Add temporal metadata
   - `author`: Add author information
   - `jsonld_override`: Full control to override or extend the entire JSON-LD object

4. **Context-Aware**: All values fall back to sensible defaults if not specified, ensuring valid JSON-LD on every page.

5. **Safe Output**: Uses Jinja's `tojson` filter to properly escape JSON, preventing syntax errors.

## Frontmatter Usage Examples

### 1. Basic Page (Uses Default "TechArticle" type)
```markdown
---
title: "Introduction to Polkadot"
description: "Learn about the Polkadot network and its architecture"
---

Your content here...
```

### 2. Override JSON-LD Type
```markdown
---
title: "Tutorial: Building a Parachain"
description: "Step-by-step guide to building your first parachain"
jsonld_type: "HowTo"
---

Your content here...
```

### 3. Add Dates and Author
```markdown
---
title: "Polkadot Architecture Deep Dive"
description: "Understanding the core architecture of Polkadot"
date: "2024-01-15"
updated: "2024-02-20"
author: "Dr. Gavin Wood"
jsonld_type: "ScholarlyArticle"
---

Your content here...
```

### 4. Full JSON-LD Override
```markdown
---
title: "Custom JSON-LD Example"
jsonld_override:
  "@type": "Course"
  "name": "Mastering Substrate"
  "description": "Learn Substrate from the ground up"
  "provider":
    "@type": "Organization"
    "name": "Polkadot Academy"
---

Your content here...
```

---

## 🔍 Review Preference

Choose one:
- [x] ✅ I have time to handle formatting/style feedback myself 
- [x] ⚡ Docs team handles formatting (check "Allow edits from maintainers")  

## ✅ Checklist

- [x] Changes tested  
- [x] [PaperMoon Style Guide](https://github.com/papermoonio/documentation-style-guide) followed
