### PR TITLE
Add animation to Docs Assistant widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target
 Cargo.lock
 .DS_Store
 .scratch/
+site
 
 # Python
 venv

--- a/docs/js/docs-assistant.js
+++ b/docs/js/docs-assistant.js
@@ -192,7 +192,14 @@
     input.value = '';
     sendBtn.disabled = true;
     addUser(q);
-    const thinking = el('div', 'da-msg da-bot da-thinking', '…');
+    const thinking = el('div', 'da-msg da-bot da-thinking');
+    thinking.setAttribute('role', 'status');
+    thinking.setAttribute('aria-label', 'Searching the docs and writing an answer');
+    thinking.innerHTML =
+      '<span class="da-thinking-icon" aria-hidden="true">' +
+      '  <svg viewBox="0 0 24 24" width="16" height="16"><path fill="currentColor" d="M12 2l1.6 4.9a4 4 0 0 0 2.5 2.5L21 11l-4.9 1.6a4 4 0 0 0-2.5 2.5L12 22l-1.6-4.9a4 4 0 0 0-2.5-2.5L3 13l4.9-1.6a4 4 0 0 0 2.5-2.5L12 2z"/></svg>' +
+      '</span>' +
+      '<span class="da-dots" aria-hidden="true"><span></span><span></span><span></span></span>';
     msgs.appendChild(thinking);
     msgs.scrollTop = msgs.scrollHeight;
 

--- a/docs/js/docs-assistant.js
+++ b/docs/js/docs-assistant.js
@@ -219,6 +219,8 @@
       })
       .catch(function () {
         thinking.classList.remove('da-thinking');
+        thinking.removeAttribute('aria-label'); // drop the stale "Searching…" label
+        thinking.setAttribute('role', 'alert');  // announce the error, not the old status
         thinking.textContent = 'The assistant is temporarily unavailable. Please try again in a moment, or browse the docs directly.';
       })
       .then(function () {

--- a/material-overrides/assets/stylesheets/docs-assistant.css
+++ b/material-overrides/assets/stylesheets/docs-assistant.css
@@ -210,8 +210,9 @@ a.da-chip:hover {
 @media (prefers-reduced-motion: reduce) {
   .da-thinking-icon,
   .da-dots span {
-    animation-duration: 0.01ms;
-    animation-iteration-count: 1;
+    animation: none;
+    transform: none;
+    opacity: 1;
   }
 }
 

--- a/material-overrides/assets/stylesheets/docs-assistant.css
+++ b/material-overrides/assets/stylesheets/docs-assistant.css
@@ -167,7 +167,52 @@ a.da-chip:hover {
 }
 
 .da-thinking {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
   color: var(--color-text-secondary);
+}
+
+/* Pulsing, gently spinning spark shows the assistant is actively working. */
+.da-thinking-icon {
+  display: inline-flex;
+  color: var(--accent-default);
+  animation: da-spark 1.6s ease-in-out infinite;
+}
+
+@keyframes da-spark {
+  0%, 100% { transform: rotate(0deg) scale(0.85); opacity: 0.6; }
+  50%      { transform: rotate(180deg) scale(1); opacity: 1; }
+}
+
+/* Three dots rippling to signal "looking and writing an answer". */
+.da-dots {
+  display: inline-flex;
+  gap: 0.22rem;
+}
+
+.da-dots span {
+  width: 0.3rem;
+  height: 0.3rem;
+  border-radius: 50%;
+  background: currentColor;
+  animation: da-bounce 1.2s ease-in-out infinite;
+}
+
+.da-dots span:nth-child(2) { animation-delay: 0.2s; }
+.da-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes da-bounce {
+  0%, 80%, 100% { transform: translateY(0); opacity: 0.4; }
+  40%           { transform: translateY(-0.25rem); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .da-thinking-icon,
+  .da-dots span {
+    animation-duration: 0.01ms;
+    animation-iteration-count: 1;
+  }
 }
 
 .da-input {


### PR DESCRIPTION
This PR updates the "thinking" state of the docs assistant widget so it shows an **animated icon next to the three dots** while the bot is looking up and writing an answer.

**What changed:**

`docs/js/docs-assistant.js` — the placeholder that used to be a static `…` is now a bubble containing:
- an **AI spark icon** (accent-pink) that gently pulses and rotates, and
- **three dots** that ripple in sequence (typing-indicator style).

It also gets `role="status"` and `aria-label="Searching the docs and writing an answer"` so screen readers announce the working state. The error fallback still works (it overwrites the bubble with the text message).

`material-overrides/assets/stylesheets/docs-assistant.css` — added the `da-spark` (icon) and `da-bounce` (dots) keyframe animations, laid the indicator out in a flex row, and included a `prefers-reduced-motion` guard so the animation is disabled for users who opt out.

The icon uses the existing theme variables (`--accent-default`, `--color-text-secondary`), so it follows light/dark mode automatically like the rest of the widget. I verified it renders correctly in the browser.