### PR TITLE
Update navigation bar (add Tech Reference)

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -5,6 +5,6 @@ nav:
   - 'Parachains': parachains
   - 'Chain Interactions': chain-interactions
   - 'Node Infrastructure': node-infrastructure
-  - 'Technical Reference': reference
+  - 'Tech Reference': reference
   - 'AI Resources': ai-resources.md
   - 'Support': get-support.md

--- a/docs/reference/.nav.yml
+++ b/docs/reference/.nav.yml
@@ -1,4 +1,3 @@
-footer_nav: 1
 nav:
  - 'Overview': index.md
  - 'Polkadot Hub': polkadot-hub


### PR DESCRIPTION
## 📝 Description

This PR moves the `Tech Reference` section from the footer links into the main top navigation bar, alongside the other documentation sections.

Tech Reference is one of the largest content sections on the site (Polkadot Hub, Parachains concepts, On-Chain Governance, App Development, Glossary, and a 15-entry Tools reference), but it was surfaced only as a small link in the bottom-left footer — grouped with utility links (AI Resources, Support) rather than with actual documentation.

This made a core part of the docs effectively unbrowsable: readers could land on Reference pages via inline links (there are ~94 in-links to the section from 28 pages across Chain Interactions, Apps, Parachains, etc.), but had no way to discover or browse the section from the top nav like every other section.

Promoting it to a top-level tab gives it parity with the rest of the documentation and closes that discoverability gap. The footer keeps the genuine utility links (AI Resources, Support).

## ✅ Checklist

- [x] Changes tested  
