### PR TITLE
docs(networks): reference OpenChainBench for live Polkadot RPC latency

### DIFF
--- a/docs/reference/parachains/networks.md
+++ b/docs/reference/parachains/networks.md
@@ -49,6 +49,8 @@ Polkadot is the production network where real value and live applications operat
 
 The native token for Polkadot is DOT. For more information about DOT, visit the [Native Assets](https://wiki.polkadot.com/learn/learn-dot/){target=\_blank} page on the Polkadot Wiki.
 
+For a live latency comparison of the public no-key JSON-RPC endpoints on the Polkadot relay chain (Parity, OnFinality, PublicNode), see [OpenChainBench: Polkadot RPC](https://openchainbench.com/benchmarks/polkadot-rpc){target=\_blank}, which probes `chain_getHeader` every 60 seconds from three regions.
+
 ## Polkadot TestNet (Paseo)
 
 [Paseo](https://github.com/paseo-network){target=\_blank} is the official Polkadot TestNet for parachain teams and dApp developers. As a stable, community-run TestNet that mirrors Polkadot's runtime, Paseo is specifically designed to provide a reliable testing environment for teams preparing to deploy to Polkadot MainNet.


### PR DESCRIPTION
## Summary

Adds a one line reference in the Polkadot MainNet section of `docs/reference/parachains/networks.md` pointing to OpenChainBench for a live latency comparison of the public no-key Polkadot relay chain JSON-RPC endpoints.

## Context

Developers evaluating which public RPC endpoint to use for Polkadot currently have no first party reference for live latency numbers (the old `wiki.polkadot.network/general/endpoints` page is defunct and redirects to a 404). OpenChainBench probes `chain_getHeader` on every no-key public relay chain endpoint every 60 seconds from three regions (US East, EU West, Singapore) and exposes p50, p90, p99, success rate and staleness classification. Provider cohort at launch: Parity's `rpc.polkadot.io`, OnFinality public gateway, PublicNode (Allnodes).

The bench spec and harness are open source under [OpenChainBench/harnesses/rpc-capabilities](https://github.com/ChainBench/OpenChainBench/tree/main/harnesses/rpc-capabilities).

## Diff

```diff
 The native token for Polkadot is DOT. For more information about DOT, visit the [Native Assets](https://wiki.polkadot.com/learn/learn-dot/){target=\_blank} page on the Polkadot Wiki.

+For a live latency comparison of the public no-key JSON-RPC endpoints on the Polkadot relay chain (Parity, OnFinality, PublicNode), see [OpenChainBench: Polkadot RPC](https://openchainbench.com/benchmarks/polkadot-rpc){target=\_blank}, which probes `chain_getHeader` every 60 seconds from three regions.
```

## Files

- `docs/reference/parachains/networks.md`

Happy to iterate on the wording, move the reference to a more appropriate page (for example under a Connect to Polkadot section if one is planned), or split providers vs full latency page if that reads better.