### PR TITLE
deps: bump nltk to 3.10.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ joblib==1.4.2
 livereload==2.7.1
 lunr==0.8.0
 MarkupSafe==3.0.2
-nltk==3.9.1
+nltk==3.10.3
 Pillow==11.3.0
 polib==1.2.0
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
Updates `nltk` to address the advisories below.

Evidence:
- `requirements.txt` pinned `nltk==3.9.1`
- `osv-scanner` reported 39 advisories for `nltk@3.9.1`, including GHSA-469j-vmhf-r6v7, GHSA-68j8-pq59-fqgm, GHSA-6hm5-jgcp-p838, GHSA-7p94-766c-hgjp, GHSA-848c-c2cx-j7qx, GHSA-fg7f-2386-8897, GHSA-qvv7-cg9c-w4x3, GHSA-xh95-f55m-82fw, GHSA-m42h-3232-vpv3, GHSA-p4gq-832x-fm9v, and their PYSEC counterparts
- updated version: `3.10.3`

Validation:
- `osv-scanner` reports no advisories for `nltk@3.10.3`
- `mkdocs build` (as run by `.github/workflows/check-mkdocs-build.yml`) completes with the updated pin

Scope: dependency pin update only, `requirements.txt` line 31.
