### PR TITLE
Scroll to the cited section in place from source chips

### DIFF
--- a/docs/js/docs-assistant.js
+++ b/docs/js/docs-assistant.js
@@ -90,6 +90,15 @@
     catch (e) { return null; }
   }
 
+  // true if href points at the page the reader is already on (ignoring hash/trailing slash)
+  function samePage(href) {
+    try {
+      const u = new URL(href, location.href);
+      const strip = function (p) { return p.replace(/\/+$/, ''); };
+      return u.origin === location.origin && strip(u.pathname) === strip(location.pathname);
+    } catch (e) { return false; }
+  }
+
   const btn = el('button', 'da-launcher');
   btn.type = 'button';
   btn.setAttribute('aria-label', 'Open the docs assistant');
@@ -148,13 +157,25 @@
         const pid = (s.ref || '').split('#')[0];
         if (seen[pid]) return;
         seen[pid] = true;
-        const href = s.url && httpUrl(s.url);
+        const anchor = (s.ref || '').split('#')[1] || '';
+        const href = s.url && httpUrl(s.url); // s.url already includes the #section anchor
         let chip;
         if (href) {
           chip = el('a', 'da-chip', s.page_title || s.title || pid);
           chip.href = href;
-          chip.target = '_blank';
           chip.rel = 'noopener';
+          if (samePage(href)) {
+            // already on this page: smooth-scroll to the heading in place, keep the chat open
+            chip.addEventListener('click', function (e) {
+              const target = anchor && document.getElementById(anchor);
+              if (!target) return; // slug not on the page -> let the browser handle the #hash
+              e.preventDefault();
+              if (history.replaceState) history.replaceState(null, '', '#' + anchor);
+              target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            });
+          } else {
+            chip.target = '_blank'; // other page: open the exact section in a new tab (keeps the chat)
+          }
         } else {
           chip = el('span', 'da-chip', s.page_title || s.title || pid);
         }


### PR DESCRIPTION
Makes the source chips navigate smarter:

- **Cited section is on the page you're already reading** → clicking the chip smooth-scrolls to that heading **in place** — no reload, and the chat panel stays open.
- **Cited section is on another page** → opens that page at the exact section in a new tab (so the conversation isn't lost), as before.

The chips already deep-linked to the exact section — the feed's `url` includes the `#anchor` — so this only adds the in-place scroll for same-page sources. Verified the corpus anchors match the live heading ids (spot-checked several pages, 100%).

Not included: reload-free navigation to *other* pages. That needs MkDocs Material's site-wide instant navigation (`navigation.instant`), which changes navigation for the whole site and affects other custom scripts, so it belongs in its own tested change rather than riding along here.
